### PR TITLE
E04: Hierarchy パネル最小実装

### DIFF
--- a/Editor/Source/Application.cpp
+++ b/Editor/Source/Application.cpp
@@ -92,6 +92,7 @@ namespace Xelqoria::Editor
         }
 
         RefreshAssetsPanel();
+        RefreshHierarchyPanel();
         return true;
     }
 
@@ -109,6 +110,7 @@ namespace Xelqoria::Editor
         (void)deltaTime;
         UpdateLayout();
         SyncAssetSelection();
+        SyncHierarchySelection();
     }
 
     void Application::Render()
@@ -152,6 +154,14 @@ namespace Xelqoria::Editor
             L"ListBox",
             L"",
             WS_CHILD | WS_VISIBLE | WS_VSCROLL | LBS_NOTIFY | LBS_NOINTEGRALHEIGHT | WS_BORDER);
+        m_hierarchySummaryLabel = CreateChildWindow(
+            L"Static",
+            L"Entities: pending",
+            WS_CHILD | WS_VISIBLE);
+        m_hierarchyListBox = CreateChildWindow(
+            L"ListBox",
+            L"",
+            WS_CHILD | WS_VISIBLE | WS_VSCROLL | LBS_NOTIFY | LBS_NOINTEGRALHEIGHT | WS_BORDER);
 
         return m_hierarchyPanel != nullptr
             && m_assetsPanel != nullptr
@@ -161,7 +171,9 @@ namespace Xelqoria::Editor
             && m_sceneViewHost != nullptr
             && m_sceneViewSizeLabel != nullptr
             && m_assetsSummaryLabel != nullptr
-            && m_assetsListBox != nullptr;
+            && m_assetsListBox != nullptr
+            && m_hierarchySummaryLabel != nullptr
+            && m_hierarchyListBox != nullptr;
     }
 
     void Application::UpdateLayout()
@@ -212,6 +224,20 @@ namespace Xelqoria::Editor
             assetsPanelY + groupHeaderHeight + labelHeight + 6,
             sideInnerWidth,
             (std::max)(100, assetsPanelHeight - groupHeaderHeight - labelHeight - outerPadding - 12),
+            TRUE);
+        MoveWindow(
+            m_hierarchySummaryLabel,
+            outerPadding + outerPadding,
+            outerPadding + groupHeaderHeight,
+            sideInnerWidth,
+            labelHeight,
+            TRUE);
+        MoveWindow(
+            m_hierarchyListBox,
+            outerPadding + outerPadding,
+            outerPadding + groupHeaderHeight + labelHeight + 6,
+            sideInnerWidth,
+            (std::max)(100, hierarchyPanelHeight - groupHeaderHeight - labelHeight - outerPadding - 12),
             TRUE);
 
         const int sceneInnerWidth = (std::max)(120, centerWidth - (outerPadding * 2));
@@ -427,6 +453,88 @@ namespace Xelqoria::Editor
         }
 
         m_selectedSpriteAssetId = m_visibleSpriteAssetIds[index];
