### PR TITLE
S04: 欠損 Asset フォールバック

### DIFF
--- a/App/Source/Application.cpp
+++ b/App/Source/Application.cpp
@@ -163,6 +163,16 @@ namespace Xelqoria::App
 
 		if (m_spriteRenderer && m_scene)
 		{
+			m_scene->ValidateSpriteReferences(
+				m_spriteAssetRegistry,
+				m_hasLoggedSceneResolution
+					? std::function<void(const std::string&)>{}
+					: std::function<void(const std::string&)>(
+						[](const std::string& message)
+						{
+							const std::string line = message + "\n";
+							::OutputDebugStringA(line.c_str());
+						}));
 			const auto resolvedSprites = m_scene->ResolveSprites(
 				m_spriteAssetRegistry,
 				m_textureAssetRegistry,

--- a/Game/Source/Scene.cpp
+++ b/Game/Source/Scene.cpp
@@ -27,6 +27,16 @@ namespace Xelqoria::Game
 		return m_entities.back();
 	}
 
+	Entity& Scene::CreateEntity(EntityId entityId)
+	{
+		m_entities.emplace_back(entityId);
+		if (entityId >= m_nextEntityId) {
+			m_nextEntityId = entityId + 1;
+		}
+
+		return m_entities.back();
+	}
+
 	bool Scene::DestroyEntity(EntityId entityId)
 	{
 		const auto it = std::find_if(

--- a/Game/Source/Scene.cpp
+++ b/Game/Source/Scene.cpp
@@ -197,4 +197,38 @@ namespace Xelqoria::Game
 
 		return resolvedSprites;
 	}
+
+	void Scene::ValidateSpriteReferences(
+		const Assets::ISpriteAssetResolver& spriteAssetResolver,
+		const std::function<void(const std::string&)>& logger)
+	{
+		for (auto& entity : m_entities) {
+			auto spriteComponent = entity.GetSpriteComponent();
+			if (!spriteComponent.has_value()) {
+				continue;
+			}
+
+			auto& spriteComponentValue = spriteComponent->get();
+			if (spriteComponentValue.spriteAssetRef.IsEmpty()) {
+				spriteComponentValue.spriteAssetState = SpriteAssetReferenceState::Unknown;
+				spriteComponentValue.missingSpriteAssetRef = {};
+				continue;
+			}
+
+			const auto spriteAsset = spriteAssetResolver.ResolveSpriteAsset(spriteComponentValue.spriteAssetRef);
+			if (!spriteAsset.has_value()) {
+				spriteComponentValue.spriteAssetState = SpriteAssetReferenceState::Missing;
+				spriteComponentValue.missingSpriteAssetRef = spriteComponentValue.spriteAssetRef;
+
+				std::ostringstream message;
+				message << "Scene::ValidateSpriteReferences detected missing SpriteAsset '"
+					<< spriteComponentValue.spriteAssetRef.GetValue() << "' for entity " << entity.GetId() << ".";
+				LogMessage(logger, message.str());
+				continue;
+			}
+
+			spriteComponentValue.spriteAssetState = SpriteAssetReferenceState::Resolved;
+			spriteComponentValue.missingSpriteAssetRef = {};
+		}
+	}
 }

--- a/Game/Source/Scene.h
+++ b/Game/Source/Scene.h
@@ -59,6 +59,13 @@ namespace Xelqoria::Game
 		Entity& CreateEntity();
 
 		/// <summary>
+		/// 指定した Entity ID で新しい Entity を生成して Scene に追加する。
+		/// </summary>
+		/// <param name="entityId">割り当てる Entity ID。</param>
+		/// <returns>追加された Entity。</returns>
+		Entity& CreateEntity(EntityId entityId);
+
+		/// <summary>
 		/// 指定した Entity を Scene から削除する。
 		/// </summary>
 		/// <param name="entityId">削除対象の Entity ID。</param>

--- a/Game/Source/Scene.h
+++ b/Game/Source/Scene.h
@@ -128,6 +128,15 @@ namespace Xelqoria::Game
 			const Graphics::ITextureAssetResolver& textureAssetResolver,
 			const std::function<void(const std::string&)>& logger = {}) const;
 
