### PR TITLE
V02: Screen->World 座標変換

### DIFF
--- a/.codex/skills/xelqoria-parent-issue-implementation/SKILL.md
+++ b/.codex/skills/xelqoria-parent-issue-implementation/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: xelqoria-parent-issue-implementation
-description: Use when implementing a parent GitHub issue in the Xelqoria repository by processing the listed child issues in numeric order. Switch to each child issue branch, implement the required changes with minimal edits, commit and push each branch, and create a pull request back to the parent issue branch.
+description: Use when implementing a parent GitHub issue in the Xelqoria repository by processing the listed child issues in numeric order. Switch to each child issue branch, implement the required changes with minimal edits, commit and push each branch, and create a pull request back to the parent or ancestor issue branch even when the child branch is created from a previous child branch.
 allowed-tools: Bash(git fetch:*) Bash(git branch:*) Bash(git checkout:*) Bash(git status:*) Bash(git diff:*) Bash(git add:*) Bash(git commit:*) Bash(git push:*) Bash(rg:*) Bash(sed:*) Bash(find:*) Bash("/mnt/c/Program Files/GitHub CLI/gh.exe" issue view:*) Bash("/mnt/c/Program Files/GitHub CLI/gh.exe" repo view:*) Bash("/mnt/c/Program Files/GitHub CLI/gh.exe" pr create:*) Bash("/mnt/c/Program Files/GitHub CLI/gh.exe" auth status:*) Bash("/mnt/c/Program Files/GitHub CLI/gh.exe" auth setup-git:*) Read Edit
 ---
 
@@ -13,7 +13,7 @@ Xelqoria で、親 Issue に列挙された子 Issue を順番に実装する時
 ## 使いどころ
 
 - ユーザーが「親 Issue の子 Issue を順に全部実装して」と依頼した時
-- 親 Issue に子 Issue 一覧があり、各子 Issue を個別ブランチで実装して親 Issue に対する PR を積みたい時
+- 親 Issue に子 Issue 一覧があり、各子 Issue を個別ブランチで実装して親 Issue または先祖 Issue に対する PR を積みたい時
 
 ## 最初にやること
 
@@ -44,6 +44,13 @@ Xelqoria で、親 Issue に列挙された子 Issue を順番に実装する時
 4. 順序数が比較できる子 Issue は昇順で処理する
 5. 順序数が読めないものは末尾に回し、必要ならユーザーに確認する
 
+## 依存する子 Issue ブランチの切り方
+
+1. 後続の子 Issue が前の子 Issue 実装に依存する場合は、その子 Issue ブランチを前の子 Issue ブランチから作成してよい
+2. その場合でも PR の base は、ユーザーが指定した親 Issue または先祖 Issue ブランチに向ける
+3. 例: `issue-96` が `issue-95` に依存するなら、`issue-95` から `issue-96` を切って実装し、PR は `issue-92` に向ける
+4. つまり「ブランチの作成元」と「PR の base」は別々に判断する
+
 ## 標準ワークフロー
 
 1. 親ブランチを確認する
@@ -53,7 +60,8 @@ Xelqoria で、親 Issue に列挙された子 Issue を順番に実装する時
 
 2. 子 Issue を 1 件ずつ処理する
 - 対象の子 Issue ブランチ `issue-<子番号>` へ切り替える
-- ローカルにない場合は親ブランチから新規作成する
+- ローカルにない場合は、通常は親ブランチから新規作成する
+- 直前の子 Issue 実装に依存する場合は、その直前の子 Issue ブランチから新規作成してよい
 - 既にブランチがある場合は未コミット変更の有無を確認してから切り替える
 
 3. 子 Issue の内容を実装する
@@ -70,8 +78,9 @@ Xelqoria で、親 Issue に列挙された子 Issue を順番に実装する時
 5. 子 Issue 単位で反映する
 - 差分を確認して `git add`、`git commit`、`git push` を行う
 - `gh auth status` で認証状態を確認し、必要なら `gh auth setup-git` を使う
