### PR TITLE
R03: SpriteAsset 経由描画

### DIFF
--- a/App/Source/Application.cpp
+++ b/App/Source/Application.cpp
@@ -1,11 +1,12 @@
 #include <Windows.h>
 #include <chrono>
 #include <memory>
+#include <string>
 
 #include "Application.h"
 #include "RenderBackendBootstrap.h"
 #include "Scene.h"
-#include "Sprite.h"
+#include "Assets/SpriteAsset.h"
 #include "SpriteRenderer.h"
 #include "Texture2D.h"
 #include "GraphicsAPI.h"
@@ -84,33 +85,58 @@ namespace Xelqoria::App
             return false;
         }
 
-        m_spriteRenderer = std::make_unique<Graphics::SpriteRenderer>(*m_graphics);
-        m_scene = std::make_unique<Game::Scene>();
-        m_sceneRuntimeReady = true;
+		m_spriteRenderer = std::make_unique<Graphics::SpriteRenderer>(*m_graphics);
+		m_scene = std::make_unique<Game::Scene>();
+		m_sceneRuntimeReady = true;
 
         auto spriteTexture = std::make_shared<Graphics::Texture2D>();
-        if (!spriteTexture->LoadFromFile(L"../Resource\\mapchip.png", *m_graphics))
-        {
-            return false;
-        }
+		if (!spriteTexture->LoadFromFile(L"../Resource\\mapchip.png", *m_graphics))
+		{
+			return false;
+		}
 
-        auto sprite = std::make_shared<Graphics::Sprite>();
-        sprite->SetTexture(spriteTexture);
-        sprite->SetPosition(-160.0f, 0.0f);
-        m_scene->AddSprite(sprite);
+		m_textureAssetRegistry.RegisterTexture("textures/mapchip", spriteTexture);
+		m_spriteAssetRegistry.RegisterSpriteAsset(
+			"sprites/mapchip-left",
+			Game::Assets::SpriteAsset{ "textures/mapchip" });
+		m_spriteAssetRegistry.RegisterSpriteAsset(
+			"sprites/mapchip-right",
+			Game::Assets::SpriteAsset{ "textures/mapchip" });
 
-        auto secondSprite = std::make_shared<Graphics::Sprite>();
-        secondSprite->SetTexture(spriteTexture);
-        secondSprite->SetPosition(160.0f, 90.0f);
-        secondSprite->SetScale(0.75f, 0.75f);
-        m_scene->AddSprite(secondSprite);
+		{
+			auto& entity = m_scene->CreateEntity();
+			entity.GetTransform().SetPosition(-160.0f, 0.0f, 0.0f);
+			entity.SetSpriteComponent(Game::SpriteComponent{
+				"sprites/mapchip-left",
+				{
+					true,
+					0,
+					1.0f
+				}
+			});
+		}
 
-        return true;
-    }
+		{
+			auto& entity = m_scene->CreateEntity();
+			entity.GetTransform().SetPosition(160.0f, 90.0f, 0.0f);
+			entity.GetTransform().scale = { 0.75f, 0.75f, 1.0f };
+			entity.SetSpriteComponent(Game::SpriteComponent{
+				"sprites/mapchip-right",
+				{
+					true,
+					1,
+					1.0f
+				}
+			});
+		}
+
+		return true;
+	}
 
     void Application::Shutdown()
     {
         m_sceneRuntimeReady = false;
+        m_hasLoggedSceneResolution = false;
         m_scene.reset();
         m_spriteRenderer.reset();
 
@@ -135,20 +161,28 @@ namespace Xelqoria::App
 
         m_graphics->BeginFrame();
 
-        if (m_spriteRenderer && m_scene)
-        {
-            m_spriteRenderer->Begin();
-            for (const auto& sprite : m_scene->GetSprites())
-            {
-                if (!sprite)
-                {
-                    continue;
-                }
+		if (m_spriteRenderer && m_scene)
+		{
+			const auto resolvedSprites = m_scene->ResolveSprites(
+				m_spriteAssetRegistry,
+				m_textureAssetRegistry,
+				m_hasLoggedSceneResolution
+					? std::function<void(const std::string&)>{}
+					: std::function<void(const std::string&)>(
+						[](const std::string& message)
+						{
+							const std::string line = message + "\n";
+							::OutputDebugStringA(line.c_str());
+						}));
+			m_hasLoggedSceneResolution = true;
 
-                m_spriteRenderer->Draw(*sprite);
-            }
-            m_spriteRenderer->End();
-        }
+			m_spriteRenderer->Begin();
+			for (const auto& sprite : resolvedSprites)
+			{
+				m_spriteRenderer->Draw(sprite);
+			}
+			m_spriteRenderer->End();
+		}
 
         m_graphics->EndFrame();
     }