+		/// <summary>
+		/// Scene 内の Sprite アセット参照を検証して欠損状態を更新する。
+		/// </summary>
+		/// <param name="spriteAssetResolver">SpriteAsset を解決する Resolver。</param>
+		/// <param name="logger">検証状況を受け取るロガー。未指定時はログ出力しない。</param>
+		void ValidateSpriteReferences(
+			const Assets::ISpriteAssetResolver& spriteAssetResolver,
+			const std::function<void(const std::string&)>& logger = {});
+
 	private:
 		std::vector<Entity> m_entities;
 		std::vector<std::shared_ptr<Graphics::Sprite>> m_sprites;

--- a/Game/Source/SceneSerializer.cpp
+++ b/Game/Source/SceneSerializer.cpp
@@ -1,0 +1,51 @@
+#include "SceneSerializer.h"
+
+#include <iomanip>
+#include <sstream>
+
+#include "SceneSaveFormat.h"
+
+namespace
+{
+	void AppendVector3(std::ostringstream& stream, const Xelqoria::Game::Vector3& value)
+	{
+		stream << value.x << "," << value.y << "," << value.z;
+	}
+}
+
+namespace Xelqoria::Game
+{
+	std::string SceneSerializer::SaveToText(const Scene& scene)
+	{
+		std::ostringstream stream;
+		stream << std::fixed << std::setprecision(6);
+		stream << "magic=" << SceneSaveFormatMagic << "\n";
+		stream << "version=" << SceneSaveFormatVersion << "\n";
+
+		const auto entities = scene.GetEntities();
+		for (std::size_t entityIndex = 0; entityIndex < entities.size(); ++entityIndex)
+		{
+			const auto& entity = entities[entityIndex];
+			const auto& transform = entity.GetTransform();
+			const auto prefix = "entity." + std::to_string(entityIndex);
+
+			stream << prefix << ".id=" << entity.GetId() << "\n";
+			stream << prefix << ".transform.position=";
+			AppendVector3(stream, transform.position);
+			stream << "\n";
+			stream << prefix << ".transform.rotation=";
+			AppendVector3(stream, transform.rotation);
+			stream << "\n";
+			stream << prefix << ".transform.scale=";
+			AppendVector3(stream, transform.scale);
+			stream << "\n";
+
+			const auto spriteComponent = entity.GetSpriteComponent();
+			if (spriteComponent.has_value() && !spriteComponent->get().spriteAssetRef.IsEmpty()) {
+				stream << prefix << ".spriteRef=" << spriteComponent->get().spriteAssetRef.GetValue() << "\n";
+			}
+		}
+
+		return stream.str();
+	}
+}

--- a/Game/Source/SceneSerializer.cpp
+++ b/Game/Source/SceneSerializer.cpp
@@ -1,15 +1,102 @@
 #include "SceneSerializer.h"
 
+#include <charconv>
 #include <iomanip>
+#include <map>
+#include <optional>
 #include <sstream>
+#include <string_view>
 
 #include "SceneSaveFormat.h"
 
 namespace
 {
+	std::string_view Trim(std::string_view value)
+	{
+		const auto first = value.find_first_not_of(" \t\r");
+		if (first == std::string_view::npos) {
+			return {};
+		}
+
+		const auto last = value.find_last_not_of(" \t\r");
+		return value.substr(first, last - first + 1);
+	}
+
 	void AppendVector3(std::ostringstream& stream, const Xelqoria::Game::Vector3& value)
 	{
 		stream << value.x << "," << value.y << "," << value.z;
+	}
+
+	std::optional<std::uint32_t> ParseUnsigned(std::string_view value)
+	{
+		std::uint32_t parsedValue = 0;
+		const auto* begin = value.data();
+		const auto* end = value.data() + value.size();
+		const auto [ptr, ec] = std::from_chars(begin, end, parsedValue);
+		if (ec != std::errc{} || ptr != end) {
+			return std::nullopt;
+		}
+
+		return parsedValue;
+	}
+
+	std::optional<float> ParseFloat(std::string_view value)
+	{
+		std::istringstream stream{ std::string(value) };
+		float parsedValue = 0.0f;
+		stream >> parsedValue;
+		if (!stream || !stream.eof()) {
+			return std::nullopt;
+		}
+
+		return parsedValue;
+	}
+
+	std::optional<Xelqoria::Game::Vector3> ParseVector3(std::string_view value)
+	{
+		Xelqoria::Game::Vector3 vector{};
+		std::size_t cursor = 0;
+		float* components[3] = { &vector.x, &vector.y, &vector.z };
+
+		for (int index = 0; index < 3; ++index)
+		{
+			const std::size_t separator = value.find(',', cursor);
+			const std::string_view token = separator == std::string_view::npos
+				? value.substr(cursor)
+				: value.substr(cursor, separator - cursor);
+			const auto parsedComponent = ParseFloat(Trim(token));
+			if (!parsedComponent.has_value()) {
+				return std::nullopt;
+			}
+
+			*components[index] = *parsedComponent;
+			if (separator == std::string_view::npos) {
+				return index == 2 ? std::optional<Xelqoria::Game::Vector3>(vector) : std::nullopt;
+			}
+
+			cursor = separator + 1;
+		}
+
+		if (value.find(',', cursor) != std::string_view::npos) {
+			return std::nullopt;
+		}
+
+		return vector;
+	}
+
+	Xelqoria::Game::SceneLoadResult MakeError(
+		std::size_t lineNumber,
+		std::string_view fieldName,
+		std::string message)
+	{
+		return {
+			std::nullopt,
+			Xelqoria::Game::SceneLoadError{
+				lineNumber,
+				std::string(fieldName),
+				std::move(message)
+			}
+		};
 	}
 }
 