-- PR は `issue-<子番号>` から `issue-<親番号>` へ作成する
-- PR 本文には親 Issue 番号と対応した子 Issue 番号を明記する
+- PR は `issue-<子番号>` から `issue-<親番号>` またはユーザーが指定した先祖 Issue ブランチへ作成する
+- 子 Issue ブランチが前の子 Issue ブランチから派生していても、PR base は親 Issue または先祖 Issue のままでよい
+- PR 本文には親 Issue 番号、必要なら先祖 Issue 番号、対応した子 Issue 番号を明記する
 
 6. 次の子 Issue へ進む
 - 親ブランチへ戻る
@@ -80,9 +89,9 @@ Xelqoria で、親 Issue に列挙された子 Issue を順番に実装する時
 
 ## 重要な判断基準
 
-- 各 PR は必ず親 Issue ブランチ向けに作る
-- 次の子 Issue が前の子 Issue の未マージ差分に依存する場合は、そのまま続行しない
-- その場合は「親ブランチへ先に取り込む必要がある」または「stacked PR に切り替える必要がある」と短く報告して止める
+- 各 PR は必ず親 Issue またはユーザーが指定した先祖 Issue ブランチ向けに作る
+- 次の子 Issue が前の子 Issue の未マージ差分に依存する場合は、必要に応じて前の子 Issue ブランチから次の子 Issue ブランチを切る
+- その場合でも PR base を勝手に前の子 Issue へ変えない
 - 既存の未コミット変更があるブランチへは、そのまま切り替えない
 - 子 Issue の順序は親 Issue の記述順ではなく、子 Issue 名に含まれる順序数を優先する
 
@@ -91,14 +100,15 @@ Xelqoria で、親 Issue に列挙された子 Issue を順番に実装する時
 - 親 Issue を探す時に、親の親まで辿らない
 - 親 Issue 本文中の上位 Issue、epic、meta issue を新しい親 Issue として扱わない
 - 子 Issue の実装順を、親 Issue に記載された順番だけで決めない
-- 後続の子 Issue のために、前の子 Issue の未反映差分を勝手に親ブランチへ取り込んだ前提で作業しない
+- 後続の子 Issue のために、前の子 Issue の未反映差分を親ブランチへ取り込んだ前提で作業しない
+- 子 Issue ブランチの作成元が前の子 Issue ブランチであることを理由に、PR base まで前の子 Issue ブランチへ変えない
 - 既存の未コミット変更がある状態で別の子 Issue ブランチへ切り替えない
 
 ## 完了条件
 
 - 親 Issue に列挙された子 Issue を順番に処理している
 - 各子 Issue で実装、検証、コミット、push、PR 作成まで完了している
-- 各 PR が親 Issue ブランチを base にしている
+- 各 PR が親 Issue または指定された先祖 Issue ブランチを base にしている
 - 途中で止めた場合は、止めた子 Issue と理由が明確になっている
 
 ## 出力スタイル

--- a/Editor/Source/Application.cpp
+++ b/Editor/Source/Application.cpp
@@ -822,13 +822,12 @@ namespace Xelqoria::Editor
             POINT clientPoint = screenPoint;
             ScreenToClient(m_sceneViewHost, &clientPoint);
 
-            const float zoom = m_sceneViewCamera.GetZoom();
-            m_lastSceneClickX =
-                (static_cast<float>(clientPoint.x) - static_cast<float>(m_sceneViewWidth) * 0.5f) / zoom
-                + m_sceneViewCamera.GetCenterX();
-            m_lastSceneClickY =
-                -(static_cast<float>(clientPoint.y) - static_cast<float>(m_sceneViewHeight) * 0.5f) / zoom
-                + m_sceneViewCamera.GetCenterY();
+            const auto worldPoint = m_sceneViewCamera.TransformScreenToWorld(EditorScreenPoint{
+                static_cast<float>(clientPoint.x),
+                static_cast<float>(clientPoint.y)
+            });
+            m_lastSceneClickX = worldPoint.x;
+            m_lastSceneClickY = worldPoint.y;
             m_hasSceneClick = true;
         }
 

--- a/Editor/Source/Application.cpp
+++ b/Editor/Source/Application.cpp
@@ -174,11 +174,11 @@ namespace Xelqoria::Editor
                 const auto scale = sprite.GetScale();
 
                 sprite.SetPosition(
-                    (position.x - m_sceneViewCamera.centerX) * m_sceneViewCamera.zoom,
-                    (position.y - m_sceneViewCamera.centerY) * m_sceneViewCamera.zoom);
+                    m_sceneViewCamera.TransformWorldToViewX(position.x),
+                    m_sceneViewCamera.TransformWorldToViewY(position.y));
                 sprite.SetScale(
-                    scale.x * m_sceneViewCamera.zoom,
-                    scale.y * m_sceneViewCamera.zoom);
+                    m_sceneViewCamera.TransformWorldScale(scale.x),
+                    m_sceneViewCamera.TransformWorldScale(scale.y));
                 m_spriteRenderer->Draw(sprite);
             }
             m_spriteRenderer->End();