--- a/App/Source/Application.h
+++ b/App/Source/Application.h
@@ -2,6 +2,8 @@
 #include <Windows.h>
 #include <memory>
 
+#include "Assets/ISpriteAssetResolver.h"
+#include "ITextureAssetResolver.h"
 #include "Scene.h"
 #include "Window.h"
 #include "IGraphicsContext.h"
@@ -126,9 +128,24 @@ namespace Xelqoria::App
 		std::unique_ptr<Graphics::SpriteRenderer> m_spriteRenderer;
 
 		/// <summary>
+		/// Scene が参照する SpriteAsset を解決するレジストリ。
+		/// </summary>
+		Game::Assets::SpriteAssetRegistry m_spriteAssetRegistry{};
+
+		/// <summary>
+		/// Scene が参照する Texture2D を解決するレジストリ。
+		/// </summary>
+		Graphics::TextureAssetRegistry m_textureAssetRegistry{};
+
+		/// <summary>
 		/// Scene ベースのランタイムへ移行するための準備状態。
 		/// </summary>
 		bool m_sceneRuntimeReady = false;
+
+		/// <summary>
+		/// Scene の Asset 解決ログを初回描画で出力済みかを表す。
+		/// </summary>
+		bool m_hasLoggedSceneResolution = false;
 
 		/// <summary>
 		/// アプリケーション実行フラグ。

--- a/Game/Source/Assets/ISpriteAssetResolver.h
+++ b/Game/Source/Assets/ISpriteAssetResolver.h
@@ -1,0 +1,66 @@
+#pragma once
+
+#include <optional>
+#include <string>
+#include <unordered_map>
+#include <utility>
+
+#include "AssetId.h"
+#include "SpriteAsset.h"
+
+namespace Xelqoria::Game::Assets
+{
+	/// <summary>
+	/// SpriteAsset を AssetId から解決する抽象インターフェースを表す。
+	/// </summary>
+	class ISpriteAssetResolver
+	{
+	public:
+		/// <summary>
+		/// Resolver を破棄する。
+		/// </summary>
+		virtual ~ISpriteAssetResolver() = default;
+
+		/// <summary>
+		/// 指定した AssetId に対応する SpriteAsset を取得する。
+		/// </summary>
+		/// <param name="assetId">取得対象の SpriteAsset 識別子。</param>
+		/// <returns>解決できた SpriteAsset。未解決時は空。</returns>
+		virtual std::optional<SpriteAsset> ResolveSpriteAsset(const Core::AssetId& assetId) const = 0;
+	};
+
+	/// <summary>
+	/// AssetId と SpriteAsset の対応を保持する簡易レジストリを表す。
+	/// </summary>
+	class SpriteAssetRegistry final : public ISpriteAssetResolver
+	{
+	public:
+		/// <summary>
+		/// SpriteAsset を登録する。
+		/// </summary>
+		/// <param name="assetId">登録に使用する SpriteAsset 識別子。</param>
+		/// <param name="spriteAsset">登録する SpriteAsset。</param>
+		void RegisterSpriteAsset(Core::AssetId assetId, SpriteAsset spriteAsset)
+		{
+			m_spriteAssets[assetId.GetValue()] = std::move(spriteAsset);
+		}
+
+		/// <summary>
+		/// 指定した AssetId に対応する SpriteAsset を取得する。
+		/// </summary>
+		/// <param name="assetId">取得対象の SpriteAsset 識別子。</param>
+		/// <returns>解決できた SpriteAsset。未解決時は空。</returns>
+		std::optional<SpriteAsset> ResolveSpriteAsset(const Core::AssetId& assetId) const override
+		{
+			const auto it = m_spriteAssets.find(assetId.GetValue());
+			if (it == m_spriteAssets.end()) {
+				return std::nullopt;
+			}
+
+			return it->second;
+		}
+
+	private:
+		std::unordered_map<std::string, SpriteAsset> m_spriteAssets;
+	};
+}