@@ -47,5 +134,133 @@ namespace Xelqoria::Game
 		}
 
 		return stream.str();
+	}
+
+	SceneLoadResult SceneSerializer::LoadFromText(std::string_view source)
+	{
+		std::optional<std::string> magic;
+		std::optional<std::uint32_t> version;
+		std::map<std::size_t, SceneEntitySaveRecord> records;
+		std::size_t lineNumber = 0;
+		std::size_t cursor = 0;
+
+		while (cursor <= source.size())
+		{
+			++lineNumber;
+
+			const std::size_t lineEnd = source.find('\n', cursor);
+			const std::size_t lineLength = lineEnd == std::string_view::npos
+				? source.size() - cursor
+				: lineEnd - cursor;
+			std::string_view line = Trim(source.substr(cursor, lineLength));
+
+			if (!line.empty()) {
+				const std::size_t separator = line.find('=');
+				if (separator == std::string_view::npos) {
+					return MakeError(lineNumber, {}, "Scene の各行は key=value 形式である必要があります。");
+				}
+
+				const std::string_view key = Trim(line.substr(0, separator));
+				const std::string_view value = Trim(line.substr(separator + 1));
+				if (key == "magic") {
+					magic = std::string(value);
+				}
+				else if (key == "version") {
+					version = ParseUnsigned(value);
+					if (!version.has_value()) {
+						return MakeError(lineNumber, key, "version は符号なし整数である必要があります。");
+					}
+				}
+				else if (key.starts_with("entity.")) {
+					const std::string_view remainder = key.substr(std::string_view("entity.").size());
+					const std::size_t nextDot = remainder.find('.');
+					if (nextDot == std::string_view::npos) {
+						return MakeError(lineNumber, key, "entity フィールド名が不正です。");
+					}
+
+					const auto entityIndex = ParseUnsigned(remainder.substr(0, nextDot));
+					if (!entityIndex.has_value()) {
+						return MakeError(lineNumber, key, "entity index は符号なし整数である必要があります。");
+					}
+
+					auto& record = records[*entityIndex];
+					const std::string_view fieldKey = remainder.substr(nextDot + 1);
+					if (fieldKey == "id") {
+						const auto entityId = ParseUnsigned(value);
+						if (!entityId.has_value()) {
+							return MakeError(lineNumber, key, "entity id は符号なし整数である必要があります。");
+						}
+
+						record.entityId = *entityId;
+					}
+					else if (fieldKey == "transform.position") {
+						const auto parsedVector = ParseVector3(value);
+						if (!parsedVector.has_value()) {
+							return MakeError(lineNumber, key, "position は x,y,z 形式である必要があります。");
+						}
+
+						record.transform.position = *parsedVector;
+					}
+					else if (fieldKey == "transform.rotation") {
+						const auto parsedVector = ParseVector3(value);
+						if (!parsedVector.has_value()) {
+							return MakeError(lineNumber, key, "rotation は x,y,z 形式である必要があります。");
+						}
+
+						record.transform.rotation = *parsedVector;
+					}
+					else if (fieldKey == "transform.scale") {
+						const auto parsedVector = ParseVector3(value);
+						if (!parsedVector.has_value()) {
+							return MakeError(lineNumber, key, "scale は x,y,z 形式である必要があります。");
+						}
+
+						record.transform.scale = *parsedVector;
+					}
+					else if (fieldKey == "spriteRef") {
+						record.spriteRef = SceneSpriteRefRecord{ Core::AssetId(value) };
+					}
+					else if (!fieldKey.starts_with(SceneSaveExtensionFieldPrefix)) {
+						return MakeError(lineNumber, key, "未対応の Scene フィールドです。");
+					}
+				}
+				else {
+					return MakeError(lineNumber, key, "未対応の Scene フィールドです。");
+				}
+			}
+
+			if (lineEnd == std::string_view::npos) {
+				break;
+			}
+
+			cursor = lineEnd + 1;
+		}
+
+		if (!magic.has_value() || *magic != SceneSaveFormatMagic) {
+			return MakeError(0, "magic", "SceneSaveFormatMagic と一致する magic が必要です。");
+		}
+
+		if (!version.has_value() || *version != SceneSaveFormatVersion) {
+			return MakeError(0, "version", "対応していない Scene 保存バージョンです。");
+		}
+
+		Scene scene;
+		for (const auto& [entityIndex, record] : records)
+		{
+			if (record.entityId == 0) {
+				return MakeError(0, "entity." + std::to_string(entityIndex) + ".id", "entity id が不足しています。");
+			}
+
+			auto& entity = scene.CreateEntity(record.entityId);
+			entity.GetTransform() = record.transform;
+			if (record.spriteRef.has_value()) {
+				entity.SetSpriteComponent(SpriteComponent{
+					record.spriteRef->spriteAssetRef,
+					{}
+				});
+			}
+		}
+
+		return { std::move(scene), std::nullopt };
 	}
 }