@@ -424,6 +424,7 @@ namespace Xelqoria::Editor
         {
             m_sceneViewWidth = newWidth;
             m_sceneViewHeight = newHeight;
+            m_sceneViewCamera.SetViewport(m_sceneViewWidth, m_sceneViewHeight);
 
             wchar_t sizeText[128]{};
             std::swprintf(
@@ -821,12 +822,13 @@ namespace Xelqoria::Editor
             POINT clientPoint = screenPoint;
             ScreenToClient(m_sceneViewHost, &clientPoint);
 
+            const float zoom = m_sceneViewCamera.GetZoom();
             m_lastSceneClickX =
-                (static_cast<float>(clientPoint.x) - static_cast<float>(m_sceneViewWidth) * 0.5f) / m_sceneViewCamera.zoom
-                + m_sceneViewCamera.centerX;
+                (static_cast<float>(clientPoint.x) - static_cast<float>(m_sceneViewWidth) * 0.5f) / zoom
+                + m_sceneViewCamera.GetCenterX();
             m_lastSceneClickY =
-                -(static_cast<float>(clientPoint.y) - static_cast<float>(m_sceneViewHeight) * 0.5f) / m_sceneViewCamera.zoom
-                + m_sceneViewCamera.centerY;
+                -(static_cast<float>(clientPoint.y) - static_cast<float>(m_sceneViewHeight) * 0.5f) / zoom
+                + m_sceneViewCamera.GetCenterY();
             m_hasSceneClick = true;
         }
 
@@ -856,7 +858,7 @@ namespace Xelqoria::Editor
         SetWindowTextW(m_sceneViewSizeLabel, statusText);
         SetWindowTextW(
             m_sceneViewPlanLabel,
-            L"Runtime 描画は child HWND に埋め込み済みです。Camera center=(0,0), zoom=1.0");
+            L"Runtime 描画は child HWND に埋め込み済みです。2D EditorCamera で pan/zoom 状態を管理しています。");
     }
 
     HWND Application::CreateChildWindow(const wchar_t* className, const wchar_t* text, DWORD style, DWORD exStyle) const

--- a/Editor/Source/Application.h
+++ b/Editor/Source/Application.h
@@ -11,6 +11,7 @@
 
 #include "AssetId.h"
 #include "Assets/SpriteAssetRegistry.h"
+#include "EditorCamera2D.h"
 #include "IGraphicsContext.h"
 #include "TextureAssetRegistry.h"
 #include "Scene.h"
@@ -29,27 +30,6 @@ namespace Xelqoria::Editor
         /// SceneView 専用 child HWND を swap chain の描画先にする。
         /// </summary>
         ChildWindowSwapChainHost = 0
-    };
-
-    /// <summary>
-    /// SceneView で使用する簡易カメラ状態を表す。
-    /// </summary>
-    struct SceneViewCameraState
-    {
-        /// <summary>
-        /// カメラ中心 X 座標を表す。
-        /// </summary>
-        float centerX = 0.0f;
-
-        /// <summary>
-        /// カメラ中心 Y 座標を表す。
-        /// </summary>
-        float centerY = 0.0f;
-
-        /// <summary>
-        /// 表示倍率を表す。
-        /// </summary>
-        float zoom = 1.0f;
     };
 
     /// <summary>
@@ -345,7 +325,7 @@ namespace Xelqoria::Editor
         /// <summary>
         /// SceneView で使用する固定カメラ状態を保持する。
         /// </summary>
-        SceneViewCameraState m_sceneViewCamera{};
+        EditorCamera2D m_sceneViewCamera{};
 
         /// <summary>
         /// 直近クリックした SceneView のワールド座標 X を保持する。

