### PR TITLE
Q01: Undo/Redo 1操作対応

### DIFF
--- a/Editor/Source/Application.cpp
+++ b/Editor/Source/Application.cpp
@@ -10,6 +10,7 @@
 #include "GraphicsAPI.h"
 #include "RenderBackendBootstrap.h"
 #include "SceneSerializer.h"
+#include "SceneCommandHistory.h"
 #include "Texture2D.h"
 #include <Windows.h>
 #include <cstdint>
@@ -148,6 +149,7 @@ namespace Xelqoria::Editor
         RefreshAssetsPanel();
         RefreshHierarchyPanel();
         RefreshInspectorPanel();
+        m_sceneCommandHistory.Reset(CaptureSceneHistoryEntry());
         return true;
     }
 
@@ -170,6 +172,7 @@ namespace Xelqoria::Editor
         SyncInspectorEdits();
         UpdateSceneViewInteraction();
         ProcessPendingSceneDrop();
+        UpdateCommandShortcuts();
     }
 
     void Application::Render()
@@ -1082,6 +1085,7 @@ namespace Xelqoria::Editor
         m_lastInspectorEntityId.reset();
         RefreshHierarchyPanel();
         RefreshInspectorPanel();
+        m_sceneCommandHistory.Push(CaptureSceneHistoryEntry());
 
         wchar_t statusText[160]{};
         std::swprintf(
@@ -1105,6 +1109,70 @@ namespace Xelqoria::Editor
             + std::to_string(dropWorldY)
             + ") and reloaded the scene snapshot.\n";
         ::OutputDebugStringA(debugLine.c_str());
+    }
+
+    void Application::UpdateCommandShortcuts()
+    {
+        const bool isControlDown = (GetAsyncKeyState(VK_CONTROL) & 0x8000) != 0;
+        const bool isUndoDown = isControlDown && (GetAsyncKeyState('Z') & 0x8000) != 0;
+        const bool isRedoDown = isControlDown && (GetAsyncKeyState('Y') & 0x8000) != 0;
+
+        if (isUndoDown && !m_wasUndoShortcutDown)
+        {
+            const auto entry = m_sceneCommandHistory.Undo();
+            if (entry.has_value() && RestoreSceneHistoryEntry(*entry))
+            {
+                SetWindowTextW(m_sceneViewPlanLabel, L"Ctrl+Z で直前の Scene スナップショットへ戻しました。");
+            }
+        }
+
+        if (isRedoDown && !m_wasRedoShortcutDown)
+        {
+            const auto entry = m_sceneCommandHistory.Redo();
+            if (entry.has_value() && RestoreSceneHistoryEntry(*entry))
+            {
+                SetWindowTextW(m_sceneViewPlanLabel, L"Ctrl+Y で Scene スナップショットを再適用しました。");
+            }
+        }
+
+        m_wasUndoShortcutDown = isUndoDown;
+        m_wasRedoShortcutDown = isRedoDown;
+    }
+
+    SceneCommandHistoryEntry Application::CaptureSceneHistoryEntry() const
+    {
+        if (!m_scene)
+        {
+            return SceneCommandHistoryEntry{};
+        }
+
+        return SceneCommandHistoryEntry{
+            Game::SceneSerializer::SaveToText(*m_scene),
+            m_selectedEntityId
+        };
+    }
+
+    bool Application::RestoreSceneHistoryEntry(const SceneCommandHistoryEntry& entry)
+    {
+        const auto loadResult = Game::SceneSerializer::LoadFromText(entry.serializedScene);
+        if (!loadResult.IsSuccess() || !loadResult.scene.has_value())
+        {
+            ::OutputDebugStringA("Editor::Application failed to restore Scene history entry.\n");
+            SetWindowTextW(m_sceneViewPlanLabel, L"履歴スナップショットの再読込に失敗しました。");
+            return false;
+        }
+
+        m_scene = std::make_unique<Game::Scene>(*loadResult.scene);
+        m_selectedEntityId = entry.selectedEntityId;
+        if (m_selectedEntityId.has_value() && !m_scene->FindEntity(*m_selectedEntityId).has_value())
+        {
+            m_selectedEntityId.reset();
+        }
+
+        m_lastInspectorEntityId.reset();
+        RefreshHierarchyPanel();
+        RefreshInspectorPanel();
+        return true;
     }
 
     HWND Application::CreateChildWindow(const wchar_t* className, const wchar_t* text, DWORD style, DWORD exStyle) const