--- a/Game/Source/SceneSerializer.h
+++ b/Game/Source/SceneSerializer.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include <string>
+
+#include "Scene.h"
+
+namespace Xelqoria::Game
+{
+	/// <summary>
+	/// Scene を保存用テキストへ変換する。
+	/// </summary>
+	class SceneSerializer
+	{
+	public:
+		/// <summary>
+		/// Scene を `key=value` 形式の保存テキストへ変換する。
+		/// </summary>
+		/// <param name="scene">保存対象の Scene。</param>
+		/// <returns>保存フォーマットに従ったテキスト。</returns>
+		static std::string SaveToText(const Scene& scene);
+	};
+}

--- a/Game/Source/SceneSerializer.h
+++ b/Game/Source/SceneSerializer.h
@@ -1,11 +1,60 @@
 #pragma once
 
+#include <cstddef>
+#include <optional>
 #include <string>
+#include <string_view>
 
 #include "Scene.h"
 
 namespace Xelqoria::Game
 {
+	/// <summary>
+	/// Scene 読込失敗時の詳細情報を表す。
+	/// </summary>
+	struct SceneLoadError
+	{
+		/// <summary>
+		/// 問題が発生した入力行番号を表す。
+		/// </summary>
+		std::size_t lineNumber = 0;
+
+		/// <summary>
+		/// 問題が発生したフィールド名を表す。
+		/// </summary>
+		std::string fieldName{};
+
+		/// <summary>
+		/// 読込失敗理由を表す。
+		/// </summary>
+		std::string message{};
+	};
+
+	/// <summary>
+	/// Scene 読込結果を表す。
+	/// </summary>
+	struct SceneLoadResult
+	{
+		/// <summary>
+		/// 読込に成功した Scene を表す。
+		/// </summary>
+		std::optional<Scene> scene{};
+
+		/// <summary>
+		/// 読込に失敗した場合の詳細情報を表す。
+		/// </summary>
+		std::optional<SceneLoadError> error{};
+
+		/// <summary>
+		/// 読込に成功したかどうかを返す。
+		/// </summary>
+		/// <returns>成功時は true。</returns>
+		bool IsSuccess() const
+		{
+			return scene.has_value();
+		}
+	};
+
 	/// <summary>
 	/// Scene を保存用テキストへ変換する。
 	/// </summary>
@@ -18,5 +67,12 @@ namespace Xelqoria::Game
 		/// <param name="scene">保存対象の Scene。</param>
 		/// <returns>保存フォーマットに従ったテキスト。</returns>
 		static std::string SaveToText(const Scene& scene);
+
+		/// <summary>
+		/// `key=value` 形式の保存テキストから Scene を復元する。
+		/// </summary>
+		/// <param name="source">読込対象のテキスト全体。</param>
+		/// <returns>復元した Scene または失敗詳細。</returns>
+		static SceneLoadResult LoadFromText(std::string_view source);
 	};
 }