--- a/Editor/Source/EditorCamera2D.h
+++ b/Editor/Source/EditorCamera2D.h
@@ -6,6 +6,38 @@
 namespace Xelqoria::Editor
 {
     /// <summary>
+    /// SceneView 内のスクリーン座標を表す。
+    /// </summary>
+    struct EditorScreenPoint
+    {
+        /// <summary>
+        /// SceneView 左上基準の X 座標を表す。
+        /// </summary>
+        float x = 0.0f;
+
+        /// <summary>
+        /// SceneView 左上基準の Y 座標を表す。
+        /// </summary>
+        float y = 0.0f;
+    };
+
+    /// <summary>
+    /// Editor 内で扱う 2D ワールド座標を表す。
+    /// </summary>
+    struct EditorWorldPoint
+    {
+        /// <summary>
+        /// ワールド X 座標を表す。
+        /// </summary>
+        float x = 0.0f;
+
+        /// <summary>
+        /// ワールド Y 座標を表す。
+        /// </summary>
+        float y = 0.0f;
+    };
+
+    /// <summary>
     /// 2D SceneView で使用するビューポート設定を表す。
     /// </summary>
     struct EditorViewport
@@ -122,6 +154,22 @@ namespace Xelqoria::Editor
         float TransformWorldScale(float worldScale) const
         {
             return worldScale * m_zoom;
+        }
+
+        /// <summary>
+        /// SceneView のスクリーン座標をワールド座標へ変換する。
+        /// </summary>
+        /// <param name="screenPoint">SceneView 左上基準のスクリーン座標。</param>
+        /// <returns>pan/zoom を加味したワールド座標。</returns>
+        EditorWorldPoint TransformScreenToWorld(const EditorScreenPoint& screenPoint) const
+        {
+            const float halfWidth = static_cast<float>(m_viewport.width) * 0.5f;
+            const float halfHeight = static_cast<float>(m_viewport.height) * 0.5f;
+
+            return EditorWorldPoint{
+                (screenPoint.x - halfWidth) / m_zoom + m_centerX,
+                -(screenPoint.y - halfHeight) / m_zoom + m_centerY
+            };
         }
 
     private:

--- a/Editor/Source/EditorCamera2D.h
+++ b/Editor/Source/EditorCamera2D.h
@@ -1,0 +1,148 @@
+#pragma once
+
+#include <algorithm>
+#include <cstdint>
+
+namespace Xelqoria::Editor
+{
+    /// <summary>
+    /// 2D SceneView で使用するビューポート設定を表す。
+    /// </summary>
+    struct EditorViewport
+    {
+        /// <summary>
+        /// ビューポート幅を表す。
+        /// </summary>
+        std::uint32_t width = 0;
+
+        /// <summary>
+        /// ビューポート高さを表す。
+        /// </summary>
+        std::uint32_t height = 0;
+    };
+
+    /// <summary>
+    /// SceneView の pan/zoom 状態と表示設定を保持する 2D カメラを表す。
+    /// </summary>
+    class EditorCamera2D
+    {
+    public:
+        /// <summary>
+        /// カメラ中心座標を設定する。
+        /// </summary>
+        /// <param name="centerX">設定する中心 X 座標。</param>
+        /// <param name="centerY">設定する中心 Y 座標。</param>
+        void SetCenter(float centerX, float centerY)
+        {
+            m_centerX = centerX;
+            m_centerY = centerY;
+        }
+
+        /// <summary>
+        /// カメラ中心 X 座標を取得する。
+        /// </summary>
+        /// <returns>現在の中心 X 座標。</returns>
+        float GetCenterX() const
+        {
+            return m_centerX;
+        }
+
+        /// <summary>
+        /// カメラ中心 Y 座標を取得する。
+        /// </summary>
+        /// <returns>現在の中心 Y 座標。</returns>
+        float GetCenterY() const
+        {
+            return m_centerY;
+        }
+
+        /// <summary>
+        /// 表示倍率を設定する。
+        /// </summary>
+        /// <param name="zoom">設定する倍率。</param>
+        void SetZoom(float zoom)
+        {
+            m_zoom = (std::max)(zoom, 0.0001f);
+        }
+
+        /// <summary>
+        /// 表示倍率を取得する。
+        /// </summary>
+        /// <returns>現在の表示倍率。</returns>
+        float GetZoom() const
+        {
+            return m_zoom;
+        }
+
+        /// <summary>
+        /// SceneView のビューポートサイズを設定する。
+        /// </summary>
+        /// <param name="width">ビューポート幅。</param>
+        /// <param name="height">ビューポート高さ。</param>
+        void SetViewport(std::uint32_t width, std::uint32_t height)
+        {
+            m_viewport.width = width;
+            m_viewport.height = height;
+        }
+
+        /// <summary>
+        /// 現在のビューポート設定を取得する。
+        /// </summary>
+        /// <returns>現在保持しているビューポート設定。</returns>
+        EditorViewport GetViewport() const
+        {
+            return m_viewport;
+        }
+
+        /// <summary>
+        /// ワールド X 座標を SceneView 描画座標へ変換する。
+        /// </summary>
+        /// <param name="worldX">変換対象のワールド X 座標。</param>
+        /// <returns>描画に使用する SceneView 座標。</returns>
+        float TransformWorldToViewX(float worldX) const
+        {
+            return (worldX - m_centerX) * m_zoom;
+        }
+
+        /// <summary>
+        /// ワールド Y 座標を SceneView 描画座標へ変換する。
+        /// </summary>
+        /// <param name="worldY">変換対象のワールド Y 座標。</param>
+        /// <returns>描画に使用する SceneView 座標。</returns>
+        float TransformWorldToViewY(float worldY) const
+        {
+            return (worldY - m_centerY) * m_zoom;
+        }
+
+        /// <summary>
+        /// スプライト拡大率へカメラ倍率を適用する。
+        /// </summary>
+        /// <param name="worldScale">ワールド上の拡大率。</param>
+        /// <returns>描画に使用する拡大率。</returns>
+        float TransformWorldScale(float worldScale) const
+        {
+            return worldScale * m_zoom;
+        }
+
+    private:
+        /// <summary>
+        /// カメラ中心 X 座標を保持する。
+        /// </summary>
+        float m_centerX = 0.0f;
+
+        /// <summary>
+        /// カメラ中心 Y 座標を保持する。
+        /// </summary>
+        float m_centerY = 0.0f;
+
+        /// <summary>
+        /// 表示倍率を保持する。
+        /// </summary>
+        float m_zoom = 1.0f;
+
+        /// <summary>
+        /// SceneView のビューポート設定を保持する。
+        /// </summary>
+        EditorViewport m_viewport{};
+    };
+}

--- a/Editor/Xelqoria.Editor.vcxproj.filters
+++ b/Editor/Xelqoria.Editor.vcxproj.filters
@@ -20,6 +20,9 @@
     <ClInclude Include="Source\Application.h">
       <Filter>Source</Filter>
     </ClInclude>
+    <ClInclude Include="Source\EditorCamera2D.h">
+      <Filter>Source</Filter>
+    </ClInclude>
     <ClInclude Include="Source\RenderBackendBootstrap.h">
       <Filter>Source</Filter>
     </ClInclude>

--- a/Xelqoria.slnx
+++ b/Xelqoria.slnx
@@ -60,6 +60,9 @@
   <Folder Name="/ソリューション項目/tests/Graphics/">
     <Project Path="tests/Graphics/Xelqoria.Tests.Graphics.vcxproj" Id="a6d67a9b-2c63-4d32-b3d8-6f1c7de4d111" />
   </Folder>
+  <Folder Name="/ソリューション項目/tests/Editor/">
+    <Project Path="tests/Editor/Xelqoria.Tests.Editor.vcxproj" Id="5b9e9e22-77e0-4b57-9d12-6a6a86a8a6a4" />
+  </Folder>
   <Project Path="App/Xelqoria.App.vcxproj" Id="67f2121c-56d6-425e-adca-de9605ab0b9e" />
   <Project Path="Backends.D3D11/Xelqoria.Backends.D3D11.vcxproj" Id="d89979a3-9ede-4b5b-a2b1-2dd1db261114" />
   <Project Path="Backends.D3D12/Xelqoria.Backends.D3D12.vcxproj" Id="14484bbf-f4fb-48aa-9ce4-bd7cbe1b24a4" />

--- a/tests/Editor/Source/EditorCamera2DTests.cpp
+++ b/tests/Editor/Source/EditorCamera2DTests.cpp
@@ -1,0 +1,39 @@
+#include <gtest/gtest.h>
+
+#include "EditorCamera2D.h"
+
+TEST(EditorCamera2DTests, StoresPanZoomAndViewportState)
+{
+    Xelqoria::Editor::EditorCamera2D camera;
+
+    camera.SetCenter(120.0f, -48.0f);
+    camera.SetZoom(2.5f);
+    camera.SetViewport(1280, 720);
+
+    const auto viewport = camera.GetViewport();
+    EXPECT_FLOAT_EQ(camera.GetCenterX(), 120.0f);
+    EXPECT_FLOAT_EQ(camera.GetCenterY(), -48.0f);
+    EXPECT_FLOAT_EQ(camera.GetZoom(), 2.5f);
+    EXPECT_EQ(viewport.width, 1280u);
+    EXPECT_EQ(viewport.height, 720u);
+}
+
+TEST(EditorCamera2DTests, AppliesCameraStateToSceneViewRenderCoordinates)
+{
+    Xelqoria::Editor::EditorCamera2D camera;
+    camera.SetCenter(100.0f, -20.0f);
+    camera.SetZoom(1.5f);
+
+    EXPECT_FLOAT_EQ(camera.TransformWorldToViewX(140.0f), 60.0f);
+    EXPECT_FLOAT_EQ(camera.TransformWorldToViewY(20.0f), 60.0f);
+    EXPECT_FLOAT_EQ(camera.TransformWorldScale(2.0f), 3.0f);
+}
+
+TEST(EditorCamera2DTests, ClampsZoomToPositiveMinimum)
+{
+    Xelqoria::Editor::EditorCamera2D camera;
+
+    camera.SetZoom(0.0f);
+
+    EXPECT_GT(camera.GetZoom(), 0.0f);
+}

--- a/tests/Editor/Source/EditorCamera2DTests.cpp
+++ b/tests/Editor/Source/EditorCamera2DTests.cpp
@@ -37,3 +37,35 @@ TEST(EditorCamera2DTests, ClampsZoomToPositiveMinimum)
 
     EXPECT_GT(camera.GetZoom(), 0.0f);
 }