--- a/Game/Source/Scene.cpp
+++ b/Game/Source/Scene.cpp
@@ -1,13 +1,22 @@
 #include "Scene.h"
 
 #include <algorithm>
-#include "Sprite.h"
+#include <sstream>
+
 #include "Entity.h"
-#include <optional>
-#include <type_traits>
 
 namespace Xelqoria::Game
 {
+	namespace
+	{
+		void LogMessage(const std::function<void(const std::string&)>& logger, std::string message)
+		{
+			if (logger) {
+				logger(message);
+			}
+		}
+	}
+
 	Scene::Scene() = default;
 
 	Scene::~Scene() = default;
@@ -118,5 +127,64 @@ namespace Xelqoria::Game
 		}
 
 		return renderItems;
+	}
+
+	std::vector<Graphics::Sprite> Scene::ResolveSprites(
+		const Assets::ISpriteAssetResolver& spriteAssetResolver,
+		const Graphics::ITextureAssetResolver& textureAssetResolver,
+		const std::function<void(const std::string&)>& logger) const
+	{
+		std::vector<Graphics::Sprite> resolvedSprites;
+		const auto renderItems = CollectSpriteRenderItems();
+		resolvedSprites.reserve(renderItems.size());
+
+		for (const auto& renderItem : renderItems) {
+			if (renderItem.transform == nullptr || renderItem.spriteComponent == nullptr) {
+				LogMessage(logger, "Scene::ResolveSprites skipped an item because required references were null.");
+				continue;
+			}
+
+			const auto& spriteAssetRef = renderItem.spriteComponent->spriteAssetRef;
+			if (spriteAssetRef.IsEmpty()) {
+				std::ostringstream message;
+				message << "Scene::ResolveSprites skipped entity " << renderItem.entityId
+					<< " because spriteAssetRef was empty.";
+				LogMessage(logger, message.str());
+				continue;
+			}
+
+			const auto spriteAsset = spriteAssetResolver.ResolveSpriteAsset(spriteAssetRef);
+			if (!spriteAsset.has_value()) {
+				std::ostringstream message;
+				message << "Scene::ResolveSprites could not resolve SpriteAsset '"
+					<< spriteAssetRef.GetValue() << "' for entity " << renderItem.entityId << ".";
+				LogMessage(logger, message.str());
+				continue;
+			}
+
+			const auto texture = textureAssetResolver.ResolveTexture(spriteAsset->textureAssetId);
+			if (!texture) {
+				std::ostringstream message;
+				message << "Scene::ResolveSprites could not resolve Texture2D '"
+					<< spriteAsset->textureAssetId.GetValue() << "' for entity " << renderItem.entityId << ".";
+				LogMessage(logger, message.str());
+				continue;
+			}
+
+			Graphics::Sprite sprite{};
+			sprite.SetTexture(texture);
+			sprite.SetTextureAssetId(spriteAsset->textureAssetId);
+			sprite.SetPosition(renderItem.transform->position.x, renderItem.transform->position.y);
+			sprite.SetScale(renderItem.transform->scale.x, renderItem.transform->scale.y);
+			resolvedSprites.push_back(std::move(sprite));
+
+			std::ostringstream message;
+			message << "Scene::ResolveSprites resolved entity " << renderItem.entityId
+				<< " from SpriteAsset '" << spriteAssetRef.GetValue()
+				<< "' to Texture2D '" << spriteAsset->textureAssetId.GetValue() << "'.";
+			LogMessage(logger, message.str());
+		}
+
+		return resolvedSprites;
 	}
 }

