### PR TITLE
E01: Editor ターゲット作成

### DIFF
--- a/Editor/Source/Application.cpp
+++ b/Editor/Source/Application.cpp
@@ -1,0 +1,104 @@
+#include "Application.h"
+
+#include <chrono>
+#include <memory>
+#include <string>
+
+#include "GraphicsAPI.h"
+#include "RenderBackendBootstrap.h"
+
+namespace Xelqoria::Editor
+{
+    Application::Application(HINSTANCE hInstance)
+        : m_hInstance(hInstance)
+    {
+    }
+
+    Application::~Application()
+    {
+        Shutdown();
+    }
+
+    int Application::Run()
+    {
+        if (!Initialize())
+        {
+            return -1;
+        }
+
+        using clock = std::chrono::steady_clock;
+        auto lastTime = clock::now();
+
+        while (m_running)
+        {
+            if (!m_window.PumpMessages())
+            {
+                m_running = false;
+                continue;
+            }
+
+            const auto currentTime = clock::now();
+            const std::chrono::duration<float> delta = currentTime - lastTime;
+            lastTime = currentTime;
+
+            Update(delta.count());
+            Render();
+        }
+
+        return 0;
+    }
+
+    bool Application::Initialize()
+    {
+        constexpr auto clientWidth = 1600u;
+        constexpr auto clientHeight = 900u;
+        constexpr RHI::GraphicsAPI api = RHI::GraphicsAPI::D3D11;
+
+        m_graphics = BootstrapRenderBackend(api);
+        if (!m_graphics)
+        {
+            return false;
+        }
+
+        std::wstring title = L"Xelqoria Editor - ";
+        title += RHI::GraphicsAPIToString(api);
+
+        if (!m_window.Create(m_hInstance, title.c_str(), clientWidth, clientHeight))
+        {
+            return false;
+        }
+
+        m_window.Show();
+
+        return m_graphics->Initialize(
+            m_window.GetHwnd(),
+            m_hInstance,
+            m_window.GetWidth(),
+            m_window.GetHeight());
+    }
+
+    void Application::Shutdown()
+    {
+        if (m_graphics)
+        {
+            m_graphics->Shutdown();
+            m_graphics.reset();
+        }
+    }
+
+    void Application::Update(float deltaTime)
+    {
+        (void)deltaTime;
+    }
+
+    void Application::Render()
+    {
+        if (!m_graphics)
+        {
+            return;
+        }
+
+        m_graphics->BeginFrame();
+        m_graphics->EndFrame();
+    }
+}

--- a/Editor/Source/Application.h
+++ b/Editor/Source/Application.h
@@ -1,0 +1,83 @@
+#pragma once
+
+#include <Windows.h>
+#include <memory>
+
+#include "IGraphicsContext.h"
+#include "Window.h"
+
+namespace Xelqoria::Editor
+{
+    /// <summary>
+    /// Editor ターゲットの最小実行ループを管理する。
+    /// </summary>
+    class Application
+    {
+    public:
+        /// <summary>
+        /// Editor 用 Application を生成する。
+        /// </summary>
+        /// <param name="hInstance">Windows アプリケーションのインスタンスハンドル。</param>
+        explicit Application(HINSTANCE hInstance);
+
+        /// <summary>
+        /// 内部リソースを解放する。
+        /// </summary>
+        ~Application();
+
+        Application(const Application&) = delete;
+        Application& operator=(const Application&) = delete;
+        Application(Application&&) = delete;
+        Application& operator=(Application&&) = delete;
+
+        /// <summary>
+        /// Editor のメインループを実行する。
+        /// </summary>
+        /// <returns>プロセス終了コード。</returns>
+        int Run();
+
+    private:
+        /// <summary>
+        /// Editor ターゲットを初期化する。
+        /// </summary>
+        /// <returns>初期化に成功した場合は true。</returns>
+        bool Initialize();
+
+        /// <summary>
+        /// 終了時のクリーンアップを行う。
+        /// </summary>
+        void Shutdown();
+
+        /// <summary>
+        /// Editor 用のフレーム更新処理を行う。
+        /// </summary>
+        /// <param name="deltaTime">前フレームからの経過時間（秒）。</param>
+        void Update(float deltaTime);
+
+        /// <summary>
+        /// Editor 用のフレーム描画を行う。
+        /// </summary>
+        void Render();
+
+    private:
+        /// <summary>
+        /// Windows アプリケーションインスタンスを保持する。
+        /// </summary>
+        HINSTANCE m_hInstance = nullptr;
+
+        /// <summary>
+        /// Editor のメインウィンドウを保持する。
+        /// </summary>
+        Core::Window m_window{};
+
+        /// <summary>
+        /// 将来の SceneView 実装に備える描画コンテキストを保持する。
+        /// </summary>
+        std::unique_ptr<RHI::IGraphicsContext> m_graphics;
+
+        /// <summary>
+        /// メインループの継続状態を表す。
+        /// </summary>
+        bool m_running = true;
+    };
+}