+
+TEST(EditorCamera2DTests, ConvertsScreenPointToWorldPointWithPanAndZoom)
+{
+    Xelqoria::Editor::EditorCamera2D camera;
+    camera.SetCenter(100.0f, -20.0f);
+    camera.SetZoom(2.0f);
+    camera.SetViewport(800, 600);
+
+    const auto worldPoint = camera.TransformScreenToWorld(Xelqoria::Editor::EditorScreenPoint{
+        500.0f,
+        260.0f
+    });
+
+    EXPECT_FLOAT_EQ(worldPoint.x, 150.0f);
+    EXPECT_FLOAT_EQ(worldPoint.y, 0.0f);
+}
+
+TEST(EditorCamera2DTests, ConvertsViewportCenterToCameraCenter)
+{
+    Xelqoria::Editor::EditorCamera2D camera;
+    camera.SetCenter(-32.0f, 48.0f);
+    camera.SetZoom(3.0f);
+    camera.SetViewport(1280, 720);
+
+    const auto worldPoint = camera.TransformScreenToWorld(Xelqoria::Editor::EditorScreenPoint{
+        640.0f,
+        360.0f
+    });
+
+    EXPECT_FLOAT_EQ(worldPoint.x, -32.0f);
+    EXPECT_FLOAT_EQ(worldPoint.y, 48.0f);
+}