--- a/Game/Source/SpriteComponent.h
+++ b/Game/Source/SpriteComponent.h
@@ -7,6 +7,16 @@
 namespace Xelqoria::Game
 {
 	/// <summary>
+	/// Sprite アセット参照の解決状態を表す。
+	/// </summary>
+	enum class SpriteAssetReferenceState
+	{
+		Unknown = 0,
+		Resolved,
+		Missing
+	};
+
+	/// <summary>
 	/// SpriteComponent が保持する描画設定を表す。
 	/// </summary>
 	struct SpriteRenderSettings
@@ -41,5 +51,16 @@ namespace Xelqoria::Game
 		/// 描画時に使用する設定値を表す。
 		/// </summary>
 		SpriteRenderSettings renderSettings{};
+
+		/// <summary>
+		/// Sprite アセット参照の解決状態を表す。
+		/// </summary>
+		SpriteAssetReferenceState spriteAssetState = SpriteAssetReferenceState::Unknown;
+
+		/// <summary>
+		/// 欠損している Sprite アセット識別子を表す。
+		/// 正常時は空を保持する。
+		/// </summary>
+		Core::AssetId missingSpriteAssetRef{};
 	};
 }

--- a/Game/Xelqoria.Game.vcxproj
+++ b/Game/Xelqoria.Game.vcxproj
@@ -30,6 +30,7 @@
     <ClCompile Include="Source\Assets\SpriteAssetLoader.cpp" />
     <ClCompile Include="Source\Entity.cpp" />
     <ClCompile Include="Source\Scene.cpp" />
+    <ClCompile Include="Source\SceneSerializer.cpp" />
     <ClCompile Include="Source\Transform.cpp" />
   </ItemGroup>
   <ItemGroup>
@@ -39,6 +40,7 @@
     <ClInclude Include="Source\Entity.h" />
     <ClInclude Include="Source\Scene.h" />
     <ClInclude Include="Source\SceneSaveFormat.h" />
+    <ClInclude Include="Source\SceneSerializer.h" />
     <ClInclude Include="Source\SpriteComponent.h" />
     <ClInclude Include="Source\Transform.h" />
   </ItemGroup>

--- a/Game/Xelqoria.Game.vcxproj.filters
+++ b/Game/Xelqoria.Game.vcxproj.filters
@@ -20,6 +20,9 @@
     <ClCompile Include="Source\Scene.cpp">
       <Filter>Source</Filter>
     </ClCompile>
+    <ClCompile Include="Source\SceneSerializer.cpp">
+      <Filter>Source</Filter>
+    </ClCompile>
     <ClCompile Include="Source\Transform.cpp">
       <Filter>Source</Filter>
     </ClCompile>
@@ -41,6 +44,9 @@
       <Filter>Source</Filter>
     </ClInclude>
     <ClInclude Include="Source\SceneSaveFormat.h">
+      <Filter>Source</Filter>
+    </ClInclude>
+    <ClInclude Include="Source\SceneSerializer.h">
       <Filter>Source</Filter>
     </ClInclude>
     <ClInclude Include="Source\SpriteComponent.h">

--- a/Tests.Game/Source/TransformTests.cpp
+++ b/Tests.Game/Source/TransformTests.cpp
@@ -10,6 +10,7 @@
 #include "ITexture.h"
 #include "Scene.h"
 #include "SceneSaveFormat.h"
+#include "SceneSerializer.h"
 #include "Sprite.h"
 #include "SpriteComponent.h"
 #include "SpriteRenderMath.h"