--- a/Editor/Source/Entry.cpp
+++ b/Editor/Source/Entry.cpp
@@ -1,0 +1,17 @@
+#include <Windows.h>
+
+#include "Application.h"
+
+int APIENTRY wWinMain(
+    _In_ HINSTANCE hInstance,
+    _In_opt_ HINSTANCE hPrevInstance,
+    _In_ PWSTR pCmdLine,
+    _In_ int nCmdShow)
+{
+    UNREFERENCED_PARAMETER(hPrevInstance);
+    UNREFERENCED_PARAMETER(pCmdLine);
+    UNREFERENCED_PARAMETER(nCmdShow);
+
+    Xelqoria::Editor::Application app(hInstance);
+    return app.Run();
+}

--- a/Editor/Source/RenderBackendBootstrap.cpp
+++ b/Editor/Source/RenderBackendBootstrap.cpp
@@ -1,0 +1,23 @@
+#include "RenderBackendBootstrap.h"
+
+#include <memory>
+
+#include "D3D11GraphicsContext.h"
+#include "D3D12GraphicsContext.h"
+
+namespace Xelqoria::Editor
+{
+    std::unique_ptr<RHI::IGraphicsContext> BootstrapRenderBackend(RHI::GraphicsAPI api)
+    {
+        switch (api)
+        {
+        case RHI::GraphicsAPI::D3D11:
+            return std::make_unique<Xelqoria::Backends::D3D11::D3D11GraphicsContext>();
+        case RHI::GraphicsAPI::D3D12:
+            return std::make_unique<Xelqoria::Backends::D3D12::D3D12GraphicsContext>();
+        case RHI::GraphicsAPI::None:
+        default:
+            return nullptr;
+        }
+    }
+}

--- a/Editor/Source/RenderBackendBootstrap.h
+++ b/Editor/Source/RenderBackendBootstrap.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include <memory>
+
+#include "GraphicsAPI.h"
+#include "IGraphicsContext.h"
+
+namespace Xelqoria::Editor
+{
+    /// <summary>
+    /// Editor ターゲットで使用する描画バックエンドを生成する。
+    /// </summary>
+    /// <param name="api">生成対象の GraphicsAPI。</param>
+    /// <returns>生成した描画コンテキスト。未対応の場合は nullptr。</returns>
+    std::unique_ptr<RHI::IGraphicsContext> BootstrapRenderBackend(RHI::GraphicsAPI api);
+}

--- a/Editor/Xelqoria.Editor.vcxproj
+++ b/Editor/Xelqoria.Editor.vcxproj
@@ -1,0 +1,177 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="Source\Application.cpp" />
+    <ClCompile Include="Source\Entry.cpp" />
+    <ClCompile Include="Source\RenderBackendBootstrap.cpp" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="Source\Application.h" />
+    <ClInclude Include="Source\RenderBackendBootstrap.h" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Core\Xelqoria.Core.vcxproj">
+      <Project>{79E8E826-7407-4766-B731-675CB84F6552}</Project>
+    </ProjectReference>
+    <ProjectReference Include="..\RHI\Xelqoria.RHI.vcxproj">
+      <Project>{158B81FC-B108-4237-8A37-EB8C6EF29392}</Project>
+    </ProjectReference>
+    <ProjectReference Include="..\Graphics\Xelqoria.Graphics.vcxproj">
+      <Project>{7693792A-4AD4-445A-98F7-B90D6989A837}</Project>
+    </ProjectReference>
+    <ProjectReference Include="..\Game\Xelqoria.Game.vcxproj">
+      <Project>{B43E8E97-59EF-4CAA-8A27-BD9192D8833A}</Project>
+    </ProjectReference>
+    <ProjectReference Include="..\Backends.D3D11\Xelqoria.Backends.D3D11.vcxproj">
+      <Project>{D89979A3-9EDE-4B5B-A2B1-2DD1DB261114}</Project>
+    </ProjectReference>
+    <ProjectReference Include="..\Backends.D3D12\Xelqoria.Backends.D3D12.vcxproj">
+      <Project>{14484BBF-F4FB-48AA-9CE4-BD7CBE1B24A4}</Project>
+    </ProjectReference>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <VCProjectVersion>18.0</VCProjectVersion>
+    <Keyword>Win32Proj</Keyword>
+    <ProjectGuid>{2A2FC413-07F6-41D7-AB02-079CE112C042}</ProjectGuid>
+    <RootNamespace>XelqoriaEditor</RootNamespace>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v145</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v145</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v145</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v145</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings" />
+  <ImportGroup Label="Shared" />
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup>
+    <OutDir>$(SolutionDir)artifacts\$(Platform)\$(Configuration)\</OutDir>
+    <IntDir>$(SolutionDir)build\$(ProjectName)\$(Platform)\$(Configuration)\</IntDir>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+      <LanguageStandard>stdcpp20</LanguageStandard>
+      <AdditionalIncludeDirectories>$(ProjectDir)Source;$(SolutionDir)Core\Source;$(SolutionDir)Game\Source;$(SolutionDir)Graphics\Source;$(SolutionDir)RHI\Source;$(SolutionDir)Backends.D3D11\Source;$(SolutionDir)Backends.D3D12\Source;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalOptions>/utf-8 %(AdditionalOptions)</AdditionalOptions>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalDependencies>d3d11.lib;dxgi.lib;dxguid.lib;d3d12.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+      <LanguageStandard>stdcpp20</LanguageStandard>
+      <AdditionalIncludeDirectories>$(ProjectDir)Source;$(SolutionDir)Core\Source;$(SolutionDir)Game\Source;$(SolutionDir)Graphics\Source;$(SolutionDir)RHI\Source;$(SolutionDir)Backends.D3D11\Source;$(SolutionDir)Backends.D3D12\Source;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalOptions>/utf-8 %(AdditionalOptions)</AdditionalOptions>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalDependencies>d3d11.lib;dxgi.lib;dxguid.lib;d3d12.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+      <LanguageStandard>stdcpp20</LanguageStandard>
+      <AdditionalIncludeDirectories>$(ProjectDir)Source;$(SolutionDir)Core\Source;$(SolutionDir)Game\Source;$(SolutionDir)Graphics\Source;$(SolutionDir)RHI\Source;$(SolutionDir)Backends.D3D11\Source;$(SolutionDir)Backends.D3D12\Source;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalOptions>/utf-8 %(AdditionalOptions)</AdditionalOptions>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalDependencies>d3d11.lib;dxgi.lib;dxguid.lib;d3d12.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+      <LanguageStandard>stdcpp20</LanguageStandard>
+      <AdditionalIncludeDirectories>$(ProjectDir)Source;$(SolutionDir)Core\Source;$(SolutionDir)Game\Source;$(SolutionDir)Graphics\Source;$(SolutionDir)RHI\Source;$(SolutionDir)Backends.D3D11\Source;$(SolutionDir)Backends.D3D12\Source;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalOptions>/utf-8 %(AdditionalOptions)</AdditionalOptions>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalDependencies>d3d11.lib;dxgi.lib;dxguid.lib;d3d12.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <Target Name="ValidateLayerDependencies" BeforeTargets="ClCompile">
+    <Exec Command="powershell -NoProfile -ExecutionPolicy Bypass -File &quot;$(SolutionDir)tools\check-layer-dependencies.ps1&quot; -RepoDir &quot;$(SolutionDir)&quot;" />
+  </Target>
+  <ImportGroup Label="ExtensionTargets" />
+</Project>