--- a/Game/Source/Scene.h
+++ b/Game/Source/Scene.h
@@ -5,15 +5,13 @@
 #include <memory>
 #include <optional>
 #include <span>
+#include <string>
 #include <vector>
 
+#include "Assets/ISpriteAssetResolver.h"
 #include "Entity.h"
-#include <type_traits>
-
-namespace Xelqoria::Graphics
-{
-	class Sprite;
-}
+#include "ITextureAssetResolver.h"
+#include "Sprite.h"
 
 namespace Xelqoria::Game
 {
@@ -110,6 +108,18 @@ namespace Xelqoria::Game
 		/// </summary>
 		/// <returns>描画候補の一覧。</returns>
 		std::vector<SceneSpriteRenderItem> CollectSpriteRenderItems() const;
+
+		/// <summary>
+		/// Scene 内の Sprite 描画候補を Asset 解決経由で描画用 Sprite に変換する。
+		/// </summary>
+		/// <param name="spriteAssetResolver">SpriteAsset を解決する Resolver。</param>
+		/// <param name="textureAssetResolver">Texture2D を解決する Resolver。</param>
+		/// <param name="logger">解決状況を受け取るロガー。未指定時はログ出力しない。</param>
+		/// <returns>描画可能な Sprite 一覧。</returns>
+		std::vector<Graphics::Sprite> ResolveSprites(
+			const Assets::ISpriteAssetResolver& spriteAssetResolver,
+			const Graphics::ITextureAssetResolver& textureAssetResolver,
+			const std::function<void(const std::string&)>& logger = {}) const;
 
 	private:
 		std::vector<Entity> m_entities;

--- a/Game/Xelqoria.Game.vcxproj
+++ b/Game/Xelqoria.Game.vcxproj
@@ -33,6 +33,7 @@
     <ClCompile Include="Source\Transform.cpp" />
   </ItemGroup>
   <ItemGroup>
+    <ClInclude Include="Source\Assets\ISpriteAssetResolver.h" />
     <ClInclude Include="Source\Assets\SpriteAsset.h" />
     <ClInclude Include="Source\Assets\SpriteAssetLoader.h" />
     <ClInclude Include="Source\Entity.h" />

--- a/Game/Xelqoria.Game.vcxproj.filters
+++ b/Game/Xelqoria.Game.vcxproj.filters
@@ -25,6 +25,9 @@
     </ClCompile>
   </ItemGroup>
   <ItemGroup>
+    <ClInclude Include="Source\Assets\ISpriteAssetResolver.h">
+      <Filter>Source\Assets</Filter>
+    </ClInclude>
     <ClInclude Include="Source\Assets\SpriteAsset.h">
       <Filter>Source\Assets</Filter>
     </ClInclude>

--- a/Graphics/Source/ITextureAssetResolver.h
+++ b/Graphics/Source/ITextureAssetResolver.h
@@ -1,0 +1,67 @@
+#pragma once
+
+#include <memory>
+#include <string>
+#include <unordered_map>
+#include <utility>
+
+#include "AssetId.h"
+
+namespace Xelqoria::Graphics
+{
+	class Texture2D;
+
+	/// <summary>
+	/// Texture2D を AssetId から解決する抽象インターフェースを表す。
+	/// </summary>
+	class ITextureAssetResolver
+	{
+	public:
+		/// <summary>
+		/// Resolver を破棄する。
+		/// </summary>
+		virtual ~ITextureAssetResolver() = default;
+
+		/// <summary>
+		/// 指定した AssetId に対応する Texture2D を取得する。
+		/// </summary>
+		/// <param name="assetId">取得対象のテクスチャアセット識別子。</param>
+		/// <returns>解決できた Texture2D。未解決時は空。</returns>
+		virtual std::shared_ptr<Texture2D> ResolveTexture(const Core::AssetId& assetId) const = 0;
+	};
+
+	/// <summary>
+	/// AssetId と Texture2D の対応を保持する簡易レジストリを表す。
+	/// </summary>
+	class TextureAssetRegistry final : public ITextureAssetResolver
+	{
+	public:
+		/// <summary>
+		/// テクスチャアセットを登録する。
+		/// </summary>
+		/// <param name="assetId">登録に使用するテクスチャアセット識別子。</param>
+		/// <param name="texture">登録する Texture2D。</param>
+		void RegisterTexture(Core::AssetId assetId, std::shared_ptr<Texture2D> texture)
+		{
+			m_textures[assetId.GetValue()] = std::move(texture);
+		}
+
+		/// <summary>
+		/// 指定した AssetId に対応する Texture2D を取得する。
+		/// </summary>
+		/// <param name="assetId">取得対象のテクスチャアセット識別子。</param>
+		/// <returns>解決できた Texture2D。未解決時は空。</returns>
+		std::shared_ptr<Texture2D> ResolveTexture(const Core::AssetId& assetId) const override
+		{
+			const auto it = m_textures.find(assetId.GetValue());
+			if (it == m_textures.end()) {
+				return nullptr;
+			}
+
+			return it->second;
+		}
+
+	private:
+		std::unordered_map<std::string, std::shared_ptr<Texture2D>> m_textures;
+	};
+}

--- a/Graphics/Xelqoria.Graphics.vcxproj
+++ b/Graphics/Xelqoria.Graphics.vcxproj
@@ -24,6 +24,7 @@
     <ClCompile Include="Source\Texture2D.cpp" />
   </ItemGroup>
   <ItemGroup>
+    <ClInclude Include="Source\ITextureAssetResolver.h" />
     <ClInclude Include="Source\Sprite.h" />
     <ClInclude Include="Source\SpriteRenderMath.h" />
     <ClInclude Include="Source\SpriteRenderer.h" />

--- a/Graphics/Xelqoria.Graphics.vcxproj.filters
+++ b/Graphics/Xelqoria.Graphics.vcxproj.filters
@@ -17,6 +17,9 @@
     </ClCompile>
   </ItemGroup>
   <ItemGroup>
+    <ClInclude Include="Source\ITextureAssetResolver.h">
+      <Filter>Source</Filter>
+    </ClInclude>
     <ClInclude Include="Source\Sprite.h">
       <Filter>Source</Filter>
     </ClInclude>

--- a/Tests.Game/Source/TransformTests.cpp
+++ b/Tests.Game/Source/TransformTests.cpp
@@ -1,8 +1,12 @@
 #include <memory>
 #include <cmath>
+#include <string>
+#include <vector>
 
 #include "AssetId.h"
+#include "Assets/ISpriteAssetResolver.h"
 #include "Assets/SpriteAssetLoader.h"
+#include "ITextureAssetResolver.h"
 #include "ITexture.h"
 #include "Scene.h"
 #include "Sprite.h"
@@ -142,6 +146,7 @@ int main()
 
 	Xelqoria::Game::Entity& visibleSpriteEntity = scene.CreateEntity();
 	visibleSpriteEntity.GetTransform().SetPosition(10.0f, 20.0f, 30.0f);
+	visibleSpriteEntity.GetTransform().scale = { 2.0f, 3.0f, 1.0f };
 	visibleSpriteEntity.SetSpriteComponent(Xelqoria::Game::SpriteComponent{
 		"ui/visible",
 		{
@@ -258,6 +263,45 @@ int main()
 		return 1;
 	}
 
+	Xelqoria::Game::Assets::SpriteAssetRegistry spriteAssetRegistry;
+	spriteAssetRegistry.RegisterSpriteAsset(
+		"sprites/player-idle",
+		Xelqoria::Game::Assets::SpriteAsset{ "textures/player-idle" });
+
+	Xelqoria::Graphics::TextureAssetRegistry textureAssetRegistry;
+	textureAssetRegistry.RegisterTexture("textures/player-idle", renderTexture);
+
+	std::vector<std::string> resolveLogs;
+	const auto resolvedSprites = scene.ResolveSprites(
+		spriteAssetRegistry,
+		textureAssetRegistry,
+		[&resolveLogs](const std::string& message)
+		{
+			resolveLogs.push_back(message);
+		});
+
+	if (resolvedSprites.size() != 1) {
+		return 1;
+	}
+
+	if (resolvedSprites[0].GetTexture() != renderTexture ||
+		resolvedSprites[0].GetTextureAssetId() != Xelqoria::Core::AssetId("textures/player-idle")) {
+		return 1;
+	}
+
+	if (!IsEqual(resolvedSprites[0].GetPosition().x, 10.0f) ||
+		!IsEqual(resolvedSprites[0].GetPosition().y, 20.0f) ||
+		!IsEqual(resolvedSprites[0].GetScale().x, 2.0f) ||
+		!IsEqual(resolvedSprites[0].GetScale().y, 3.0f)) {
+		return 1;
+	}
+
+	if (resolveLogs.size() != 1 ||
+		resolveLogs[0].find("resolved entity") == std::string::npos ||
+		resolveLogs[0].find("sprites/player-idle") == std::string::npos) {
+		return 1;
+	}
+
 	const auto missingFieldLoadResult = Xelqoria::Game::Assets::SpriteAssetLoader::LoadFromText(
 		"# textureAssetId is missing\n");
 	if (missingFieldLoadResult.IsSuccess() || !missingFieldLoadResult.error.has_value()) {
@@ -266,6 +310,36 @@ int main()
 
 	if (missingFieldLoadResult.error->code != Xelqoria::Game::Assets::SpriteAssetLoadErrorCode::MissingRequiredField ||
 		missingFieldLoadResult.error->fieldName != "textureAssetId") {
+		return 1;
+	}
+
+	Xelqoria::Game::Scene missingAssetScene;
+	auto& missingAssetEntity = missingAssetScene.CreateEntity();
+	missingAssetEntity.SetSpriteComponent(Xelqoria::Game::SpriteComponent{
+		"sprites/missing",
+		{
+			true,
+			0,
+			1.0f
+		}
+	});
+
+	std::vector<std::string> missingAssetLogs;
+	const auto unresolvedSprites = missingAssetScene.ResolveSprites(
+		spriteAssetRegistry,
+		textureAssetRegistry,
+		[&missingAssetLogs](const std::string& message)
+		{
+			missingAssetLogs.push_back(message);
+		});
+
+	if (!unresolvedSprites.empty()) {
+		return 1;
+	}
+
+	if (missingAssetLogs.size() != 1 ||
+		missingAssetLogs[0].find("could not resolve SpriteAsset") == std::string::npos ||
+		missingAssetLogs[0].find("sprites/missing") == std::string::npos) {
 		return 1;
 	}
 


### PR DESCRIPTION
## 概要
- Scene が SpriteAsset の AssetId 参照から描画用 Sprite を解決できるようにしました
- SpriteAsset と Texture2D を解決する薄い resolver を追加しました
- 未解決時はクラッシュせずログで追跡できるようにしました

## 変更内容
- Scene に Asset 解決経由で描画用 Sprite 一覧を構築する API を追加
- App を生の Sprite 登録から SpriteAsset ベースの描画経路へ切り替え
- 成功系と未解決系の自動テストを追加
- 新規 resolver ヘッダを vcxproj / filters に登録

## 検証
- Layer dependency check passed.

## 未確認
- この環境では  が見つからず、Windows ビルドと実行確認は未実施です