--- a/tests/Editor/Xelqoria.Tests.Editor.vcxproj
+++ b/tests/Editor/Xelqoria.Tests.Editor.vcxproj
@@ -19,40 +19,18 @@
     </ProjectConfiguration>
   </ItemGroup>
   <ItemGroup>
-    <ClCompile Include="Source\Application.cpp" />
-    <ClCompile Include="Source\Entry.cpp" />
-    <ClCompile Include="Source\RenderBackendBootstrap.cpp" />
+    <ClCompile Include="Source\EditorCamera2DTests.cpp" />
   </ItemGroup>
   <ItemGroup>
-    <ClInclude Include="Source\Application.h" />
-    <ClInclude Include="Source\EditorCamera2D.h" />
-    <ClInclude Include="Source\RenderBackendBootstrap.h" />
-  </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\Core\Xelqoria.Core.vcxproj">
-      <Project>{79E8E826-7407-4766-B731-675CB84F6552}</Project>
-    </ProjectReference>
-    <ProjectReference Include="..\RHI\Xelqoria.RHI.vcxproj">
-      <Project>{158B81FC-B108-4237-8A37-EB8C6EF29392}</Project>
-    </ProjectReference>
-    <ProjectReference Include="..\Graphics\Xelqoria.Graphics.vcxproj">
-      <Project>{7693792A-4AD4-445A-98F7-B90D6989A837}</Project>
-    </ProjectReference>
-    <ProjectReference Include="..\Game\Xelqoria.Game.vcxproj">
-      <Project>{B43E8E97-59EF-4CAA-8A27-BD9192D8833A}</Project>
-    </ProjectReference>
-    <ProjectReference Include="..\Backends.D3D11\Xelqoria.Backends.D3D11.vcxproj">
-      <Project>{D89979A3-9EDE-4B5B-A2B1-2DD1DB261114}</Project>
-    </ProjectReference>
-    <ProjectReference Include="..\Backends.D3D12\Xelqoria.Backends.D3D12.vcxproj">
-      <Project>{14484BBF-F4FB-48AA-9CE4-BD7CBE1B24A4}</Project>
+    <ProjectReference Include="..\..\third_party\googletest\Xelqoria.GoogleTest.vcxproj">
+      <Project>{0F71D759-12A2-42D9-B1CA-9F19C4E586C9}</Project>
     </ProjectReference>
   </ItemGroup>
   <PropertyGroup Label="Globals">
     <VCProjectVersion>18.0</VCProjectVersion>
     <Keyword>Win32Proj</Keyword>