--- a/Editor/Source/Application.h
+++ b/Editor/Source/Application.h
@@ -13,6 +13,7 @@
 #include "Assets/SpriteAssetRegistry.h"
 #include "EditorCamera2D.h"
 #include "IGraphicsContext.h"
+#include "SceneCommandHistory.h"
 #include "TextureAssetRegistry.h"
 #include "Scene.h"
 #include "SpriteRenderer.h"
@@ -155,6 +156,24 @@ namespace Xelqoria::Editor
         /// SceneView で受理済みのドロップ入力を Entity 生成へ反映する。
         /// </summary>
         void ProcessPendingSceneDrop();
+
+        /// <summary>
+        /// Editor の Undo/Redo ショートカットを処理する。
+        /// </summary>
+        void UpdateCommandShortcuts();
+
+        /// <summary>
+        /// 現在の Scene と選択状態から履歴スナップショットを作成する。
+        /// </summary>
+        /// <returns>履歴へ保存できる Scene スナップショット。</returns>
+        SceneCommandHistoryEntry CaptureSceneHistoryEntry() const;
+
+        /// <summary>
+        /// 履歴スナップショットを Scene と選択状態へ復元する。
+        /// </summary>
+        /// <param name="entry">復元する履歴スナップショット。</param>
+        /// <returns>復元に成功した場合は true。</returns>
+        bool RestoreSceneHistoryEntry(const SceneCommandHistoryEntry& entry);
 
         /// <summary>
         /// 共通設定を適用した子ウィンドウを生成する。
@@ -407,5 +426,20 @@ namespace Xelqoria::Editor
         /// SceneView で未処理のドロップがあるかを表す。
         /// </summary>
         bool m_hasPendingSceneDrop = false;
+
+        /// <summary>
+        /// Scene 編集コマンドの Undo/Redo 履歴を保持する。
+        /// </summary>
+        SceneCommandHistory m_sceneCommandHistory{};
+
+        /// <summary>
+        /// 前フレームで Ctrl+Z が押下されていたかを表す。
+        /// </summary>
+        bool m_wasUndoShortcutDown = false;
+
+        /// <summary>
+        /// 前フレームで Ctrl+Y が押下されていたかを表す。
+        /// </summary>
+        bool m_wasRedoShortcutDown = false;
     };
 }

--- a/Editor/Source/SceneCommandHistory.cpp
+++ b/Editor/Source/SceneCommandHistory.cpp
@@ -1,0 +1,77 @@
+#include "SceneCommandHistory.h"
+
+#include <utility>
+
+namespace Xelqoria::Editor
+{
+    void SceneCommandHistory::Reset(SceneCommandHistoryEntry entry)
+    {
+        m_entries.clear();
+        m_entries.push_back(std::move(entry));
+        m_currentIndex = 0;
+    }
+
+    void SceneCommandHistory::Push(SceneCommandHistoryEntry entry)
+    {
+        if (m_entries.empty())
+        {
+            Reset(std::move(entry));
+            return;
+        }
+
+        if (m_currentIndex + 1 < m_entries.size())
+        {
+            m_entries.erase(m_entries.begin() + static_cast<std::ptrdiff_t>(m_currentIndex + 1), m_entries.end());
+        }
+
+        m_entries.push_back(std::move(entry));
+        m_currentIndex = m_entries.size() - 1;
+    }
+
+    bool SceneCommandHistory::CanUndo() const
+    {
+        return !m_entries.empty() && m_currentIndex > 0;
+    }
+
+    bool SceneCommandHistory::CanRedo() const
+    {
+        return !m_entries.empty() && (m_currentIndex + 1) < m_entries.size();
+    }
+
+    std::optional<SceneCommandHistoryEntry> SceneCommandHistory::Undo()
+    {
+        if (!CanUndo())
+        {
+            return std::nullopt;
+        }
+
+        --m_currentIndex;
+        return m_entries[m_currentIndex];
+    }
+
+    std::optional<SceneCommandHistoryEntry> SceneCommandHistory::Redo()
+    {
+        if (!CanRedo())
+        {
+            return std::nullopt;
+        }
+
+        ++m_currentIndex;
+        return m_entries[m_currentIndex];
+    }
+
+    std::optional<SceneCommandHistoryEntry> SceneCommandHistory::GetCurrent() const
+    {
+        if (m_entries.empty())
+        {
+            return std::nullopt;
+        }
+
+        return m_entries[m_currentIndex];
+    }
+
+    std::size_t SceneCommandHistory::GetCount() const
+    {
+        return m_entries.size();
+    }
+}

