### PR TITLE
E02: Editor メインウィンドウ雛形

### DIFF
--- a/Editor/Source/Application.cpp
+++ b/Editor/Source/Application.cpp
@@ -1,6 +1,8 @@
 #include "Application.h"
 
+#include <algorithm>
 #include <chrono>
+#include <cwchar>
 #include <memory>
 #include <string>
 
@@ -54,27 +56,22 @@ namespace Xelqoria::Editor
         constexpr auto clientHeight = 900u;
         constexpr RHI::GraphicsAPI api = RHI::GraphicsAPI::D3D11;
 
-        m_graphics = BootstrapRenderBackend(api);
-        if (!m_graphics)
-        {
-            return false;
-        }
-
         std::wstring title = L"Xelqoria Editor - ";
         title += RHI::GraphicsAPIToString(api);
-
         if (!m_window.Create(m_hInstance, title.c_str(), clientWidth, clientHeight))
         {
             return false;
         }
 
+        if (!CreateEditorShell())
+        {
+            return false;
+        }
+
+        UpdateLayout();
         m_window.Show();
 
-        return m_graphics->Initialize(
-            m_window.GetHwnd(),
-            m_hInstance,
-            m_window.GetWidth(),
-            m_window.GetHeight());
+        return InitializeSceneViewGraphics();
     }
 
     void Application::Shutdown()
@@ -89,6 +86,7 @@ namespace Xelqoria::Editor
     void Application::Update(float deltaTime)
     {
         (void)deltaTime;
+        UpdateLayout();
     }
 
     void Application::Render()
@@ -100,5 +98,173 @@ namespace Xelqoria::Editor
 
         m_graphics->BeginFrame();
         m_graphics->EndFrame();