-    <ProjectGuid>{2A2FC413-07F6-41D7-AB02-079CE112C042}</ProjectGuid>
-    <RootNamespace>XelqoriaEditor</RootNamespace>
+    <ProjectGuid>{5B9E9E22-77E0-4B57-9D12-6A6A86A8A6A4}</ProjectGuid>
+    <RootNamespace>XelqoriaTestsEditor</RootNamespace>
     <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
@@ -99,8 +77,9 @@
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup>
-    <OutDir>$(SolutionDir)artifacts\$(Platform)\$(Configuration)\</OutDir>
-    <IntDir>$(SolutionDir)build\$(ProjectName)\$(Platform)\$(Configuration)\</IntDir>
+    <RepoRootDir>$(MSBuildProjectDirectory)\..\..\</RepoRootDir>
+    <OutDir>$(RepoRootDir)artifacts\$(Platform)\$(Configuration)\</OutDir>
+    <IntDir>$(RepoRootDir)build\$(ProjectName)\$(Platform)\$(Configuration)\</IntDir>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
@@ -109,14 +88,16 @@
       <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <LanguageStandard>stdcpp20</LanguageStandard>
-      <AdditionalIncludeDirectories>$(ProjectDir)Source;$(SolutionDir)Core\Source;$(SolutionDir)Game\Source;$(SolutionDir)Graphics\Source;$(SolutionDir)RHI\Source;$(SolutionDir)Backends.D3D11\Source;$(SolutionDir)Backends.D3D12\Source;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(RepoRootDir)Editor\Source;$(RepoRootDir)third_party\googletest\googletest\include;$(ProjectDir)Source;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <AdditionalOptions>/utf-8 %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
-      <SubSystem>Windows</SubSystem>
+      <SubSystem>Console</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalDependencies>d3d11.lib;dxgi.lib;dxguid.lib;d3d12.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
+    <PostBuildEvent>
+      <Command>echo. &gt; &quot;$(TargetPath).is_google_test&quot;</Command>
+    </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <ClCompile>
@@ -127,14 +108,16 @@
       <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <LanguageStandard>stdcpp20</LanguageStandard>
-      <AdditionalIncludeDirectories>$(ProjectDir)Source;$(SolutionDir)Core\Source;$(SolutionDir)Game\Source;$(SolutionDir)Graphics\Source;$(SolutionDir)RHI\Source;$(SolutionDir)Backends.D3D11\Source;$(SolutionDir)Backends.D3D12\Source;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(RepoRootDir)Editor\Source;$(RepoRootDir)third_party\googletest\googletest\include;$(ProjectDir)Source;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <AdditionalOptions>/utf-8 %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
-      <SubSystem>Windows</SubSystem>
+      <SubSystem>Console</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalDependencies>d3d11.lib;dxgi.lib;dxguid.lib;d3d12.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
+    <PostBuildEvent>
+      <Command>echo. &gt; &quot;$(TargetPath).is_google_test&quot;</Command>
+    </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ClCompile>
@@ -143,14 +126,16 @@
       <PreprocessorDefinitions>_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <LanguageStandard>stdcpp20</LanguageStandard>
