### PR TITLE
S01: Scene 保存フォーマット定義

### DIFF
--- a/Game/Source/SceneSaveFormat.h
+++ b/Game/Source/SceneSaveFormat.h
@@ -1,0 +1,73 @@
+#pragma once
+
+#include <cstdint>
+#include <optional>
+#include <string_view>
+
+#include "AssetId.h"
+#include "Entity.h"
+#include "Transform.h"
+
+namespace Xelqoria::Game
+{
+	/// <summary>
+	/// Scene 保存フォーマットの識別名を表す。
+	/// </summary>
+	inline constexpr std::string_view SceneSaveFormatMagic = "xelqoria.scene";
+
+	/// <summary>
+	/// Scene 保存フォーマットの初期バージョンを表す。
+	/// </summary>
+	inline constexpr std::uint32_t SceneSaveFormatVersion = 1;
+
+	/// <summary>
+	/// 将来拡張用フィールドを配置する接頭辞を表す。
+	/// </summary>
+	inline constexpr std::string_view SceneSaveExtensionFieldPrefix = "extensions.";
+
+	/// <summary>
+	/// Scene 保存時に 1 Entity 分の SpriteRef を表す。
+	/// </summary>
+	struct SceneSpriteRefRecord
+	{
+		/// <summary>
+		/// Entity に関連付ける Sprite アセット参照を表す。
+		/// </summary>
+		Core::AssetId spriteAssetRef{};
+	};
+
+	/// <summary>
+	/// Scene 保存時に 1 Entity 分の保存対象を表す。
+	/// </summary>
+	struct SceneEntitySaveRecord
+	{
+		/// <summary>
+		/// 保存対象の Entity ID を表す。
+		/// </summary>
+		EntityId entityId = 0;
+
+		/// <summary>
+		/// 保存対象の Transform を表す。
+		/// </summary>
+		Transform transform{};
+
+		/// <summary>
+		/// 保存対象の SpriteRef を表す。
+		/// 未設定の Entity では空を許容する。
+		/// </summary>
+		std::optional<SceneSpriteRefRecord> spriteRef{};
+	};
+
+	/// <summary>
+	/// Scene 保存フォーマット v1 の項目構成を説明する。
+	/// </summary>
+	inline constexpr std::string_view SceneSaveFormatDocumentation =
+		R"(magic=xelqoria.scene
+version=1
+entity.<index>.id=<EntityId>
+entity.<index>.transform.position=<x>,<y>,<z>
+entity.<index>.transform.rotation=<x>,<y>,<z>
+entity.<index>.transform.scale=<x>,<y>,<z>
+entity.<index>.spriteRef=<SpriteAssetId>
+entity.<index>.extensions.<name>=<reserved>)";
+}

--- a/Game/Xelqoria.Game.vcxproj
+++ b/Game/Xelqoria.Game.vcxproj
@@ -38,6 +38,7 @@
     <ClInclude Include="Source\Assets\SpriteAssetLoader.h" />
     <ClInclude Include="Source\Entity.h" />
     <ClInclude Include="Source\Scene.h" />
+    <ClInclude Include="Source\SceneSaveFormat.h" />
     <ClInclude Include="Source\SpriteComponent.h" />
     <ClInclude Include="Source\Transform.h" />
   </ItemGroup>

--- a/Game/Xelqoria.Game.vcxproj.filters
+++ b/Game/Xelqoria.Game.vcxproj.filters
@@ -40,6 +40,9 @@
     <ClInclude Include="Source\Scene.h">
       <Filter>Source</Filter>
     </ClInclude>
+    <ClInclude Include="Source\SceneSaveFormat.h">
+      <Filter>Source</Filter>
+    </ClInclude>
     <ClInclude Include="Source\SpriteComponent.h">
       <Filter>Source</Filter>
     </ClInclude>

--- a/Tests.Game/Source/TransformTests.cpp
+++ b/Tests.Game/Source/TransformTests.cpp
@@ -9,6 +9,7 @@
 #include "ITextureAssetResolver.h"
 #include "ITexture.h"
 #include "Scene.h"
+#include "SceneSaveFormat.h"
 #include "Sprite.h"
 #include "SpriteComponent.h"
 #include "SpriteRenderMath.h"
@@ -340,6 +341,35 @@ int main()
 	if (missingAssetLogs.size() != 1 ||
 		missingAssetLogs[0].find("could not resolve SpriteAsset") == std::string::npos ||
 		missingAssetLogs[0].find("sprites/missing") == std::string::npos) {
+		return 1;
+	}
+
+	if (Xelqoria::Game::SceneSaveFormatMagic != std::string_view("xelqoria.scene") ||
+		Xelqoria::Game::SceneSaveFormatVersion != 1 ||
+		Xelqoria::Game::SceneSaveExtensionFieldPrefix != std::string_view("extensions.")) {
+		return 1;
+	}
+
+	const std::string sceneSaveFormatDocumentation(Xelqoria::Game::SceneSaveFormatDocumentation);
+	if (sceneSaveFormatDocumentation.find("entity.<index>.transform.position=<x>,<y>,<z>") == std::string::npos ||
+		sceneSaveFormatDocumentation.find("entity.<index>.spriteRef=<SpriteAssetId>") == std::string::npos ||
+		sceneSaveFormatDocumentation.find("entity.<index>.extensions.<name>=<reserved>") == std::string::npos) {
+		return 1;
+	}
+
+	Xelqoria::Game::SceneEntitySaveRecord sceneSaveRecord{};
+	sceneSaveRecord.entityId = 77;
+	sceneSaveRecord.transform.SetPosition(4.0f, 5.0f, 6.0f);
+	sceneSaveRecord.transform.rotation = { 0.0f, 0.0f, 45.0f };
+	sceneSaveRecord.transform.scale = { 2.0f, 3.0f, 1.0f };
+	sceneSaveRecord.spriteRef = Xelqoria::Game::SceneSpriteRefRecord{ "sprites/player" };
+
+	if (sceneSaveRecord.entityId != 77 ||
+		!IsEqual(sceneSaveRecord.transform.position.x, 4.0f) ||
+		!IsEqual(sceneSaveRecord.transform.position.y, 5.0f) ||
+		!IsEqual(sceneSaveRecord.transform.position.z, 6.0f) ||
+		!sceneSaveRecord.spriteRef.has_value() ||
+		sceneSaveRecord.spriteRef->spriteAssetRef != Xelqoria::Core::AssetId("sprites/player")) {
 		return 1;
 	}
 


### PR DESCRIPTION
## 概要
- Transform と SpriteRef を含む Scene 保存フォーマット定義を追加
- フォーマットの magic/version と将来拡張欄を定義
- フォーマット定義を固定するテストを追加

## 検証
- `MSBuild.exe Xelqoria.slnx /p:Configuration=Debug /p:Platform=x64` を実行
- `Core/RHI/Graphics/Game/App` は通過
- `Tests.Game` は既存の `ITexture.h` include 解決不備で失敗

Parent issue: #60
Related issue: #61