--- a/Editor/Xelqoria.Editor.vcxproj.filters
+++ b/Editor/Xelqoria.Editor.vcxproj.filters
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Filter Include="Source">
+      <UniqueIdentifier>{F879A90A-5E6D-4D34-96B0-14B6D8A7D280}</UniqueIdentifier>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="Source\Application.cpp">
+      <Filter>Source</Filter>
+    </ClCompile>
+    <ClCompile Include="Source\Entry.cpp">
+      <Filter>Source</Filter>
+    </ClCompile>
+    <ClCompile Include="Source\RenderBackendBootstrap.cpp">
+      <Filter>Source</Filter>
+    </ClCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="Source\Application.h">
+      <Filter>Source</Filter>
+    </ClInclude>
+    <ClInclude Include="Source\RenderBackendBootstrap.h">
+      <Filter>Source</Filter>
+    </ClInclude>
+  </ItemGroup>
+</Project>

--- a/Xelqoria.slnx
+++ b/Xelqoria.slnx
@@ -50,6 +50,7 @@
   <Project Path="Backends.D3D11/Xelqoria.Backends.D3D11.vcxproj" Id="d89979a3-9ede-4b5b-a2b1-2dd1db261114" />
   <Project Path="Backends.D3D12/Xelqoria.Backends.D3D12.vcxproj" Id="14484bbf-f4fb-48aa-9ce4-bd7cbe1b24a4" />
   <Project Path="Core/Xelqoria.Core.vcxproj" Id="79e8e826-7407-4766-b731-675cb84f6552" />
+  <Project Path="Editor/Xelqoria.Editor.vcxproj" Id="2a2fc413-07f6-41d7-ab02-079ce112c042" />
   <Project Path="Game/Xelqoria.Game.vcxproj" Id="b43e8e97-59ef-4caa-8a27-bd9192d8833a" />
   <Project Path="Graphics/Xelqoria.Graphics.vcxproj" Id="7693792a-4ad4-445a-98f7-b90d6989a837" />
   <Project Path="RHI/Xelqoria.RHI.vcxproj" Id="158b81fc-b108-4237-8a37-eb8c6ef29392" />


### PR DESCRIPTION
## 概要
- Editor 用の独立した実行ターゲットを追加
- App とは分離した Editor 専用 Application / Entry / RenderBackendBootstrap を追加
- ソリューションに Editor プロジェクトを登録

## 検証
- "/mnt/c/Program Files/Microsoft Visual Studio/18/Community/MSBuild/Current/Bin/MSBuild.exe" Xelqoria.slnx /p:Configuration=Debug /p:Platform=x64

## 関連
- Parent: #65
- Child: #66