-      <AdditionalIncludeDirectories>$(ProjectDir)Source;$(SolutionDir)Core\Source;$(SolutionDir)Game\Source;$(SolutionDir)Graphics\Source;$(SolutionDir)RHI\Source;$(SolutionDir)Backends.D3D11\Source;$(SolutionDir)Backends.D3D12\Source;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(RepoRootDir)Editor\Source;$(RepoRootDir)third_party\googletest\googletest\include;$(ProjectDir)Source;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <AdditionalOptions>/utf-8 %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
-      <SubSystem>Windows</SubSystem>
+      <SubSystem>Console</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalDependencies>d3d11.lib;dxgi.lib;dxguid.lib;d3d12.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
+    <PostBuildEvent>
+      <Command>echo. &gt; &quot;$(TargetPath).is_google_test&quot;</Command>
+    </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <ClCompile>
@@ -161,23 +146,17 @@
       <PreprocessorDefinitions>NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <LanguageStandard>stdcpp20</LanguageStandard>
-      <AdditionalIncludeDirectories>$(ProjectDir)Source;$(SolutionDir)Core\Source;$(SolutionDir)Game\Source;$(SolutionDir)Graphics\Source;$(SolutionDir)RHI\Source;$(SolutionDir)Backends.D3D11\Source;$(SolutionDir)Backends.D3D12\Source;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(RepoRootDir)Editor\Source;$(RepoRootDir)third_party\googletest\googletest\include;$(ProjectDir)Source;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <AdditionalOptions>/utf-8 %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
-      <SubSystem>Windows</SubSystem>
+      <SubSystem>Console</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalDependencies>d3d11.lib;dxgi.lib;dxguid.lib;d3d12.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
+    <PostBuildEvent>
+      <Command>echo. &gt; &quot;$(TargetPath).is_google_test&quot;</Command>
+    </PostBuildEvent>
   </ItemDefinitionGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
-  <PropertyGroup>
-    <RepoRootDir>$(MSBuildProjectDirectory)\..\</RepoRootDir>
-    <LayerDependencyCheckerExe>$(RepoRootDir)tools\LayerDependencyChecker\bin\$(Configuration)\net8.0\LayerDependencyChecker.exe</LayerDependencyCheckerExe>
-  </PropertyGroup>
-  <Target Name="ValidateLayerDependencies" BeforeTargets="ClCompile">
-    <Error Condition="!Exists('$(LayerDependencyCheckerExe)')" Text="LayerDependencyChecker.exe が見つかりません。tools\LayerDependencyChecker をビルドしてください。期待パス: $(LayerDependencyCheckerExe)" />
-    <Exec Command="&quot;$(LayerDependencyCheckerExe)&quot; &quot;$(RepoRootDir)&quot;" />
-  </Target>
   <ImportGroup Label="ExtensionTargets" />
 </Project>

--- a/tests/Editor/Xelqoria.Tests.Editor.vcxproj.filters
+++ b/tests/Editor/Xelqoria.Tests.Editor.vcxproj.filters
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Filter Include="Source">
+      <UniqueIdentifier>{4E1F6204-E6C2-4ECF-8716-2FA9E1AE2105}</UniqueIdentifier>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="Source\EditorCamera2DTests.cpp">
+      <Filter>Source</Filter>
+    </ClCompile>
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
## 概要
- EditorCamera2D に Screen->World 座標変換 API を追加
- SceneView クリック座標の変換経路を EditorCamera2D 経由へ統一
- 親 Issue Skill に、依存する子 Issue は前の子 Issue ブランチから切っても PR base は親/先祖へ向ける運用を明記

## Issue
- 親 Issue: #92
- 先祖 base Issue: #92
- 対応した子 Issue: #96
- ブランチ作成元: issue-95

## 検証
- MSBuild で Debug x64 の solution ビルドに成功
- Xelqoria.Tests.Editor.exe の 5 テストが成功