### PR TITLE
S02: Scene 保存実装

### DIFF
--- a/Game/Source/SceneSerializer.cpp
+++ b/Game/Source/SceneSerializer.cpp
@@ -1,0 +1,51 @@
+#include "SceneSerializer.h"
+
+#include <iomanip>
+#include <sstream>
+
+#include "SceneSaveFormat.h"
+
+namespace
+{
+	void AppendVector3(std::ostringstream& stream, const Xelqoria::Game::Vector3& value)
+	{
+		stream << value.x << "," << value.y << "," << value.z;
+	}
+}
+
+namespace Xelqoria::Game
+{
+	std::string SceneSerializer::SaveToText(const Scene& scene)
+	{
+		std::ostringstream stream;
+		stream << std::fixed << std::setprecision(6);
+		stream << "magic=" << SceneSaveFormatMagic << "\n";
+		stream << "version=" << SceneSaveFormatVersion << "\n";
+
+		const auto entities = scene.GetEntities();
+		for (std::size_t entityIndex = 0; entityIndex < entities.size(); ++entityIndex)
+		{
+			const auto& entity = entities[entityIndex];
+			const auto& transform = entity.GetTransform();
+			const auto prefix = "entity." + std::to_string(entityIndex);
+
+			stream << prefix << ".id=" << entity.GetId() << "\n";
+			stream << prefix << ".transform.position=";
+			AppendVector3(stream, transform.position);
+			stream << "\n";
+			stream << prefix << ".transform.rotation=";
+			AppendVector3(stream, transform.rotation);
+			stream << "\n";
+			stream << prefix << ".transform.scale=";
+			AppendVector3(stream, transform.scale);
+			stream << "\n";
+
+			const auto spriteComponent = entity.GetSpriteComponent();
+			if (spriteComponent.has_value() && !spriteComponent->get().spriteAssetRef.IsEmpty()) {
+				stream << prefix << ".spriteRef=" << spriteComponent->get().spriteAssetRef.GetValue() << "\n";
+			}
+		}
+
+		return stream.str();
+	}
+}

--- a/Game/Source/SceneSerializer.h
+++ b/Game/Source/SceneSerializer.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include <string>
+
+#include "Scene.h"
+
+namespace Xelqoria::Game
+{
+	/// <summary>
+	/// Scene を保存用テキストへ変換する。
+	/// </summary>
+	class SceneSerializer
+	{
+	public:
+		/// <summary>
+		/// Scene を `key=value` 形式の保存テキストへ変換する。
+		/// </summary>
+		/// <param name="scene">保存対象の Scene。</param>
+		/// <returns>保存フォーマットに従ったテキスト。</returns>
+		static std::string SaveToText(const Scene& scene);
+	};
+}

--- a/Game/Xelqoria.Game.vcxproj
+++ b/Game/Xelqoria.Game.vcxproj
@@ -30,6 +30,7 @@
     <ClCompile Include="Source\Assets\SpriteAssetLoader.cpp" />
     <ClCompile Include="Source\Entity.cpp" />
     <ClCompile Include="Source\Scene.cpp" />
+    <ClCompile Include="Source\SceneSerializer.cpp" />
     <ClCompile Include="Source\Transform.cpp" />
   </ItemGroup>
   <ItemGroup>
@@ -39,6 +40,7 @@
     <ClInclude Include="Source\Entity.h" />
     <ClInclude Include="Source\Scene.h" />
     <ClInclude Include="Source\SceneSaveFormat.h" />
+    <ClInclude Include="Source\SceneSerializer.h" />
     <ClInclude Include="Source\SpriteComponent.h" />
     <ClInclude Include="Source\Transform.h" />
   </ItemGroup>

--- a/Game/Xelqoria.Game.vcxproj.filters
+++ b/Game/Xelqoria.Game.vcxproj.filters
@@ -20,6 +20,9 @@
     <ClCompile Include="Source\Scene.cpp">
       <Filter>Source</Filter>
     </ClCompile>
+    <ClCompile Include="Source\SceneSerializer.cpp">
+      <Filter>Source</Filter>
+    </ClCompile>
     <ClCompile Include="Source\Transform.cpp">
       <Filter>Source</Filter>
     </ClCompile>
@@ -41,6 +44,9 @@
       <Filter>Source</Filter>
     </ClInclude>
     <ClInclude Include="Source\SceneSaveFormat.h">
+      <Filter>Source</Filter>
+    </ClInclude>
+    <ClInclude Include="Source\SceneSerializer.h">
       <Filter>Source</Filter>
     </ClInclude>
     <ClInclude Include="Source\SpriteComponent.h">

--- a/Tests.Game/Source/TransformTests.cpp
+++ b/Tests.Game/Source/TransformTests.cpp
@@ -10,6 +10,7 @@
 #include "ITexture.h"
 #include "Scene.h"
 #include "SceneSaveFormat.h"
+#include "SceneSerializer.h"
 #include "Sprite.h"
 #include "SpriteComponent.h"
 #include "SpriteRenderMath.h"