--- a/Editor/Source/SceneCommandHistory.h
+++ b/Editor/Source/SceneCommandHistory.h
@@ -1,0 +1,86 @@
+#pragma once
+
+#include <cstddef>
+#include <optional>
+#include <string>
+#include <vector>
+
+#include "Scene.h"
+
+namespace Xelqoria::Editor
+{
+    /// <summary>
+    /// Editor の履歴へ保存する Scene スナップショットを表す。
+    /// </summary>
+    struct SceneCommandHistoryEntry
+    {
+        /// <summary>
+        /// Scene の保存テキストを保持する。
+        /// </summary>
+        std::string serializedScene{};
+
+        /// <summary>
+        /// スナップショット時点の選択 EntityId を保持する。
+        /// </summary>
+        std::optional<Game::EntityId> selectedEntityId{};
+    };
+
+    /// <summary>
+    /// Scene 全体のスナップショットを使って Undo/Redo を管理する。
+    /// </summary>
+    class SceneCommandHistory
+    {
+    public:
+        /// <summary>
+        /// 既存履歴を破棄して初期スナップショットを設定する。
+        /// </summary>
+        /// <param name="entry">履歴の先頭へ設定するスナップショット。</param>
+        void Reset(SceneCommandHistoryEntry entry);
+
+        /// <summary>
+        /// 新しい編集結果を履歴へ積む。
+        /// </summary>
+        /// <param name="entry">追加するスナップショット。</param>
+        void Push(SceneCommandHistoryEntry entry);
+
+        /// <summary>
+        /// Undo 可能かを取得する。
+        /// </summary>
+        /// <returns>Undo 可能な場合は true。</returns>
+        bool CanUndo() const;
+
+        /// <summary>
+        /// Redo 可能かを取得する。
+        /// </summary>
+        /// <returns>Redo 可能な場合は true。</returns>
+        bool CanRedo() const;
+
+        /// <summary>
+        /// 1 段階 Undo して復元対象スナップショットを返す。
+        /// </summary>
+        /// <returns>復元対象スナップショット。Undo 不可の場合は空。</returns>
+        std::optional<SceneCommandHistoryEntry> Undo();
+
+        /// <summary>
+        /// 1 段階 Redo して復元対象スナップショットを返す。
+        /// </summary>
+        /// <returns>復元対象スナップショット。Redo 不可の場合は空。</returns>
+        std::optional<SceneCommandHistoryEntry> Redo();
+
+        /// <summary>
+        /// 現在位置のスナップショットを取得する。
+        /// </summary>
+        /// <returns>現在スナップショット。未初期化時は空。</returns>
+        std::optional<SceneCommandHistoryEntry> GetCurrent() const;
+
+        /// <summary>
+        /// 履歴に保存されている件数を取得する。
+        /// </summary>
+        /// <returns>履歴件数。</returns>
+        std::size_t GetCount() const;
+
+    private:
+        std::vector<SceneCommandHistoryEntry> m_entries{};
+        std::size_t m_currentIndex = 0;
+    };
+}

--- a/Editor/Xelqoria.Editor.vcxproj
+++ b/Editor/Xelqoria.Editor.vcxproj
@@ -22,11 +22,13 @@
     <ClCompile Include="Source\Application.cpp" />
     <ClCompile Include="Source\Entry.cpp" />
     <ClCompile Include="Source\RenderBackendBootstrap.cpp" />
+    <ClCompile Include="Source\SceneCommandHistory.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="Source\Application.h" />
     <ClInclude Include="Source\EditorCamera2D.h" />
     <ClInclude Include="Source\RenderBackendBootstrap.h" />
+    <ClInclude Include="Source\SceneCommandHistory.h" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Core\Xelqoria.Core.vcxproj">