+    }
+
+    void Application::RefreshHierarchyPanel()
+    {
+        m_visibleEntityIds.clear();
+
+        SendMessageW(m_hierarchyListBox, LB_RESETCONTENT, 0, 0);
+        if (m_scene)
+        {
+            for (const auto& entity : m_scene->GetEntities())
+            {
+                m_visibleEntityIds.push_back(entity.GetId());
+
+                std::wstring label = L"Entity ";
+                label += std::to_wstring(entity.GetId());
+
+                if (const auto spriteComponent = entity.GetSpriteComponent(); spriteComponent.has_value())
+                {
+                    label += L" (";
+                    label += ToWideString(spriteComponent->get().spriteAssetRef.GetValue());
+                    label += L")";
+                }
+
+                SendMessageW(m_hierarchyListBox, LB_ADDSTRING, 0, reinterpret_cast<LPARAM>(label.c_str()));
+            }
+        }
+
+        if (!m_selectedEntityId.has_value() && !m_visibleEntityIds.empty())
+        {
+            m_selectedEntityId = m_visibleEntityIds.front();
+        }
+
+        int selectedIndex = LB_ERR;
+        for (std::size_t index = 0; index < m_visibleEntityIds.size(); ++index)
+        {
+            if (m_selectedEntityId.has_value() && m_visibleEntityIds[index] == *m_selectedEntityId)
+            {
+                selectedIndex = static_cast<int>(index);
+                break;
+            }
+        }
+
+        if (selectedIndex != LB_ERR)
+        {
+            SendMessageW(m_hierarchyListBox, LB_SETCURSEL, static_cast<WPARAM>(selectedIndex), 0);
+        }
+
+        wchar_t summaryText[128]{};
+        std::swprintf(
+            summaryText,
+            std::size(summaryText),
+            L"Entities: %u / selected: %u",
+            static_cast<unsigned>(m_visibleEntityIds.size()),
+            m_selectedEntityId.has_value() ? static_cast<unsigned>(*m_selectedEntityId) : 0u);
+        SetWindowTextW(m_hierarchySummaryLabel, summaryText);
+    }
+
+    void Application::SyncHierarchySelection()
+    {
+        if (m_hierarchyListBox == nullptr)
+        {
+            return;
+        }
+
+        const LRESULT selectedIndex = SendMessageW(m_hierarchyListBox, LB_GETCURSEL, 0, 0);
+        if (selectedIndex == LB_ERR)
+        {
+            return;
+        }
+
+        const auto index = static_cast<std::size_t>(selectedIndex);
+        if (index >= m_visibleEntityIds.size())
+        {
+            return;
+        }
+
+        const auto entityId = m_visibleEntityIds[index];
+        if (!m_selectedEntityId.has_value() || *m_selectedEntityId != entityId)
+        {
+            m_selectedEntityId = entityId;
+            RefreshHierarchyPanel();
+        }
     }
 
     HWND Application::CreateChildWindow(const wchar_t* className, const wchar_t* text, DWORD style, DWORD exStyle) const

--- a/Editor/Source/Application.h
+++ b/Editor/Source/Application.h
@@ -3,6 +3,7 @@
 #include <Windows.h>
 #include <cstdint>
 #include <memory>
+#include <optional>
 #include <string>
 #include <string_view>
 #include <vector>
@@ -113,6 +114,16 @@ namespace Xelqoria::Editor
         void SyncAssetSelection();
 
         /// <summary>
+        /// Hierarchy パネルの表示内容を更新する。
+        /// </summary>
+        void RefreshHierarchyPanel();
+
+        /// <summary>
+        /// Hierarchy パネルの選択状態を同期する。
+        /// </summary>
+        void SyncHierarchySelection();
+
+        /// <summary>
         /// 共通設定を適用した子ウィンドウを生成する。
         /// </summary>
         /// <param name="className">生成する Win32 クラス名。</param>
@@ -209,6 +220,16 @@ namespace Xelqoria::Editor
         HWND m_assetsSummaryLabel = nullptr;
 
         /// <summary>
+        /// Hierarchy パネルの要約表示ラベルを保持する。
+        /// </summary>
+        HWND m_hierarchySummaryLabel = nullptr;
+
+        /// <summary>
+        /// Hierarchy パネルの一覧表示に使う ListBox を保持する。
+        /// </summary>
+        HWND m_hierarchyListBox = nullptr;
+
+        /// <summary>
         /// Editor が編集中の Scene を保持する。
         /// </summary>
         std::unique_ptr<Game::Scene> m_scene;
@@ -237,5 +258,15 @@ namespace Xelqoria::Editor
         /// Assets パネルで現在選択中の SpriteAssetId を保持する。
         /// </summary>
         Core::AssetId m_selectedSpriteAssetId{};
+
+        /// <summary>
+        /// Hierarchy パネルへ表示する EntityId 一覧を保持する。
+        /// </summary>
+        std::vector<Game::EntityId> m_visibleEntityIds{};
+
+        /// <summary>
+        /// Hierarchy パネルで現在選択中の EntityId を保持する。
+        /// </summary>
+        std::optional<Game::EntityId> m_selectedEntityId{};
     };
 }


### PR DESCRIPTION
## 概要
- Hierarchy パネルに Entity 一覧の ListBox を追加
- sample scene の Entity を一覧表示できるようにした
- 選択 EntityId を保持して後続 Inspector で共有できる土台を追加

## 検証
- "/mnt/c/Program Files/Microsoft Visual Studio/18/Community/MSBuild/Current/Bin/MSBuild.exe" Xelqoria.slnx /p:Configuration=Debug /p:Platform=x64

## 関連
- Parent: #65
- Child: #69