### PR TITLE
E06: SceneView 表示

### DIFF
--- a/Editor/Source/Application.cpp
+++ b/Editor/Source/Application.cpp
@@ -102,6 +102,8 @@ namespace Xelqoria::Editor
             return false;
         }
 
+        m_spriteRenderer = std::make_unique<Graphics::SpriteRenderer>(*m_graphics);
+
         if (!InitializeDocument())
         {
             return false;
@@ -129,6 +131,7 @@ namespace Xelqoria::Editor
         SyncAssetSelection();
         SyncHierarchySelection();
         SyncInspectorEdits();
+        UpdateSceneViewInteraction();
     }
 
     void Application::Render()
@@ -139,6 +142,27 @@ namespace Xelqoria::Editor
         }
 
         m_graphics->BeginFrame();
+        if (m_spriteRenderer && m_scene)
+        {
+            m_scene->ValidateSpriteReferences(m_spriteAssetRegistry);
+            auto resolvedSprites = m_scene->ResolveSprites(m_spriteAssetRegistry, m_textureAssetRegistry);
+
+            m_spriteRenderer->Begin();
+            for (auto& sprite : resolvedSprites)
+            {
+                const auto position = sprite.GetPosition();
+                const auto scale = sprite.GetScale();
+
+                sprite.SetPosition(
+                    (position.x - m_sceneViewCamera.centerX) * m_sceneViewCamera.zoom,
+                    (position.y - m_sceneViewCamera.centerY) * m_sceneViewCamera.zoom);
+                sprite.SetScale(
+                    scale.x * m_sceneViewCamera.zoom,
+                    scale.y * m_sceneViewCamera.zoom);
+                m_spriteRenderer->Draw(sprite);
+            }
+            m_spriteRenderer->End();
+        }
         m_graphics->EndFrame();
     }
 
@@ -751,6 +775,68 @@ namespace Xelqoria::Editor
         {
             spriteComponent->get().spriteAssetRef = Core::AssetId(spriteRef);
         }
+    }
+
+    void Application::UpdateSceneViewInteraction()
+    {
+        if (m_sceneViewHost == nullptr || m_sceneViewWidth == 0 || m_sceneViewHeight == 0)
+        {
+            return;
+        }
+
+        POINT screenPoint{};
+        GetCursorPos(&screenPoint);
+
+        RECT sceneHostRect{};
+        GetWindowRect(m_sceneViewHost, &sceneHostRect);
+
+        const bool isCursorInside = screenPoint.x >= sceneHostRect.left
+            && screenPoint.x < sceneHostRect.right
+            && screenPoint.y >= sceneHostRect.top
+            && screenPoint.y < sceneHostRect.bottom;
+
+        const bool isLeftButtonDown = (GetAsyncKeyState(VK_LBUTTON) & 0x8000) != 0;
+        if (isCursorInside && isLeftButtonDown && !m_sceneViewLeftButtonDown)
+        {
+            POINT clientPoint = screenPoint;
+            ScreenToClient(m_sceneViewHost, &clientPoint);
+
+            m_lastSceneClickX =
+                (static_cast<float>(clientPoint.x) - static_cast<float>(m_sceneViewWidth) * 0.5f) / m_sceneViewCamera.zoom
+                + m_sceneViewCamera.centerX;
+            m_lastSceneClickY =
+                -(static_cast<float>(clientPoint.y) - static_cast<float>(m_sceneViewHeight) * 0.5f) / m_sceneViewCamera.zoom
+                + m_sceneViewCamera.centerY;
+            m_hasSceneClick = true;
+        }
+
+        m_sceneViewLeftButtonDown = isLeftButtonDown;
+
+        wchar_t statusText[160]{};
+        if (m_hasSceneClick)
+        {
+            std::swprintf(
+                statusText,
+                std::size(statusText),
+                L"SceneView size: %u x %u / click: (%.1f, %.1f)",
+                m_sceneViewWidth,
+                m_sceneViewHeight,
+                m_lastSceneClickX,
+                m_lastSceneClickY);
+        }
+        else
+        {
+            std::swprintf(
+                statusText,
+                std::size(statusText),
+                L"SceneView size: %u x %u / click: waiting",
+                m_sceneViewWidth,
+                m_sceneViewHeight);
+        }
+        SetWindowTextW(m_sceneViewSizeLabel, statusText);
+        SetWindowTextW(
+            m_sceneViewPlanLabel,
+            L"Runtime 描画は child HWND に埋め込み済みです。Camera center=(0,0), zoom=1.0");
     }
 
     HWND Application::CreateChildWindow(const wchar_t* className, const wchar_t* text, DWORD style, DWORD exStyle) const