@@ -21,6 +22,43 @@ namespace
 	bool IsEqual(float lhs, float rhs)
 	{
 		return std::fabs(lhs - rhs) < 0.0001f;
+	}
+
+	bool VerifySceneSaveSerialization()
+	{
+		Xelqoria::Game::Scene saveScene;
+		auto& playerEntity = saveScene.CreateEntity();
+		playerEntity.GetTransform().SetPosition(12.5f, -8.0f, 3.0f);
+		playerEntity.GetTransform().rotation = { 0.0f, 45.0f, 90.0f };
+		playerEntity.GetTransform().scale = { 1.0f, 2.0f, 1.0f };
+		playerEntity.SetSpriteComponent(Xelqoria::Game::SpriteComponent{
+			"sprites/player",
+			{
+				true,
+				0,
+				1.0f
+			}
+		});
+
+		auto& backgroundEntity = saveScene.CreateEntity();
+		backgroundEntity.GetTransform().SetPosition(-32.0f, 64.0f, 0.0f);
+		backgroundEntity.GetTransform().rotation = { 0.0f, 0.0f, 0.0f };
+		backgroundEntity.GetTransform().scale = { 4.0f, 4.0f, 1.0f };
+
+		const std::string sceneSaveSnapshot =
+			"magic=xelqoria.scene\n"
+			"version=1\n"
+			"entity.0.id=1\n"
+			"entity.0.transform.position=12.500000,-8.000000,3.000000\n"
+			"entity.0.transform.rotation=0.000000,45.000000,90.000000\n"
+			"entity.0.transform.scale=1.000000,2.000000,1.000000\n"
+			"entity.0.spriteRef=sprites/player\n"
+			"entity.1.id=2\n"
+			"entity.1.transform.position=-32.000000,64.000000,0.000000\n"
+			"entity.1.transform.rotation=0.000000,0.000000,0.000000\n"
+			"entity.1.transform.scale=4.000000,4.000000,1.000000\n";
+
+		return Xelqoria::Game::SceneSerializer::SaveToText(saveScene) == sceneSaveSnapshot;
 	}
 
 	class FakeTexture final : public Xelqoria::RHI::ITexture
@@ -370,6 +408,10 @@ int main()
 		!IsEqual(sceneSaveRecord.transform.position.z, 6.0f) ||
 		!sceneSaveRecord.spriteRef.has_value() ||
 		sceneSaveRecord.spriteRef->spriteAssetRef != Xelqoria::Core::AssetId("sprites/player")) {
+		return 1;
+	}
+
+	if (!VerifySceneSaveSerialization()) {
 		return 1;
 	}
 

--- a/Tests.Game/Xelqoria.Tests.Game.vcxproj
+++ b/Tests.Game/Xelqoria.Tests.Game.vcxproj
@@ -93,7 +93,7 @@
       <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <LanguageStandard>stdcpp20</LanguageStandard>
-      <AdditionalIncludeDirectories>$(SolutionDir)Core\Source;$(SolutionDir)Game\Source;$(SolutionDir)Graphics\Source;$(ProjectDir)Source;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(SolutionDir)Core\Source;$(SolutionDir)Game\Source;$(SolutionDir)Graphics\Source;$(SolutionDir)RHI\Source;$(ProjectDir)Source;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <AdditionalOptions>/utf-8 %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
@@ -110,7 +110,7 @@
       <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <LanguageStandard>stdcpp20</LanguageStandard>
-      <AdditionalIncludeDirectories>$(SolutionDir)Core\Source;$(SolutionDir)Game\Source;$(SolutionDir)Graphics\Source;$(ProjectDir)Source;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(SolutionDir)Core\Source;$(SolutionDir)Game\Source;$(SolutionDir)Graphics\Source;$(SolutionDir)RHI\Source;$(ProjectDir)Source;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <AdditionalOptions>/utf-8 %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
@@ -125,7 +125,7 @@
       <PreprocessorDefinitions>_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <LanguageStandard>stdcpp20</LanguageStandard>
-      <AdditionalIncludeDirectories>$(SolutionDir)Core\Source;$(SolutionDir)Game\Source;$(SolutionDir)Graphics\Source;$(ProjectDir)Source;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(SolutionDir)Core\Source;$(SolutionDir)Game\Source;$(SolutionDir)Graphics\Source;$(SolutionDir)RHI\Source;$(ProjectDir)Source;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <AdditionalOptions>/utf-8 %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
@@ -142,7 +142,7 @@
       <PreprocessorDefinitions>NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <LanguageStandard>stdcpp20</LanguageStandard>
-      <AdditionalIncludeDirectories>$(SolutionDir)Core\Source;$(SolutionDir)Game\Source;$(SolutionDir)Graphics\Source;$(ProjectDir)Source;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(SolutionDir)Core\Source;$(SolutionDir)Game\Source;$(SolutionDir)Graphics\Source;$(SolutionDir)RHI\Source;$(ProjectDir)Source;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <AdditionalOptions>/utf-8 %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>


### PR DESCRIPTION
## Summary
- add SceneSerializer to serialize multiple entities into the scene save text format
- add a snapshot-style save serialization check in Tests.Game
- fix Tests.Game include paths so the project can include RHI headers during build

Parent issue: #60
Child issue: #62