### PR TITLE
D01: Assets からドラッグ開始

### DIFF
--- a/Editor/Source/Application.cpp
+++ b/Editor/Source/Application.cpp
@@ -25,6 +25,8 @@ namespace Xelqoria::Editor
 {
     namespace
     {
+        constexpr int AssetDragStartThresholdPixels = 6;
+
         /// <summary>
         /// アセット識別子などの狭い文字列を簡易的にワイド文字列へ変換する。
         /// </summary>
@@ -54,6 +56,19 @@ namespace Xelqoria::Editor
             }
 
             return result;
+        }
+
+        /// <summary>
+        /// 2 点間のドラッグ開始判定に使う距離を取得する。
+        /// </summary>
+        /// <param name="lhs">始点座標。</param>
+        /// <param name="rhs">終点座標。</param>
+        /// <returns>各軸の絶対差分のうち大きい方。</returns>
+        int GetDragDistance(POINT lhs, POINT rhs)
+        {
+            const int dx = std::abs(lhs.x - rhs.x);
+            const int dy = std::abs(lhs.y - rhs.y);
+            return (std::max)(dx, dy);
         }
     }
 
@@ -149,6 +164,7 @@ namespace Xelqoria::Editor
         (void)deltaTime;
         UpdateLayout();
         SyncAssetSelection();
+        UpdateAssetDragState();
         SyncHierarchySelection();
         SyncInspectorEdits();
         UpdateSceneViewInteraction();
@@ -574,14 +590,7 @@ namespace Xelqoria::Editor
             SendMessageW(m_assetsListBox, LB_SETCURSEL, static_cast<WPARAM>(selectedIndex), 0);
         }
 
-        wchar_t summaryText[128]{};
-        std::swprintf(
-            summaryText,
-            std::size(summaryText),
-            L"Sprite assets: %u visible / %u registered",
-            static_cast<unsigned>(m_visibleSpriteAssetIds.size()),
-            static_cast<unsigned>(m_registeredSpriteAssetIds.size()));
-        SetWindowTextW(m_assetsSummaryLabel, summaryText);
+        RefreshAssetsSummaryLabel();
     }
 
     void Application::SyncAssetSelection()
@@ -604,6 +613,87 @@ namespace Xelqoria::Editor
         }
 
         m_selectedSpriteAssetId = m_visibleSpriteAssetIds[index];
+    }
+
+    void Application::UpdateAssetDragState()
+    {
+        if (m_assetsListBox == nullptr)
+        {
+            return;
+        }
+
+        POINT screenPoint{};
+        GetCursorPos(&screenPoint);
+
+        RECT assetsRect{};
+        GetWindowRect(m_assetsListBox, &assetsRect);
+
+        const bool isCursorInside = screenPoint.x >= assetsRect.left
+            && screenPoint.x < assetsRect.right
+            && screenPoint.y >= assetsRect.top
+            && screenPoint.y < assetsRect.bottom;
+        const bool isLeftButtonDown = (GetAsyncKeyState(VK_LBUTTON) & 0x8000) != 0;
+
+        if (isCursorInside && isLeftButtonDown && !m_assetsListLeftButtonDown)
+        {
+            m_assetsListLeftButtonDown = true;
+            m_assetDragStartScreenPoint = screenPoint;
+        }
+
+        if (m_assetsListLeftButtonDown
+            && !m_isAssetDragActive
+            && isLeftButtonDown
+            && !m_selectedSpriteAssetId.IsEmpty()
+            && GetDragDistance(m_assetDragStartScreenPoint, screenPoint) >= AssetDragStartThresholdPixels)
+        {
+            m_isAssetDragActive = true;
+            m_draggingSpriteAssetId = m_selectedSpriteAssetId;
+
+            const std::string debugLine =
+                "Editor::Application began dragging Sprite AssetId '" + m_draggingSpriteAssetId.GetValue() + "'.\n";
+            ::OutputDebugStringA(debugLine.c_str());
+            RefreshAssetsSummaryLabel();
+        }
+
+        if (!isLeftButtonDown)
+        {
+            const bool wasDragging = m_isAssetDragActive;
+            m_assetsListLeftButtonDown = false;
+            m_isAssetDragActive = false;
+            m_draggingSpriteAssetId = {};
+
+            if (wasDragging)
+            {
+                RefreshAssetsSummaryLabel();
+            }
+        }
+    }
+
+    void Application::RefreshAssetsSummaryLabel()
+    {
+        wchar_t summaryText[256]{};
+        if (m_isAssetDragActive && !m_draggingSpriteAssetId.IsEmpty())
+        {
+            const std::wstring draggingAssetId = ToWideString(m_draggingSpriteAssetId.GetValue());
+            std::swprintf(
+                summaryText,
+                std::size(summaryText),
+                L"Sprite assets: dragging %ls / %u visible / %u registered",
+                draggingAssetId.c_str(),
+                static_cast<unsigned>(m_visibleSpriteAssetIds.size()),
+                static_cast<unsigned>(m_registeredSpriteAssetIds.size()));
+        }
+        else
+        {
+            std::swprintf(
+                summaryText,
+                std::size(summaryText),
+                L"Sprite assets: %u visible / %u registered",
+                static_cast<unsigned>(m_visibleSpriteAssetIds.size()),
+                static_cast<unsigned>(m_registeredSpriteAssetIds.size()));
+        }
+
+        SetWindowTextW(m_assetsSummaryLabel, summaryText);
     }
 
     void Application::RefreshHierarchyPanel()

--- a/Editor/Source/Application.h
+++ b/Editor/Source/Application.h
@@ -117,6 +117,16 @@ namespace Xelqoria::Editor
         void SyncAssetSelection();
 
         /// <summary>
+        /// Assets パネルから開始するドラッグ状態を更新する。
+        /// </summary>
+        void UpdateAssetDragState();
+
+        /// <summary>
+        /// Assets パネルの要約表示を現在状態に合わせて更新する。
+        /// </summary>
+        void RefreshAssetsSummaryLabel();
+
+        /// <summary>
         /// Hierarchy パネルの表示内容を更新する。
         /// </summary>
         void RefreshHierarchyPanel();
@@ -306,6 +316,27 @@ namespace Xelqoria::Editor
         /// Assets パネルで現在選択中の SpriteAssetId を保持する。
         /// </summary>
         Core::AssetId m_selectedSpriteAssetId{};
+
+        /// <summary>
+        /// 現在ドラッグ中の SpriteAssetId を保持する。
+        /// 未ドラッグ時は空を保持する。
+        /// </summary>
+        Core::AssetId m_draggingSpriteAssetId{};
+
+        /// <summary>
+        /// Assets パネルからのドラッグが有効かを表す。
+        /// </summary>
+        bool m_isAssetDragActive = false;
+
+        /// <summary>
+        /// Assets パネル上で左ボタン押下を監視中かを表す。
+        /// </summary>
+        bool m_assetsListLeftButtonDown = false;
+
+        /// <summary>
+        /// Assets パネルでドラッグ候補を捕捉したスクリーン座標を保持する。
+        /// </summary>
+        POINT m_assetDragStartScreenPoint{};
 
         /// <summary>
         /// Hierarchy パネルへ表示する EntityId 一覧を保持する。


### PR DESCRIPTION
## 概要
- 親 Issue #93 の子 Issue #97 に対応
- Assets パネルから Sprite 項目のドラッグ開始状態を管理
- ドラッグ中の AssetId を Editor 内で保持し、対象外アセットは既存可視フィルタで除外

## 検証
- この環境からは Windows 用 MSBuild を解決できず、ビルド未実施

## 関連
- Parent: #93
- Child: #97