--- a/Editor/Source/Application.h
+++ b/Editor/Source/Application.h
@@ -14,6 +14,7 @@
 #include "IGraphicsContext.h"
 #include "ITextureAssetResolver.h"
 #include "Scene.h"
+#include "SpriteRenderer.h"
 #include "Texture2D.h"
 #include "Window.h"
 
@@ -28,6 +29,27 @@ namespace Xelqoria::Editor
         /// SceneView 専用 child HWND を swap chain の描画先にする。
         /// </summary>
         ChildWindowSwapChainHost = 0
+    };
+
+    /// <summary>
+    /// SceneView で使用する簡易カメラ状態を表す。
+    /// </summary>
+    struct SceneViewCameraState
+    {
+        /// <summary>
+        /// カメラ中心 X 座標を表す。
+        /// </summary>
+        float centerX = 0.0f;
+
+        /// <summary>
+        /// カメラ中心 Y 座標を表す。
+        /// </summary>
+        float centerY = 0.0f;
+
+        /// <summary>
+        /// 表示倍率を表す。
+        /// </summary>
+        float zoom = 1.0f;
     };
 
     /// <summary>
@@ -135,6 +157,11 @@ namespace Xelqoria::Editor
         void SyncInspectorEdits();
 
         /// <summary>
+        /// SceneView のクリック座標状態を更新する。
+        /// </summary>
+        void UpdateSceneViewInteraction();
+
+        /// <summary>
         /// 共通設定を適用した子ウィンドウを生成する。
         /// </summary>
         /// <param name="className">生成する Win32 クラス名。</param>
@@ -219,6 +246,11 @@ namespace Xelqoria::Editor
         /// 前回レイアウト時の SceneView 高さを保持する。
         /// </summary>
         std::uint32_t m_sceneViewHeight = 0;
+
+        /// <summary>
+        /// SceneView 描画に使用する SpriteRenderer を保持する。
+        /// </summary>
+        std::unique_ptr<Graphics::SpriteRenderer> m_spriteRenderer;
 
         /// <summary>
         /// Assets パネルの一覧表示に使う ListBox を保持する。
@@ -309,5 +341,30 @@ namespace Xelqoria::Editor
         /// Inspector に最後に反映した EntityId を保持する。
         /// </summary>
         std::optional<Game::EntityId> m_lastInspectorEntityId{};
+
+        /// <summary>
+        /// SceneView で使用する固定カメラ状態を保持する。
+        /// </summary>
+        SceneViewCameraState m_sceneViewCamera{};
+
+        /// <summary>
+        /// 直近クリックした SceneView のワールド座標 X を保持する。
+        /// </summary>
+        float m_lastSceneClickX = 0.0f;
+
+        /// <summary>
+        /// 直近クリックした SceneView のワールド座標 Y を保持する。
+        /// </summary>
+        float m_lastSceneClickY = 0.0f;
+
+        /// <summary>
+        /// SceneView でクリック済みかを表す。
+        /// </summary>
+        bool m_hasSceneClick = false;
+
+        /// <summary>
+        /// 前フレームで左クリックが押下されていたかを表す。
+        /// </summary>
+        bool m_sceneViewLeftButtonDown = false;
     };
 }


### PR DESCRIPTION
## 概要
- SceneView に sample scene の Sprite 描画を追加
- 固定 camera state を通した表示経路を追加
- SceneView 内クリックからワールド座標を取得して表示するようにした

## 検証
- "/mnt/c/Program Files/Microsoft Visual Studio/18/Community/MSBuild/Current/Bin/MSBuild.exe" Xelqoria.slnx /p:Configuration=Debug /p:Platform=x64

## 関連
- Parent: #65
- Child: #71