@@ -21,6 +22,43 @@ namespace
 	bool IsEqual(float lhs, float rhs)
 	{
 		return std::fabs(lhs - rhs) < 0.0001f;
+	}
+
+	bool VerifySceneSaveSerialization()
+	{
+		Xelqoria::Game::Scene saveScene;
+		auto& playerEntity = saveScene.CreateEntity();
+		playerEntity.GetTransform().SetPosition(12.5f, -8.0f, 3.0f);
+		playerEntity.GetTransform().rotation = { 0.0f, 45.0f, 90.0f };
+		playerEntity.GetTransform().scale = { 1.0f, 2.0f, 1.0f };
+		playerEntity.SetSpriteComponent(Xelqoria::Game::SpriteComponent{
+			"sprites/player",
+			{
+				true,
+				0,
+				1.0f
+			}
+		});
+
+		auto& backgroundEntity = saveScene.CreateEntity();
+		backgroundEntity.GetTransform().SetPosition(-32.0f, 64.0f, 0.0f);
+		backgroundEntity.GetTransform().rotation = { 0.0f, 0.0f, 0.0f };
+		backgroundEntity.GetTransform().scale = { 4.0f, 4.0f, 1.0f };
+
+		const std::string sceneSaveSnapshot =
+			"magic=xelqoria.scene\n"
+			"version=1\n"
+			"entity.0.id=1\n"
+			"entity.0.transform.position=12.500000,-8.000000,3.000000\n"
+			"entity.0.transform.rotation=0.000000,45.000000,90.000000\n"
+			"entity.0.transform.scale=1.000000,2.000000,1.000000\n"
+			"entity.0.spriteRef=sprites/player\n"
+			"entity.1.id=2\n"
+			"entity.1.transform.position=-32.000000,64.000000,0.000000\n"
+			"entity.1.transform.rotation=0.000000,0.000000,0.000000\n"
+			"entity.1.transform.scale=4.000000,4.000000,1.000000\n";
+
+		return Xelqoria::Game::SceneSerializer::SaveToText(saveScene) == sceneSaveSnapshot;
 	}
 
 	class FakeTexture final : public Xelqoria::RHI::ITexture
@@ -370,6 +408,10 @@ int main()
 		!IsEqual(sceneSaveRecord.transform.position.z, 6.0f) ||
 		!sceneSaveRecord.spriteRef.has_value() ||
 		sceneSaveRecord.spriteRef->spriteAssetRef != Xelqoria::Core::AssetId("sprites/player")) {
+		return 1;
+	}
+
+	if (!VerifySceneSaveSerialization()) {
 		return 1;
 	}
 

--- a/Tests.Game/Source/TransformTests.cpp
+++ b/Tests.Game/Source/TransformTests.cpp
@@ -334,7 +334,9 @@ int main()
 
 	if (!attachedSpriteComponent->get().renderSettings.visible ||
 		!IsEqual(attachedSpriteComponent->get().renderSettings.opacity, 0.75f) ||
-		attachedSpriteComponent->get().renderSettings.sortOrder != 10) {
+		attachedSpriteComponent->get().renderSettings.sortOrder != 10 ||
+		attachedSpriteComponent->get().spriteAssetState != Xelqoria::Game::SpriteAssetReferenceState::Unknown ||
+		!attachedSpriteComponent->get().missingSpriteAssetRef.IsEmpty()) {
 		return 1;
 	}
 
@@ -342,7 +344,9 @@ int main()
 	if (!defaultSpriteComponent.renderSettings.visible ||
 		defaultSpriteComponent.renderSettings.sortOrder != 0 ||
 		!IsEqual(defaultSpriteComponent.renderSettings.opacity, 1.0f) ||
-		!defaultSpriteComponent.spriteAssetRef.IsEmpty()) {
+		!defaultSpriteComponent.spriteAssetRef.IsEmpty() ||
+		defaultSpriteComponent.spriteAssetState != Xelqoria::Game::SpriteAssetReferenceState::Unknown ||
+		!defaultSpriteComponent.missingSpriteAssetRef.IsEmpty()) {
 		return 1;
 	}
 
@@ -441,6 +445,20 @@ int main()
 	});
 
 	std::vector<std::string> missingAssetLogs;
+	missingAssetScene.ValidateSpriteReferences(
+		spriteAssetRegistry,
+		[&missingAssetLogs](const std::string& message)
+		{
+			missingAssetLogs.push_back(message);
+		});
+
+	const auto missingAssetComponent = missingAssetEntity.GetSpriteComponent();
+	if (!missingAssetComponent.has_value() ||
+		missingAssetComponent->get().spriteAssetState != Xelqoria::Game::SpriteAssetReferenceState::Missing ||
+		missingAssetComponent->get().missingSpriteAssetRef != Xelqoria::Core::AssetId("sprites/missing")) {
+		return 1;
+	}
+
 	const auto unresolvedSprites = missingAssetScene.ResolveSprites(
 		spriteAssetRegistry,
 		textureAssetRegistry,
@@ -453,9 +471,11 @@ int main()
 		return 1;
 	}
 