+    }
+
+    bool Application::CreateEditorShell()
+    {
+        m_defaultFont = static_cast<HFONT>(GetStockObject(DEFAULT_GUI_FONT));
+
+        constexpr DWORD panelStyle = WS_CHILD | WS_VISIBLE | BS_GROUPBOX;
+        m_hierarchyPanel = CreateChildWindow(L"Button", L"Hierarchy", panelStyle);
+        m_assetsPanel = CreateChildWindow(L"Button", L"Assets", panelStyle);
+        m_inspectorPanel = CreateChildWindow(L"Button", L"Inspector", panelStyle);
+        m_sceneViewPanel = CreateChildWindow(L"Button", L"SceneView", panelStyle);
+        m_sceneViewPlanLabel = CreateChildWindow(
+            L"Static",
+            L"Runtime 描画は SceneView 専用 child HWND に埋め込みます。",
+            WS_CHILD | WS_VISIBLE);
+        m_sceneViewHost = CreateChildWindow(
+            L"Static",
+            L"",
+            WS_CHILD | WS_VISIBLE | SS_NOTIFY,
+            WS_EX_CLIENTEDGE);
+        m_sceneViewSizeLabel = CreateChildWindow(
+            L"Static",
+            L"SceneView size: pending",
+            WS_CHILD | WS_VISIBLE);
+
+        return m_hierarchyPanel != nullptr
+            && m_assetsPanel != nullptr
+            && m_inspectorPanel != nullptr
+            && m_sceneViewPanel != nullptr
+            && m_sceneViewPlanLabel != nullptr
+            && m_sceneViewHost != nullptr
+            && m_sceneViewSizeLabel != nullptr;
+    }
+
+    void Application::UpdateLayout()
+    {
+        RECT clientRect{};
+        GetClientRect(m_window.GetHwnd(), &clientRect);
+
+        const int clientWidth = clientRect.right - clientRect.left;
+        const int clientHeight = clientRect.bottom - clientRect.top;
+        if (clientWidth <= 0 || clientHeight <= 0)
+        {
+            return;
+        }
+
+        constexpr int outerPadding = 12;
+        constexpr int panelSpacing = 12;
+        constexpr int leftPaneWidth = 260;
+        constexpr int rightPaneWidth = 300;
+        constexpr int groupHeaderHeight = 26;
+        constexpr int hierarchyHeight = 280;
+        constexpr int labelHeight = 24;
+
+        const int centerX = outerPadding + leftPaneWidth + panelSpacing;
+        const int centerWidth = (std::max)(320, clientWidth - leftPaneWidth - rightPaneWidth - (outerPadding * 2) - (panelSpacing * 2));
+        const int rightX = centerX + centerWidth + panelSpacing;
+        const int rightWidth = (std::max)(220, clientWidth - rightX - outerPadding);
+        const int hierarchyPanelHeight = (std::max)(180, (std::min)(hierarchyHeight, clientHeight - (outerPadding * 2) - panelSpacing - 160));
+        const int assetsPanelY = outerPadding + hierarchyPanelHeight + panelSpacing;
+        const int assetsPanelHeight = (std::max)(140, clientHeight - assetsPanelY - outerPadding);
+        const int scenePanelHeight = clientHeight - (outerPadding * 2);
+
+        MoveWindow(m_hierarchyPanel, outerPadding, outerPadding, leftPaneWidth, hierarchyPanelHeight, TRUE);
+        MoveWindow(m_assetsPanel, outerPadding, assetsPanelY, leftPaneWidth, assetsPanelHeight, TRUE);
+        MoveWindow(m_sceneViewPanel, centerX, outerPadding, centerWidth, scenePanelHeight, TRUE);
+        MoveWindow(m_inspectorPanel, rightX, outerPadding, rightWidth, scenePanelHeight, TRUE);
+
+        const int sceneInnerWidth = (std::max)(120, centerWidth - (outerPadding * 2));
+        const int sceneHostHeight = (std::max)(160, scenePanelHeight - groupHeaderHeight - labelHeight - (outerPadding * 3));
+
+        MoveWindow(
+            m_sceneViewPlanLabel,
+            centerX + outerPadding,
+            outerPadding + groupHeaderHeight,
+            sceneInnerWidth,
+            labelHeight,
+            TRUE);
+        MoveWindow(
+            m_sceneViewHost,
+            centerX + outerPadding,
+            outerPadding + groupHeaderHeight + labelHeight + panelSpacing,
+            sceneInnerWidth,
+            sceneHostHeight,
+            TRUE);
+        MoveWindow(
+            m_sceneViewSizeLabel,
+            centerX + outerPadding,
+            outerPadding + groupHeaderHeight + labelHeight + panelSpacing + sceneHostHeight + 6,
+            sceneInnerWidth,
+            labelHeight,
+            TRUE);
+
+        RECT sceneHostRect{};
+        GetClientRect(m_sceneViewHost, &sceneHostRect);
+        const auto newWidth = static_cast<std::uint32_t>(sceneHostRect.right - sceneHostRect.left);
+        const auto newHeight = static_cast<std::uint32_t>(sceneHostRect.bottom - sceneHostRect.top);
+
+        if (newWidth != m_sceneViewWidth || newHeight != m_sceneViewHeight)
+        {
+            m_sceneViewWidth = newWidth;
+            m_sceneViewHeight = newHeight;
+
+            wchar_t sizeText[128]{};
+            std::swprintf(
+                sizeText,
+                std::size(sizeText),
+                L"SceneView size: %u x %u / host: child HWND",
+                m_sceneViewWidth,
+                m_sceneViewHeight);
+            SetWindowTextW(m_sceneViewSizeLabel, sizeText);
+
+            if (m_graphics && m_sceneViewWidth > 0 && m_sceneViewHeight > 0)
+            {
+                m_graphics->Resize(m_sceneViewWidth, m_sceneViewHeight);
+            }
+        }
+    }
+
+    bool Application::InitializeSceneViewGraphics()
+    {
+        constexpr RHI::GraphicsAPI api = RHI::GraphicsAPI::D3D11;
+
+        m_graphics = BootstrapRenderBackend(api);
+        if (!m_graphics)
+        {
+            return false;
+        }
+
+        if (m_sceneViewEmbeddingMode != SceneViewEmbeddingMode::ChildWindowSwapChainHost)
+        {
+            return false;
+        }
+
+        if (m_sceneViewHost == nullptr || m_sceneViewWidth == 0 || m_sceneViewHeight == 0)
+        {
+            return false;
+        }
+
+        return m_graphics->Initialize(
+            m_sceneViewHost,
+            m_hInstance,
+            m_sceneViewWidth,
+            m_sceneViewHeight);
+    }
+
+    HWND Application::CreateChildWindow(const wchar_t* className, const wchar_t* text, DWORD style, DWORD exStyle) const
+    {
+        HWND handle = CreateWindowExW(
+            exStyle,
+            className,
+            text,
+            style,
+            0,
+            0,
+            0,
+            0,
+            m_window.GetHwnd(),
+            nullptr,
+            m_hInstance,
+            nullptr);
+
+        if (handle != nullptr && m_defaultFont != nullptr)
+        {
+            SendMessageW(handle, WM_SETFONT, reinterpret_cast<WPARAM>(m_defaultFont), TRUE);
+        }
+
+        return handle;
     }
 }

--- a/Editor/Source/Application.h
+++ b/Editor/Source/Application.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <Windows.h>
+#include <cstdint>
 #include <memory>
 
 #include "IGraphicsContext.h"