--- a/tests/Editor/Source/SceneCommandHistoryTests.cpp
+++ b/tests/Editor/Source/SceneCommandHistoryTests.cpp
@@ -1,0 +1,85 @@
+#include <gtest/gtest.h>
+
+#include "SceneCommandHistory.h"
+#include "SceneSerializer.h"
+
+namespace
+{
+    Xelqoria::Editor::SceneCommandHistoryEntry CreateEntry(
+        const Xelqoria::Game::Scene& scene,
+        std::optional<Xelqoria::Game::EntityId> selectedEntityId)
+    {
+        return Xelqoria::Editor::SceneCommandHistoryEntry{
+            Xelqoria::Game::SceneSerializer::SaveToText(scene),
+            selectedEntityId
+        };
+    }
+}
+
+TEST(SceneCommandHistoryTests, StoresOneDropAsSingleUndoRedoUnit)
+{
+    Xelqoria::Editor::SceneCommandHistory history;
+
+    Xelqoria::Game::Scene initialScene;
+    history.Reset(CreateEntry(initialScene, std::nullopt));
+
+    Xelqoria::Game::Scene droppedScene;
+    auto& droppedEntity = droppedScene.CreateEntity();
+    droppedEntity.GetTransform().SetPosition(32.0f, -16.0f, 0.0f);
+    droppedEntity.SetSpriteComponent(Xelqoria::Game::SpriteComponent{
+        Xelqoria::Core::AssetId("sprites/player"),
+        {
+            true,
+            0,
+            1.0f
+        }
+    });
+    history.Push(CreateEntry(droppedScene, droppedEntity.GetId()));
+
+    ASSERT_TRUE(history.CanUndo());
+
+    const auto undone = history.Undo();
+    ASSERT_TRUE(undone.has_value());
+    const auto undoneScene = Xelqoria::Game::SceneSerializer::LoadFromText(undone->serializedScene);
+    ASSERT_TRUE(undoneScene.IsSuccess());
+    ASSERT_TRUE(undoneScene.scene.has_value());
+    EXPECT_EQ(static_cast<std::size_t>(0), undoneScene.scene->GetEntityCount());
+    EXPECT_FALSE(undone->selectedEntityId.has_value());
+
+    ASSERT_TRUE(history.CanRedo());
+
+    const auto redone = history.Redo();
+    ASSERT_TRUE(redone.has_value());
+    const auto redoneScene = Xelqoria::Game::SceneSerializer::LoadFromText(redone->serializedScene);
+    ASSERT_TRUE(redoneScene.IsSuccess());
+    ASSERT_TRUE(redoneScene.scene.has_value());
+    ASSERT_EQ(static_cast<std::size_t>(1), redoneScene.scene->GetEntityCount());
+    EXPECT_EQ(droppedEntity.GetId(), redone->selectedEntityId);
+}
+
+TEST(SceneCommandHistoryTests, ClearsRedoBranchWhenNewEditIsPushedAfterUndo)
+{
+    Xelqoria::Editor::SceneCommandHistory history;
+
+    Xelqoria::Game::Scene initialScene;
+    history.Reset(CreateEntry(initialScene, std::nullopt));
+
+    Xelqoria::Game::Scene firstScene;
+    firstScene.CreateEntity();
+    history.Push(CreateEntry(firstScene, static_cast<Xelqoria::Game::EntityId>(1)));
+
+    Xelqoria::Game::Scene secondScene = firstScene;
+    secondScene.CreateEntity();
+    history.Push(CreateEntry(secondScene, static_cast<Xelqoria::Game::EntityId>(2)));
+
+    ASSERT_TRUE(history.Undo().has_value());
+    ASSERT_TRUE(history.CanRedo());
+
+    Xelqoria::Game::Scene replacementScene = firstScene;
+    auto& replacementEntity = replacementScene.CreateEntity();
+    replacementEntity.GetTransform().SetPosition(10.0f, 20.0f, 0.0f);
+    history.Push(CreateEntry(replacementScene, replacementEntity.GetId()));
+
+    EXPECT_FALSE(history.CanRedo());
+    EXPECT_EQ(static_cast<std::size_t>(3), history.GetCount());
+}