-	if (missingAssetLogs.size() != 1 ||
-		missingAssetLogs[0].find("could not resolve SpriteAsset") == std::string::npos ||
-		missingAssetLogs[0].find("sprites/missing") == std::string::npos) {
+	if (missingAssetLogs.size() != 2 ||
+		missingAssetLogs[0].find("detected missing SpriteAsset") == std::string::npos ||
+		missingAssetLogs[0].find("sprites/missing") == std::string::npos ||
+		missingAssetLogs[1].find("could not resolve SpriteAsset") == std::string::npos ||
+		missingAssetLogs[1].find("sprites/missing") == std::string::npos) {
 		return 1;
 	}
 

--- a/Tests.Game/Source/TransformTests.cpp
+++ b/Tests.Game/Source/TransformTests.cpp
@@ -61,6 +61,83 @@ namespace
 		return Xelqoria::Game::SceneSerializer::SaveToText(saveScene) == sceneSaveSnapshot;
 	}
 
+	bool VerifySceneSaveRoundTrip()
+	{
+		Xelqoria::Game::Scene sourceScene;
+		auto& playerEntity = sourceScene.CreateEntity();
+		playerEntity.GetTransform().SetPosition(1.0f, 2.0f, 3.0f);
+		playerEntity.GetTransform().rotation = { 4.0f, 5.0f, 6.0f };
+		playerEntity.GetTransform().scale = { 7.0f, 8.0f, 9.0f };
+		playerEntity.SetSpriteComponent(Xelqoria::Game::SpriteComponent{
+			"sprites/player",
+			{
+				true,
+				3,
+				0.8f
+			}
+		});
+
+		auto& backgroundEntity = sourceScene.CreateEntity();
+		backgroundEntity.GetTransform().SetPosition(-10.0f, 20.0f, -30.0f);
+		backgroundEntity.GetTransform().rotation = { 0.0f, 15.0f, 30.0f };
+		backgroundEntity.GetTransform().scale = { 2.0f, 2.0f, 1.0f };
+
+		const std::string serializedScene = Xelqoria::Game::SceneSerializer::SaveToText(sourceScene);
+		const auto loadResult = Xelqoria::Game::SceneSerializer::LoadFromText(serializedScene);
+		if (!loadResult.IsSuccess() || !loadResult.scene.has_value()) {
+			return false;
+		}
+
+		const auto& loadedScene = *loadResult.scene;
+		if (loadedScene.GetEntityCount() != 2) {
+			return false;
+		}
+
+		const auto loadedPlayerEntity = loadedScene.FindEntity(1);
+		const auto loadedBackgroundEntity = loadedScene.FindEntity(2);
+		if (!loadedPlayerEntity.has_value() || !loadedBackgroundEntity.has_value()) {
+			return false;
+		}
+
+		const auto& loadedPlayerTransform = loadedPlayerEntity->get().GetTransform();
+		const auto& loadedBackgroundTransform = loadedBackgroundEntity->get().GetTransform();
+		if (!IsEqual(loadedPlayerTransform.position.x, 1.0f) ||
+			!IsEqual(loadedPlayerTransform.position.y, 2.0f) ||
+			!IsEqual(loadedPlayerTransform.position.z, 3.0f) ||
+			!IsEqual(loadedPlayerTransform.rotation.x, 4.0f) ||
+			!IsEqual(loadedPlayerTransform.rotation.y, 5.0f) ||
+			!IsEqual(loadedPlayerTransform.rotation.z, 6.0f) ||
+			!IsEqual(loadedPlayerTransform.scale.x, 7.0f) ||
+			!IsEqual(loadedPlayerTransform.scale.y, 8.0f) ||
+			!IsEqual(loadedPlayerTransform.scale.z, 9.0f)) {
+			return false;
+		}
+
+		if (!IsEqual(loadedBackgroundTransform.position.x, -10.0f) ||
+			!IsEqual(loadedBackgroundTransform.position.y, 20.0f) ||
+			!IsEqual(loadedBackgroundTransform.position.z, -30.0f) ||
+			!IsEqual(loadedBackgroundTransform.rotation.x, 0.0f) ||
+			!IsEqual(loadedBackgroundTransform.rotation.y, 15.0f) ||
+			!IsEqual(loadedBackgroundTransform.rotation.z, 30.0f) ||
+			!IsEqual(loadedBackgroundTransform.scale.x, 2.0f) ||
+			!IsEqual(loadedBackgroundTransform.scale.y, 2.0f) ||
+			!IsEqual(loadedBackgroundTransform.scale.z, 1.0f)) {
+			return false;
+		}
+
+		const auto loadedPlayerSpriteComponent = loadedPlayerEntity->get().GetSpriteComponent();
+		if (!loadedPlayerSpriteComponent.has_value() ||
+			loadedPlayerSpriteComponent->get().spriteAssetRef != Xelqoria::Core::AssetId("sprites/player")) {
+			return false;
+		}
+
+		if (loadedBackgroundEntity->get().GetSpriteComponent().has_value()) {
+			return false;
+		}
+
+		return Xelqoria::Game::SceneSerializer::SaveToText(loadedScene) == serializedScene;
+	}
+
 	class FakeTexture final : public Xelqoria::RHI::ITexture
 	{
 	public:
@@ -412,6 +489,10 @@ int main()
 	}
 
 	if (!VerifySceneSaveSerialization()) {
+		return 1;
+	}
+
+	if (!VerifySceneSaveRoundTrip()) {
 		return 1;
 	}
 