@@ -8,6 +9,17 @@
 
 namespace Xelqoria::Editor
 {
+    /// <summary>
+    /// SceneView へ Runtime 描画を埋め込む方式を表す。
+    /// </summary>
+    enum class SceneViewEmbeddingMode
+    {
+        /// <summary>
+        /// SceneView 専用 child HWND を swap chain の描画先にする。
+        /// </summary>
+        ChildWindowSwapChainHost = 0
+    };
+
     /// <summary>
     /// Editor ターゲットの最小実行ループを管理する。
     /// </summary>
@@ -59,6 +71,33 @@ namespace Xelqoria::Editor
         /// </summary>
         void Render();
 
+        /// <summary>
+        /// Editor の固定パネル UI を生成する。
+        /// </summary>
+        /// <returns>生成に成功した場合は true。</returns>
+        bool CreateEditorShell();
+
+        /// <summary>
+        /// 現在のクライアントサイズに合わせてパネル配置を更新する。
+        /// </summary>
+        void UpdateLayout();
+
+        /// <summary>
+        /// SceneView 用描画領域へグラフィックスコンテキストを初期化する。
+        /// </summary>
+        /// <returns>初期化に成功した場合は true。</returns>
+        bool InitializeSceneViewGraphics();
+
+        /// <summary>
+        /// 共通設定を適用した子ウィンドウを生成する。
+        /// </summary>
+        /// <param name="className">生成する Win32 クラス名。</param>
+        /// <param name="text">初期表示文字列。</param>
+        /// <param name="style">適用するウィンドウスタイル。</param>
+        /// <param name="exStyle">適用する拡張ウィンドウスタイル。</param>
+        /// <returns>生成した子ウィンドウハンドル。失敗時は nullptr。</returns>
+        HWND CreateChildWindow(const wchar_t* className, const wchar_t* text, DWORD style, DWORD exStyle = 0) const;
+
     private:
         /// <summary>
         /// Windows アプリケーションインスタンスを保持する。
@@ -71,7 +110,7 @@ namespace Xelqoria::Editor
         Core::Window m_window{};
 
         /// <summary>
-        /// 将来の SceneView 実装に備える描画コンテキストを保持する。
+        /// SceneView 描画に使用するグラフィックスコンテキストを保持する。
         /// </summary>
         std::unique_ptr<RHI::IGraphicsContext> m_graphics;
 
@@ -79,5 +118,60 @@ namespace Xelqoria::Editor
         /// メインループの継続状態を表す。
         /// </summary>
         bool m_running = true;
+
+        /// <summary>
+        /// Hierarchy パネルのグループボックスを保持する。
+        /// </summary>
+        HWND m_hierarchyPanel = nullptr;
+
+        /// <summary>
+        /// Assets パネルのグループボックスを保持する。
+        /// </summary>
+        HWND m_assetsPanel = nullptr;
+
+        /// <summary>
+        /// Inspector パネルのグループボックスを保持する。
+        /// </summary>
+        HWND m_inspectorPanel = nullptr;
+
+        /// <summary>
+        /// SceneView パネルのグループボックスを保持する。
+        /// </summary>
+        HWND m_sceneViewPanel = nullptr;
+
+        /// <summary>
+        /// SceneView 埋め込み方針を説明するラベルを保持する。
+        /// </summary>
+        HWND m_sceneViewPlanLabel = nullptr;
+
+        /// <summary>
+        /// SceneView 描画対象の child HWND を保持する。
+        /// </summary>
+        HWND m_sceneViewHost = nullptr;
+
+        /// <summary>
+        /// SceneView 現在サイズを説明するラベルを保持する。
+        /// </summary>
+        HWND m_sceneViewSizeLabel = nullptr;
+
+        /// <summary>
+        /// 既定 GUI フォントを保持する。
+        /// </summary>
+        HFONT m_defaultFont = nullptr;
+
+        /// <summary>
+        /// SceneView へ採用する埋め込み方針を表す。
+        /// </summary>
+        SceneViewEmbeddingMode m_sceneViewEmbeddingMode = SceneViewEmbeddingMode::ChildWindowSwapChainHost;
+
+        /// <summary>
+        /// 前回レイアウト時の SceneView 幅を保持する。
+        /// </summary>
+        std::uint32_t m_sceneViewWidth = 0;
+
+        /// <summary>
+        /// 前回レイアウト時の SceneView 高さを保持する。
+        /// </summary>
+        std::uint32_t m_sceneViewHeight = 0;
     };
 }


### PR DESCRIPTION
## 概要
- Editor に単一ウィンドウベースのパネルレイアウトを追加
- Hierarchy / Assets / SceneView / Inspector の最小器を配置
- SceneView 専用 child HWND を Runtime 描画の埋め込み先として初期化

## 検証
- "/mnt/c/Program Files/Microsoft Visual Studio/18/Community/MSBuild/Current/Bin/MSBuild.exe" Xelqoria.slnx /p:Configuration=Debug /p:Platform=x64

## 関連
- Parent: #65
- Child: #67