--- a/tests/Editor/Xelqoria.Tests.Editor.vcxproj
+++ b/tests/Editor/Xelqoria.Tests.Editor.vcxproj
@@ -20,10 +20,21 @@
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="Source\EditorCamera2DTests.cpp" />
+    <ClCompile Include="..\..\Editor\Source\SceneCommandHistory.cpp" />
+    <ClCompile Include="Source\SceneCommandHistoryTests.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\third_party\googletest\Xelqoria.GoogleTest.vcxproj">
       <Project>{0F71D759-12A2-42D9-B1CA-9F19C4E586C9}</Project>
+    </ProjectReference>
+    <ProjectReference Include="..\..\Core\Xelqoria.Core.vcxproj">
+      <Project>{79E8E826-7407-4766-B731-675CB84F6552}</Project>
+    </ProjectReference>
+    <ProjectReference Include="..\..\Game\Xelqoria.Game.vcxproj">
+      <Project>{B43E8E97-59EF-4CAA-8A27-BD9192D8833A}</Project>
+    </ProjectReference>
+    <ProjectReference Include="..\..\Graphics\Xelqoria.Graphics.vcxproj">
+      <Project>{7693792A-4AD4-445A-98F7-B90D6989A837}</Project>
     </ProjectReference>
   </ItemGroup>
   <PropertyGroup Label="Globals">
@@ -88,7 +99,7 @@
       <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <LanguageStandard>stdcpp20</LanguageStandard>
-      <AdditionalIncludeDirectories>$(RepoRootDir)Editor\Source;$(RepoRootDir)third_party\googletest\googletest\include;$(ProjectDir)Source;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(RepoRootDir)Core\Source;$(RepoRootDir)Game\Source;$(RepoRootDir)Graphics\Source;$(RepoRootDir)Editor\Source;$(RepoRootDir)third_party\googletest\googletest\include;$(ProjectDir)Source;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <AdditionalOptions>/utf-8 %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
@@ -108,7 +119,7 @@
       <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <LanguageStandard>stdcpp20</LanguageStandard>
-      <AdditionalIncludeDirectories>$(RepoRootDir)Editor\Source;$(RepoRootDir)third_party\googletest\googletest\include;$(ProjectDir)Source;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(RepoRootDir)Core\Source;$(RepoRootDir)Game\Source;$(RepoRootDir)Graphics\Source;$(RepoRootDir)Editor\Source;$(RepoRootDir)third_party\googletest\googletest\include;$(ProjectDir)Source;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <AdditionalOptions>/utf-8 %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
@@ -126,7 +137,7 @@
       <PreprocessorDefinitions>_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <LanguageStandard>stdcpp20</LanguageStandard>
-      <AdditionalIncludeDirectories>$(RepoRootDir)Editor\Source;$(RepoRootDir)third_party\googletest\googletest\include;$(ProjectDir)Source;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(RepoRootDir)Core\Source;$(RepoRootDir)Game\Source;$(RepoRootDir)Graphics\Source;$(RepoRootDir)Editor\Source;$(RepoRootDir)third_party\googletest\googletest\include;$(ProjectDir)Source;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <AdditionalOptions>/utf-8 %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
@@ -146,7 +157,7 @@
       <PreprocessorDefinitions>NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <LanguageStandard>stdcpp20</LanguageStandard>
-      <AdditionalIncludeDirectories>$(RepoRootDir)Editor\Source;$(RepoRootDir)third_party\googletest\googletest\include;$(ProjectDir)Source;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(RepoRootDir)Core\Source;$(RepoRootDir)Game\Source;$(RepoRootDir)Graphics\Source;$(RepoRootDir)Editor\Source;$(RepoRootDir)third_party\googletest\googletest\include;$(ProjectDir)Source;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <AdditionalOptions>/utf-8 %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>


### PR DESCRIPTION
## Summary
- add editor scene snapshot history for D&D placement undo/redo
- record one drop as one history entry and restore selection with ctrl+z / ctrl+y
- add editor tests for history behavior

## Testing
- '/mnt/c/Program Files/Microsoft Visual Studio/18/Community/MSBuild/Current/Bin/amd64/MSBuild.exe' Tests/Editor/Xelqoria.Tests.Editor.vcxproj /p:Configuration=Debug /p:Platform=x64 /p:PlatformToolset=v143
- '/mnt/d/github/Xelqoria/artifacts/x64/Debug/Xelqoria.Tests.Editor.exe'

## Related
- Parent issue: #94
- Child issue: #102