--- a/Tests.Game/Xelqoria.Tests.Game.vcxproj
+++ b/Tests.Game/Xelqoria.Tests.Game.vcxproj
@@ -93,7 +93,7 @@
       <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <LanguageStandard>stdcpp20</LanguageStandard>
-      <AdditionalIncludeDirectories>$(SolutionDir)Core\Source;$(SolutionDir)Game\Source;$(SolutionDir)Graphics\Source;$(ProjectDir)Source;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(SolutionDir)Core\Source;$(SolutionDir)Game\Source;$(SolutionDir)Graphics\Source;$(SolutionDir)RHI\Source;$(ProjectDir)Source;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <AdditionalOptions>/utf-8 %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
@@ -110,7 +110,7 @@
       <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <LanguageStandard>stdcpp20</LanguageStandard>
-      <AdditionalIncludeDirectories>$(SolutionDir)Core\Source;$(SolutionDir)Game\Source;$(SolutionDir)Graphics\Source;$(ProjectDir)Source;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(SolutionDir)Core\Source;$(SolutionDir)Game\Source;$(SolutionDir)Graphics\Source;$(SolutionDir)RHI\Source;$(ProjectDir)Source;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <AdditionalOptions>/utf-8 %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
@@ -125,7 +125,7 @@
       <PreprocessorDefinitions>_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <LanguageStandard>stdcpp20</LanguageStandard>
-      <AdditionalIncludeDirectories>$(SolutionDir)Core\Source;$(SolutionDir)Game\Source;$(SolutionDir)Graphics\Source;$(ProjectDir)Source;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(SolutionDir)Core\Source;$(SolutionDir)Game\Source;$(SolutionDir)Graphics\Source;$(SolutionDir)RHI\Source;$(ProjectDir)Source;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <AdditionalOptions>/utf-8 %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
@@ -142,7 +142,7 @@
       <PreprocessorDefinitions>NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <LanguageStandard>stdcpp20</LanguageStandard>
-      <AdditionalIncludeDirectories>$(SolutionDir)Core\Source;$(SolutionDir)Game\Source;$(SolutionDir)Graphics\Source;$(ProjectDir)Source;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(SolutionDir)Core\Source;$(SolutionDir)Game\Source;$(SolutionDir)Graphics\Source;$(SolutionDir)RHI\Source;$(ProjectDir)Source;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <AdditionalOptions>/utf-8 %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>


### PR DESCRIPTION
## Summary
- add missing sprite asset state to SpriteComponent so editor-side code can detect unresolved references
- add Scene::ValidateSpriteReferences to mark missing sprite references and log the problematic AssetId
- validate missing sprite references in the app render loop and cover the fallback state in Tests.Game

Parent issue: #60
Child issue: #64
Depends on: #74 (issue-63) merged locally into this branch for continued work