### PR TITLE
R01: Scene から Sprite 描画対象を収集

### DIFF
--- a/Game/Source/Scene.cpp
+++ b/Game/Source/Scene.cpp
@@ -93,4 +93,30 @@ namespace Xelqoria::Game
 	{
 		return std::span<const std::shared_ptr<Graphics::Sprite>>(m_sprites.data(), m_sprites.size());
 	}
+
+	std::vector<SceneSpriteRenderItem> Scene::CollectSpriteRenderItems() const
+	{
+		std::vector<SceneSpriteRenderItem> renderItems;
+		renderItems.reserve(m_entities.size());
+
+		for (const auto& entity : m_entities) {
+			const auto spriteComponent = entity.GetSpriteComponent();
+			if (!spriteComponent.has_value()) {
+				continue;
+			}
+
+			const auto& spriteComponentValue = spriteComponent->get();
+			if (!spriteComponentValue.renderSettings.visible) {
+				continue;
+			}
+
+			renderItems.push_back(SceneSpriteRenderItem{
+				entity.GetId(),
+				&entity.GetTransform(),
+				&spriteComponentValue
+			});
+		}
+
+		return renderItems;
+	}
 }

--- a/Game/Source/Scene.h
+++ b/Game/Source/Scene.h
@@ -18,6 +18,27 @@ namespace Xelqoria::Graphics
 namespace Xelqoria::Game
 {
 	/// <summary>
+	/// Scene から収集した Sprite 描画候補 1 件分の参照を表す。
+	/// </summary>
+	struct SceneSpriteRenderItem
+	{
+		/// <summary>
+		/// 描画候補に対応する Entity ID を表す。
+		/// </summary>
+		EntityId entityId = 0;
+
+		/// <summary>
+		/// 描画時に参照する Transform へのポインタを表す。
+		/// </summary>
+		const Transform* transform = nullptr;
+
+		/// <summary>
+		/// 描画設定を保持する SpriteComponent へのポインタを表す。
+		/// </summary>
+		const SpriteComponent* spriteComponent = nullptr;
+	};
+
+	/// <summary>
 	/// Entity 群を保持して列挙する Scene コンテナ。
 	/// </summary>
 	class Scene
@@ -83,6 +104,12 @@ namespace Xelqoria::Game
 		/// </summary>
 		/// <returns>Sprite 一覧の読み取り専用ビュー。</returns>
 		std::span<const std::shared_ptr<Graphics::Sprite>> GetSprites() const;
+
+		/// <summary>
+		/// Scene 内の Sprite 描画候補を収集する。
+		/// </summary>
+		/// <returns>描画候補の一覧。</returns>
+		std::vector<SceneSpriteRenderItem> CollectSpriteRenderItems() const;
 
 	private:
 		std::vector<Entity> m_entities;

--- a/Tests.Game/Source/TransformTests.cpp
+++ b/Tests.Game/Source/TransformTests.cpp
@@ -101,6 +101,52 @@ int main()
 		return 1;
 	}
 
+	Xelqoria::Game::Entity& hiddenSpriteEntity = scene.CreateEntity();
+	hiddenSpriteEntity.GetTransform().SetPosition(50.0f, 60.0f, 70.0f);
+	hiddenSpriteEntity.SetSpriteComponent(Xelqoria::Game::SpriteComponent{
+		"ui/hidden",
+		{
+			false,
+			2,
+			1.0f
+		}
+	});
+
+	Xelqoria::Game::Entity& visibleSpriteEntity = scene.CreateEntity();
+	visibleSpriteEntity.GetTransform().SetPosition(10.0f, 20.0f, 30.0f);
+	visibleSpriteEntity.SetSpriteComponent(Xelqoria::Game::SpriteComponent{
+		"ui/visible",
+		{
+			true,
+			5,
+			0.5f
+		}
+	});
+
+	const auto renderItems = scene.CollectSpriteRenderItems();
+	if (renderItems.size() != 1) {
+		return 1;
+	}
+
+	if (renderItems[0].entityId != visibleSpriteEntity.GetId() ||
+		renderItems[0].transform == nullptr ||
+		renderItems[0].spriteComponent == nullptr) {
+		return 1;
+	}
+
+	if (!IsEqual(renderItems[0].transform->position.x, 10.0f) ||
+		!IsEqual(renderItems[0].transform->position.y, 20.0f) ||
+		!IsEqual(renderItems[0].transform->position.z, 30.0f)) {
+		return 1;
+	}
+
+	if (renderItems[0].spriteComponent->spriteAssetRef != "ui/visible" ||
+		!renderItems[0].spriteComponent->renderSettings.visible ||
+		renderItems[0].spriteComponent->renderSettings.sortOrder != 5 ||
+		!IsEqual(renderItems[0].spriteComponent->renderSettings.opacity, 0.5f)) {
+		return 1;
+	}
+
 	auto sprite = std::make_shared<Xelqoria::Graphics::Sprite>();
 	scene.AddSprite(sprite);
 


### PR DESCRIPTION
## 概要
- Scene に Sprite 描画候補の収集 API を追加
- visible な SpriteComponent のみを収集するようにした
- Transform と SpriteComponent を参照できるテストを追加

## テスト
- `g++ -std=c++20 -I/mnt/d/github/Xelqoria/Core/Source -I/mnt/d/github/Xelqoria/Game/Source -I/mnt/d/github/Xelqoria/Graphics/Source /mnt/d/github/Xelqoria/Tests.Game/Source/TransformTests.cpp /mnt/d/github/Xelqoria/Game/Source/Transform.cpp /mnt/d/github/Xelqoria/Game/Source/Scene.cpp /mnt/d/github/Xelqoria/Game/Source/Entity.cpp /mnt/d/github/Xelqoria/Game/Source/Assets/SpriteAssetLoader.cpp /mnt/d/github/Xelqoria/Graphics/Source/Sprite.cpp -o /tmp/xelqoria-transform-tests`
- `/tmp/xelqoria-transform-tests`

Refs #19