### PR TITLE
Q03: 保存->再読込 E2E

### DIFF
--- a/Editor/Source/Application.cpp
+++ b/Editor/Source/Application.cpp
@@ -11,6 +11,7 @@
 #include "RenderBackendBootstrap.h"
 #include "SceneSerializer.h"
 #include "SceneCommandHistory.h"
+#include "SceneEditingOperations.h"
 #include "Texture2D.h"
 #include <Windows.h>
 #include <cstdint>
@@ -1116,6 +1117,8 @@ namespace Xelqoria::Editor
         const bool isControlDown = (GetAsyncKeyState(VK_CONTROL) & 0x8000) != 0;
         const bool isUndoDown = isControlDown && (GetAsyncKeyState('Z') & 0x8000) != 0;
         const bool isRedoDown = isControlDown && (GetAsyncKeyState('Y') & 0x8000) != 0;
+        const bool isDuplicateDown = isControlDown && (GetAsyncKeyState('D') & 0x8000) != 0;
+        const bool isDeleteDown = (GetAsyncKeyState(VK_DELETE) & 0x8000) != 0;
 
         if (isUndoDown && !m_wasUndoShortcutDown)
         {
@@ -1135,8 +1138,40 @@ namespace Xelqoria::Editor
             }
         }
 
+        if (m_scene && isDuplicateDown && !m_wasDuplicateShortcutDown)
+        {
+            const SceneEditResult duplicateResult =
+                SceneEditingOperations::DuplicateSelectedEntity(*m_scene, m_selectedEntityId);
+            if (duplicateResult.changed)
+            {
+                m_selectedEntityId = duplicateResult.selectedEntityId;
+                m_lastInspectorEntityId.reset();
+                RefreshHierarchyPanel();
+                RefreshInspectorPanel();
+                m_sceneCommandHistory.Push(CaptureSceneHistoryEntry());
+                SetWindowTextW(m_sceneViewPlanLabel, L"Ctrl+D で選択 Entity を複製しました。");
+            }
+        }
+
+        if (m_scene && isDeleteDown && !m_wasDeleteShortcutDown)
+        {
+            const SceneEditResult deleteResult =
+                SceneEditingOperations::DeleteSelectedEntity(*m_scene, m_selectedEntityId);
+            if (deleteResult.changed)
+            {
+                m_selectedEntityId = deleteResult.selectedEntityId;
+                m_lastInspectorEntityId.reset();
+                RefreshHierarchyPanel();
+                RefreshInspectorPanel();
+                m_sceneCommandHistory.Push(CaptureSceneHistoryEntry());
+                SetWindowTextW(m_sceneViewPlanLabel, L"Delete で選択 Entity を削除しました。");
+            }
+        }
+
         m_wasUndoShortcutDown = isUndoDown;
         m_wasRedoShortcutDown = isRedoDown;
+        m_wasDeleteShortcutDown = isDeleteDown;
+        m_wasDuplicateShortcutDown = isDuplicateDown;
     }
 
     SceneCommandHistoryEntry Application::CaptureSceneHistoryEntry() const

--- a/Editor/Source/Application.cpp
+++ b/Editor/Source/Application.cpp
@@ -10,6 +10,7 @@
 #include "GraphicsAPI.h"
 #include "RenderBackendBootstrap.h"
 #include "SceneSerializer.h"
+#include "SceneCommandHistory.h"
 #include "Texture2D.h"
 #include <Windows.h>
 #include <cstdint>
@@ -148,6 +149,7 @@ namespace Xelqoria::Editor
         RefreshAssetsPanel();
         RefreshHierarchyPanel();
         RefreshInspectorPanel();
+        m_sceneCommandHistory.Reset(CaptureSceneHistoryEntry());
         return true;
     }
 
@@ -170,6 +172,7 @@ namespace Xelqoria::Editor
         SyncInspectorEdits();
         UpdateSceneViewInteraction();
         ProcessPendingSceneDrop();
+        UpdateCommandShortcuts();
     }
 
     void Application::Render()
@@ -1082,6 +1085,7 @@ namespace Xelqoria::Editor
         m_lastInspectorEntityId.reset();
         RefreshHierarchyPanel();
         RefreshInspectorPanel();
+        m_sceneCommandHistory.Push(CaptureSceneHistoryEntry());
 
         wchar_t statusText[160]{};
         std::swprintf(
@@ -1105,6 +1109,70 @@ namespace Xelqoria::Editor
             + std::to_string(dropWorldY)
             + ") and reloaded the scene snapshot.\n";
         ::OutputDebugStringA(debugLine.c_str());
+    }
+
+    void Application::UpdateCommandShortcuts()
+    {
+        const bool isControlDown = (GetAsyncKeyState(VK_CONTROL) & 0x8000) != 0;
+        const bool isUndoDown = isControlDown && (GetAsyncKeyState('Z') & 0x8000) != 0;
+        const bool isRedoDown = isControlDown && (GetAsyncKeyState('Y') & 0x8000) != 0;
+
+        if (isUndoDown && !m_wasUndoShortcutDown)
+        {
+            const auto entry = m_sceneCommandHistory.Undo();
+            if (entry.has_value() && RestoreSceneHistoryEntry(*entry))
+            {
+                SetWindowTextW(m_sceneViewPlanLabel, L"Ctrl+Z で直前の Scene スナップショットへ戻しました。");
+            }
+        }
+
+        if (isRedoDown && !m_wasRedoShortcutDown)
+        {
+            const auto entry = m_sceneCommandHistory.Redo();
+            if (entry.has_value() && RestoreSceneHistoryEntry(*entry))
+            {
+                SetWindowTextW(m_sceneViewPlanLabel, L"Ctrl+Y で Scene スナップショットを再適用しました。");
+            }
+        }
+
+        m_wasUndoShortcutDown = isUndoDown;
+        m_wasRedoShortcutDown = isRedoDown;
+    }
+
+    SceneCommandHistoryEntry Application::CaptureSceneHistoryEntry() const
+    {
+        if (!m_scene)
+        {
+            return SceneCommandHistoryEntry{};
+        }
+
+        return SceneCommandHistoryEntry{
+            Game::SceneSerializer::SaveToText(*m_scene),
+            m_selectedEntityId
+        };
+    }
+
+    bool Application::RestoreSceneHistoryEntry(const SceneCommandHistoryEntry& entry)
+    {
+        const auto loadResult = Game::SceneSerializer::LoadFromText(entry.serializedScene);
+        if (!loadResult.IsSuccess() || !loadResult.scene.has_value())
+        {
+            ::OutputDebugStringA("Editor::Application failed to restore Scene history entry.\n");
+            SetWindowTextW(m_sceneViewPlanLabel, L"履歴スナップショットの再読込に失敗しました。");
+            return false;
+        }
+
+        m_scene = std::make_unique<Game::Scene>(*loadResult.scene);
+        m_selectedEntityId = entry.selectedEntityId;
+        if (m_selectedEntityId.has_value() && !m_scene->FindEntity(*m_selectedEntityId).has_value())
+        {
+            m_selectedEntityId.reset();
+        }
+
+        m_lastInspectorEntityId.reset();
+        RefreshHierarchyPanel();
+        RefreshInspectorPanel();
+        return true;
     }
 
     HWND Application::CreateChildWindow(const wchar_t* className, const wchar_t* text, DWORD style, DWORD exStyle) const

--- a/Editor/Source/Application.cpp
+++ b/Editor/Source/Application.cpp
@@ -3,7 +3,10 @@
 #include <algorithm>
 #include <chrono>
 #include <cwchar>
+#include <filesystem>
+#include <fstream>
 #include <memory>
+#include <sstream>
 #include <string>
 
 #include "Assets/SpriteAsset.h"
@@ -493,8 +496,6 @@ namespace Xelqoria::Editor
 
     bool Application::InitializeDocument()
     {
-        m_scene = std::make_unique<Game::Scene>();
-
         auto spriteTexture = std::make_shared<Graphics::Texture2D>();
         if (!spriteTexture->LoadFromFile(L"../Resource\\mapchip.png", *m_graphics))
         {
@@ -518,6 +519,13 @@ namespace Xelqoria::Editor
             m_registeredSpriteAssetIds[2],
             Game::Assets::SpriteAsset{ "textures/missing" });
 
+        if (LoadSceneDocument())
+        {
+            return true;
+        }
+
+        m_scene = std::make_unique<Game::Scene>();
+
         auto& firstEntity = m_scene->CreateEntity();
         firstEntity.GetTransform().SetPosition(-160.0f, 0.0f, 0.0f);
         firstEntity.SetSpriteComponent(Game::SpriteComponent{
@@ -540,6 +548,11 @@ namespace Xelqoria::Editor
                 1.0f
             }
         });
+
+        if (!SaveSceneDocument())
+        {
+            return false;
+        }
 
         return true;
     }
@@ -1086,6 +1099,13 @@ namespace Xelqoria::Editor
         m_lastInspectorEntityId.reset();
         RefreshHierarchyPanel();
         RefreshInspectorPanel();
+
+        if (!SaveSceneDocument())
+        {
+            SetWindowTextW(m_sceneViewPlanLabel, L"Scene は再読込できましたが、保存ファイルへの書き出しに失敗しました。");
+            return;
+        }
+
         m_sceneCommandHistory.Push(CaptureSceneHistoryEntry());
 
         wchar_t statusText[160]{};
@@ -1148,6 +1168,7 @@ namespace Xelqoria::Editor
                 m_lastInspectorEntityId.reset();
                 RefreshHierarchyPanel();
                 RefreshInspectorPanel();
+                SaveSceneDocument();
                 m_sceneCommandHistory.Push(CaptureSceneHistoryEntry());
                 SetWindowTextW(m_sceneViewPlanLabel, L"Ctrl+D で選択 Entity を複製しました。");
             }
@@ -1163,6 +1184,7 @@ namespace Xelqoria::Editor
                 m_lastInspectorEntityId.reset();
                 RefreshHierarchyPanel();
                 RefreshInspectorPanel();
+                SaveSceneDocument();
                 m_sceneCommandHistory.Push(CaptureSceneHistoryEntry());
                 SetWindowTextW(m_sceneViewPlanLabel, L"Delete で選択 Entity を削除しました。");
             }
@@ -1207,6 +1229,65 @@ namespace Xelqoria::Editor
         m_lastInspectorEntityId.reset();
         RefreshHierarchyPanel();
         RefreshInspectorPanel();
+        return true;
+    }
+
+    std::filesystem::path Application::GetSceneDocumentPath() const
+    {
+        return std::filesystem::path("Saved") / "EditorScene.xelqoria.scene";
+    }
+
+    bool Application::SaveSceneDocument() const
+    {
+        if (!m_scene)
+        {
+            return false;
+        }
+
+        const std::filesystem::path sceneDocumentPath = GetSceneDocumentPath();
+        std::error_code errorCode;
+        std::filesystem::create_directories(sceneDocumentPath.parent_path(), errorCode);
+        if (errorCode)
+        {
+            return false;
+        }
+
+        std::ofstream output(sceneDocumentPath, std::ios::binary | std::ios::trunc);
+        if (!output.is_open())
+        {
+            return false;
+        }
+
+        output << Game::SceneSerializer::SaveToText(*m_scene);
+        return output.good();
+    }
+
+    bool Application::LoadSceneDocument()
+    {
+        const std::filesystem::path sceneDocumentPath = GetSceneDocumentPath();
+        if (!std::filesystem::exists(sceneDocumentPath))
+        {
+            return false;
+        }
+
+        std::ifstream input(sceneDocumentPath, std::ios::binary);
+        if (!input.is_open())
+        {
+            return false;
+        }
+
+        std::ostringstream buffer;
+        buffer << input.rdbuf();
+
+        const auto loadResult = Game::SceneSerializer::LoadFromText(buffer.str());
+        if (!loadResult.IsSuccess() || !loadResult.scene.has_value())
+        {
+            return false;
+        }
+
+        m_scene = std::make_unique<Game::Scene>(*loadResult.scene);
+        m_selectedEntityId.reset();
+        m_lastInspectorEntityId.reset();
         return true;
     }
 

--- a/Editor/Source/Application.h
+++ b/Editor/Source/Application.h
@@ -13,6 +13,7 @@
 #include "Assets/SpriteAssetRegistry.h"
 #include "EditorCamera2D.h"
 #include "IGraphicsContext.h"
+#include "SceneCommandHistory.h"
 #include "TextureAssetRegistry.h"
 #include "Scene.h"
 #include "SpriteRenderer.h"
@@ -155,6 +156,24 @@ namespace Xelqoria::Editor
         /// SceneView で受理済みのドロップ入力を Entity 生成へ反映する。
         /// </summary>
         void ProcessPendingSceneDrop();
+
+        /// <summary>
+        /// Editor の Undo/Redo ショートカットを処理する。
+        /// </summary>
+        void UpdateCommandShortcuts();
+
+        /// <summary>
+        /// 現在の Scene と選択状態から履歴スナップショットを作成する。
+        /// </summary>
+        /// <returns>履歴へ保存できる Scene スナップショット。</returns>
+        SceneCommandHistoryEntry CaptureSceneHistoryEntry() const;
+
+        /// <summary>
+        /// 履歴スナップショットを Scene と選択状態へ復元する。
+        /// </summary>
+        /// <param name="entry">復元する履歴スナップショット。</param>
+        /// <returns>復元に成功した場合は true。</returns>
+        bool RestoreSceneHistoryEntry(const SceneCommandHistoryEntry& entry);
 
         /// <summary>
         /// 共通設定を適用した子ウィンドウを生成する。
@@ -407,5 +426,20 @@ namespace Xelqoria::Editor
         /// SceneView で未処理のドロップがあるかを表す。
         /// </summary>
         bool m_hasPendingSceneDrop = false;
+
+        /// <summary>
+        /// Scene 編集コマンドの Undo/Redo 履歴を保持する。
+        /// </summary>
+        SceneCommandHistory m_sceneCommandHistory{};
+
+        /// <summary>
+        /// 前フレームで Ctrl+Z が押下されていたかを表す。
+        /// </summary>
+        bool m_wasUndoShortcutDown = false;
+
+        /// <summary>
+        /// 前フレームで Ctrl+Y が押下されていたかを表す。
+        /// </summary>
+        bool m_wasRedoShortcutDown = false;
     };
 }

--- a/Editor/Source/Application.h
+++ b/Editor/Source/Application.h
@@ -6,6 +6,7 @@
 #include <memory>
 #include <optional>
 #include <string>
+#include <filesystem>
 #include <string_view>
 #include <vector>
 
@@ -175,6 +176,24 @@ namespace Xelqoria::Editor
         /// <param name="entry">復元する履歴スナップショット。</param>
         /// <returns>復元に成功した場合は true。</returns>
         bool RestoreSceneHistoryEntry(const SceneCommandHistoryEntry& entry);
+
+        /// <summary>
+        /// Editor が永続保存に使用する Scene ファイルパスを取得する。
+        /// </summary>
+        /// <returns>Scene 保存ファイルのパス。</returns>
+        std::filesystem::path GetSceneDocumentPath() const;
+
+        /// <summary>
+        /// 現在の Scene を永続保存ファイルへ書き出す。
+        /// </summary>
+        /// <returns>保存に成功した場合は true。</returns>
+        bool SaveSceneDocument() const;
+
+        /// <summary>
+        /// 永続保存ファイルから Scene を読み込む。
+        /// </summary>
+        /// <returns>読込に成功した場合は true。</returns>
+        bool LoadSceneDocument();
 
         /// <summary>
         /// 共通設定を適用した子ウィンドウを生成する。

--- a/Editor/Source/Application.h
+++ b/Editor/Source/Application.h
@@ -14,6 +14,7 @@
 #include "EditorCamera2D.h"
 #include "IGraphicsContext.h"
 #include "SceneCommandHistory.h"
+#include "SceneEditingOperations.h"
 #include "TextureAssetRegistry.h"
 #include "Scene.h"
 #include "SpriteRenderer.h"
@@ -441,5 +442,15 @@ namespace Xelqoria::Editor
         /// 前フレームで Ctrl+Y が押下されていたかを表す。
         /// </summary>
         bool m_wasRedoShortcutDown = false;
+
+        /// <summary>
+        /// 前フレームで Delete が押下されていたかを表す。
+        /// </summary>
+        bool m_wasDeleteShortcutDown = false;
+
+        /// <summary>
+        /// 前フレームで Ctrl+D が押下されていたかを表す。
+        /// </summary>
+        bool m_wasDuplicateShortcutDown = false;
     };
 }

--- a/Editor/Source/SceneCommandHistory.cpp
+++ b/Editor/Source/SceneCommandHistory.cpp
@@ -1,0 +1,77 @@
+#include "SceneCommandHistory.h"
+
+#include <utility>
+
+namespace Xelqoria::Editor
+{
+    void SceneCommandHistory::Reset(SceneCommandHistoryEntry entry)
+    {
+        m_entries.clear();
+        m_entries.push_back(std::move(entry));
+        m_currentIndex = 0;
+    }
+
+    void SceneCommandHistory::Push(SceneCommandHistoryEntry entry)
+    {
+        if (m_entries.empty())
+        {
+            Reset(std::move(entry));
+            return;
+        }
+
+        if (m_currentIndex + 1 < m_entries.size())
+        {
+            m_entries.erase(m_entries.begin() + static_cast<std::ptrdiff_t>(m_currentIndex + 1), m_entries.end());
+        }
+
+        m_entries.push_back(std::move(entry));
+        m_currentIndex = m_entries.size() - 1;
+    }
+
+    bool SceneCommandHistory::CanUndo() const
+    {
+        return !m_entries.empty() && m_currentIndex > 0;
+    }
+
+    bool SceneCommandHistory::CanRedo() const
+    {
+        return !m_entries.empty() && (m_currentIndex + 1) < m_entries.size();
+    }
+
+    std::optional<SceneCommandHistoryEntry> SceneCommandHistory::Undo()
+    {
+        if (!CanUndo())
+        {
+            return std::nullopt;
+        }
+
+        --m_currentIndex;
+        return m_entries[m_currentIndex];
+    }
+
+    std::optional<SceneCommandHistoryEntry> SceneCommandHistory::Redo()
+    {
+        if (!CanRedo())
+        {
+            return std::nullopt;
+        }
+
+        ++m_currentIndex;
+        return m_entries[m_currentIndex];
+    }
+
+    std::optional<SceneCommandHistoryEntry> SceneCommandHistory::GetCurrent() const
+    {
+        if (m_entries.empty())
+        {
+            return std::nullopt;
+        }
+
+        return m_entries[m_currentIndex];
+    }
+
+    std::size_t SceneCommandHistory::GetCount() const
+    {
+        return m_entries.size();
+    }
+}

--- a/Editor/Source/SceneCommandHistory.h
+++ b/Editor/Source/SceneCommandHistory.h
@@ -1,0 +1,86 @@
+#pragma once
+
+#include <cstddef>
+#include <optional>
+#include <string>
+#include <vector>
+
+#include "Scene.h"
+
+namespace Xelqoria::Editor
+{
+    /// <summary>
+    /// Editor の履歴へ保存する Scene スナップショットを表す。
+    /// </summary>
+    struct SceneCommandHistoryEntry
+    {
+        /// <summary>
+        /// Scene の保存テキストを保持する。
+        /// </summary>
+        std::string serializedScene{};
+
+        /// <summary>
+        /// スナップショット時点の選択 EntityId を保持する。
+        /// </summary>
+        std::optional<Game::EntityId> selectedEntityId{};
+    };
+
+    /// <summary>
+    /// Scene 全体のスナップショットを使って Undo/Redo を管理する。
+    /// </summary>
+    class SceneCommandHistory
+    {
+    public:
+        /// <summary>
+        /// 既存履歴を破棄して初期スナップショットを設定する。
+        /// </summary>
+        /// <param name="entry">履歴の先頭へ設定するスナップショット。</param>
+        void Reset(SceneCommandHistoryEntry entry);
+
+        /// <summary>
+        /// 新しい編集結果を履歴へ積む。
+        /// </summary>
+        /// <param name="entry">追加するスナップショット。</param>
+        void Push(SceneCommandHistoryEntry entry);
+
+        /// <summary>
+        /// Undo 可能かを取得する。
+        /// </summary>
+        /// <returns>Undo 可能な場合は true。</returns>
+        bool CanUndo() const;
+
+        /// <summary>
+        /// Redo 可能かを取得する。
+        /// </summary>
+        /// <returns>Redo 可能な場合は true。</returns>
+        bool CanRedo() const;
+
+        /// <summary>
+        /// 1 段階 Undo して復元対象スナップショットを返す。
+        /// </summary>
+        /// <returns>復元対象スナップショット。Undo 不可の場合は空。</returns>
+        std::optional<SceneCommandHistoryEntry> Undo();
+
+        /// <summary>
+        /// 1 段階 Redo して復元対象スナップショットを返す。
+        /// </summary>
+        /// <returns>復元対象スナップショット。Redo 不可の場合は空。</returns>
+        std::optional<SceneCommandHistoryEntry> Redo();
+
+        /// <summary>
+        /// 現在位置のスナップショットを取得する。
+        /// </summary>
+        /// <returns>現在スナップショット。未初期化時は空。</returns>
+        std::optional<SceneCommandHistoryEntry> GetCurrent() const;
+
+        /// <summary>
+        /// 履歴に保存されている件数を取得する。
+        /// </summary>
+        /// <returns>履歴件数。</returns>
+        std::size_t GetCount() const;
+
+    private:
+        std::vector<SceneCommandHistoryEntry> m_entries{};
+        std::size_t m_currentIndex = 0;
+    };
+}

--- a/Editor/Source/SceneEditingOperations.cpp
+++ b/Editor/Source/SceneEditingOperations.cpp
@@ -1,0 +1,131 @@
+#include "SceneEditingOperations.h"
+
+#include <span>
+
+namespace Xelqoria::Editor
+{
+    namespace
+    {
+        /// <summary>
+        /// 複製に必要な Entity 状態のスナップショットを表す。
+        /// </summary>
+        struct EntitySnapshot
+        {
+            /// <summary>
+            /// Entity の Transform を保持する。
+            /// </summary>
+            Game::Transform transform{};
+
+            /// <summary>
+            /// Entity の SpriteComponent を保持する。
+            /// </summary>
+            std::optional<Game::SpriteComponent> spriteComponent{};
+        };
+
+        /// <summary>
+        /// Entity の Transform と SpriteComponent を複製用に退避する。
+        /// </summary>
+        /// <param name="source">複製元 Entity。</param>
+        /// <returns>複製用スナップショット。</returns>
+        EntitySnapshot CaptureEntitySnapshot(const Game::Entity& source)
+        {
+            EntitySnapshot snapshot{};
+            snapshot.transform = source.GetTransform();
+
+            if (const auto spriteComponent = source.GetSpriteComponent(); spriteComponent.has_value())
+            {
+                snapshot.spriteComponent = spriteComponent->get();
+            }
+
+            return snapshot;
+        }
+
+        /// <summary>
+        /// 退避済みスナップショットを Entity へ復元する。
+        /// </summary>
+        /// <param name="snapshot">復元する複製用スナップショット。</param>
+        /// <param name="destination">複製先 Entity。</param>
+        void ApplyEntitySnapshot(const EntitySnapshot& snapshot, Game::Entity& destination)
+        {
+            destination.GetTransform() = snapshot.transform;
+
+            if (snapshot.spriteComponent.has_value())
+            {
+                destination.SetSpriteComponent(*snapshot.spriteComponent);
+                return;
+            }
+
+            destination.RemoveSpriteComponent();
+        }
+    }
+
+    SceneEditResult SceneEditingOperations::DeleteSelectedEntity(
+        Game::Scene& scene,
+        std::optional<Game::EntityId> selectedEntityId)
+    {
+        if (!selectedEntityId.has_value())
+        {
+            return SceneEditResult{};
+        }
+
+        const std::span<const Game::Entity> entities = scene.GetEntities();
+        std::optional<std::size_t> selectedIndex{};
+        for (std::size_t index = 0; index < entities.size(); ++index)
+        {
+            if (entities[index].GetId() == *selectedEntityId)
+            {
+                selectedIndex = index;
+                break;
+            }
+        }
+
+        if (!selectedIndex.has_value())
+        {
+            return SceneEditResult{};
+        }
+
+        std::optional<Game::EntityId> nextSelection{};
+        if (entities.size() > 1)
+        {
+            const std::size_t nextIndex = (*selectedIndex + 1 < entities.size())
+                ? *selectedIndex + 1
+                : *selectedIndex - 1;
+            nextSelection = entities[nextIndex].GetId();
+        }
+
+        if (!scene.DestroyEntity(*selectedEntityId))
+        {
+            return SceneEditResult{};
+        }
+
+        return SceneEditResult{
+            true,
+            nextSelection
+        };
+    }
+
+    SceneEditResult SceneEditingOperations::DuplicateSelectedEntity(
+        Game::Scene& scene,
+        std::optional<Game::EntityId> selectedEntityId)
+    {
+        if (!selectedEntityId.has_value())
+        {
+            return SceneEditResult{};
+        }
+
+        const auto sourceEntity = scene.FindEntity(*selectedEntityId);
+        if (!sourceEntity.has_value())
+        {
+            return SceneEditResult{};
+        }
+
+        const EntitySnapshot snapshot = CaptureEntitySnapshot(sourceEntity->get());
+        auto& duplicateEntity = scene.CreateEntity();
+        ApplyEntitySnapshot(snapshot, duplicateEntity);
+
+        return SceneEditResult{
+            true,
+            duplicateEntity.GetId()
+        };
+    }
+}

--- a/Editor/Source/SceneEditingOperations.h
+++ b/Editor/Source/SceneEditingOperations.h
@@ -1,0 +1,51 @@
+#pragma once
+
+#include <optional>
+
+#include "Scene.h"
+
+namespace Xelqoria::Editor
+{
+    /// <summary>
+    /// Scene 編集コマンドの適用結果を表す。
+    /// </summary>
+    struct SceneEditResult
+    {
+        /// <summary>
+        /// Scene に変更が加わったかを表す。
+        /// </summary>
+        bool changed = false;
+
+        /// <summary>
+        /// 編集後に選択すべき EntityId を表す。
+        /// </summary>
+        std::optional<Game::EntityId> selectedEntityId{};
+    };
+
+    /// <summary>
+    /// Editor から利用する基本的な Scene 編集操作を提供する。
+    /// </summary>
+    class SceneEditingOperations
+    {
+    public:
+        /// <summary>
+        /// 現在選択中の Entity を削除する。
+        /// </summary>
+        /// <param name="scene">編集対象の Scene。</param>
+        /// <param name="selectedEntityId">現在選択中の EntityId。</param>
+        /// <returns>削除結果と更新後の選択状態。</returns>
+        static SceneEditResult DeleteSelectedEntity(
+            Game::Scene& scene,
+            std::optional<Game::EntityId> selectedEntityId);
+
+        /// <summary>
+        /// 現在選択中の Entity を複製する。
+        /// </summary>
+        /// <param name="scene">編集対象の Scene。</param>
+        /// <param name="selectedEntityId">現在選択中の EntityId。</param>
+        /// <returns>複製結果と更新後の選択状態。</returns>
+        static SceneEditResult DuplicateSelectedEntity(
+            Game::Scene& scene,
+            std::optional<Game::EntityId> selectedEntityId);
+    };
+}

--- a/Editor/Xelqoria.Editor.vcxproj
+++ b/Editor/Xelqoria.Editor.vcxproj
@@ -23,12 +23,14 @@
     <ClCompile Include="Source\Entry.cpp" />
     <ClCompile Include="Source\RenderBackendBootstrap.cpp" />
     <ClCompile Include="Source\SceneCommandHistory.cpp" />
+    <ClCompile Include="Source\SceneEditingOperations.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="Source\Application.h" />
     <ClInclude Include="Source\EditorCamera2D.h" />
     <ClInclude Include="Source\RenderBackendBootstrap.h" />
     <ClInclude Include="Source\SceneCommandHistory.h" />
+    <ClInclude Include="Source\SceneEditingOperations.h" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Core\Xelqoria.Core.vcxproj">

--- a/Editor/Xelqoria.Editor.vcxproj
+++ b/Editor/Xelqoria.Editor.vcxproj
@@ -22,11 +22,13 @@
     <ClCompile Include="Source\Application.cpp" />
     <ClCompile Include="Source\Entry.cpp" />
     <ClCompile Include="Source\RenderBackendBootstrap.cpp" />
+    <ClCompile Include="Source\SceneCommandHistory.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="Source\Application.h" />
     <ClInclude Include="Source\EditorCamera2D.h" />
     <ClInclude Include="Source\RenderBackendBootstrap.h" />
+    <ClInclude Include="Source\SceneCommandHistory.h" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Core\Xelqoria.Core.vcxproj">

--- a/tests/Editor/Source/SceneCommandHistoryTests.cpp
+++ b/tests/Editor/Source/SceneCommandHistoryTests.cpp
@@ -1,0 +1,85 @@
+#include <gtest/gtest.h>
+
+#include "SceneCommandHistory.h"
+#include "SceneSerializer.h"
+
+namespace
+{
+    Xelqoria::Editor::SceneCommandHistoryEntry CreateEntry(
+        const Xelqoria::Game::Scene& scene,
+        std::optional<Xelqoria::Game::EntityId> selectedEntityId)
+    {
+        return Xelqoria::Editor::SceneCommandHistoryEntry{
+            Xelqoria::Game::SceneSerializer::SaveToText(scene),
+            selectedEntityId
+        };
+    }
+}
+
+TEST(SceneCommandHistoryTests, StoresOneDropAsSingleUndoRedoUnit)
+{
+    Xelqoria::Editor::SceneCommandHistory history;
+
+    Xelqoria::Game::Scene initialScene;
+    history.Reset(CreateEntry(initialScene, std::nullopt));
+
+    Xelqoria::Game::Scene droppedScene;
+    auto& droppedEntity = droppedScene.CreateEntity();
+    droppedEntity.GetTransform().SetPosition(32.0f, -16.0f, 0.0f);
+    droppedEntity.SetSpriteComponent(Xelqoria::Game::SpriteComponent{
+        Xelqoria::Core::AssetId("sprites/player"),
+        {
+            true,
+            0,
+            1.0f
+        }
+    });
+    history.Push(CreateEntry(droppedScene, droppedEntity.GetId()));
+
+    ASSERT_TRUE(history.CanUndo());
+
+    const auto undone = history.Undo();
+    ASSERT_TRUE(undone.has_value());
+    const auto undoneScene = Xelqoria::Game::SceneSerializer::LoadFromText(undone->serializedScene);
+    ASSERT_TRUE(undoneScene.IsSuccess());
+    ASSERT_TRUE(undoneScene.scene.has_value());
+    EXPECT_EQ(static_cast<std::size_t>(0), undoneScene.scene->GetEntityCount());
+    EXPECT_FALSE(undone->selectedEntityId.has_value());
+
+    ASSERT_TRUE(history.CanRedo());
+
+    const auto redone = history.Redo();
+    ASSERT_TRUE(redone.has_value());
+    const auto redoneScene = Xelqoria::Game::SceneSerializer::LoadFromText(redone->serializedScene);
+    ASSERT_TRUE(redoneScene.IsSuccess());
+    ASSERT_TRUE(redoneScene.scene.has_value());
+    ASSERT_EQ(static_cast<std::size_t>(1), redoneScene.scene->GetEntityCount());
+    EXPECT_EQ(droppedEntity.GetId(), redone->selectedEntityId);
+}
+
+TEST(SceneCommandHistoryTests, ClearsRedoBranchWhenNewEditIsPushedAfterUndo)
+{
+    Xelqoria::Editor::SceneCommandHistory history;
+
+    Xelqoria::Game::Scene initialScene;
+    history.Reset(CreateEntry(initialScene, std::nullopt));
+
+    Xelqoria::Game::Scene firstScene;
+    firstScene.CreateEntity();
+    history.Push(CreateEntry(firstScene, static_cast<Xelqoria::Game::EntityId>(1)));
+
+    Xelqoria::Game::Scene secondScene = firstScene;
+    secondScene.CreateEntity();
+    history.Push(CreateEntry(secondScene, static_cast<Xelqoria::Game::EntityId>(2)));
+
+    ASSERT_TRUE(history.Undo().has_value());
+    ASSERT_TRUE(history.CanRedo());
+
+    Xelqoria::Game::Scene replacementScene = firstScene;
+    auto& replacementEntity = replacementScene.CreateEntity();
+    replacementEntity.GetTransform().SetPosition(10.0f, 20.0f, 0.0f);
+    history.Push(CreateEntry(replacementScene, replacementEntity.GetId()));
+
+    EXPECT_FALSE(history.CanRedo());
+    EXPECT_EQ(static_cast<std::size_t>(3), history.GetCount());
+}

--- a/tests/Editor/Source/SceneEditingOperationsTests.cpp
+++ b/tests/Editor/Source/SceneEditingOperationsTests.cpp
@@ -1,0 +1,80 @@
+#include <gtest/gtest.h>
+
+#include "SceneEditingOperations.h"
+
+TEST(SceneEditingOperationsTests, DuplicateSelectedEntityCopiesTransformAndSpriteComponent)
+{
+    Xelqoria::Game::Scene scene;
+    auto& sourceEntity = scene.CreateEntity();
+    sourceEntity.GetTransform().SetPosition(12.0f, -8.0f, 1.0f);
+    sourceEntity.GetTransform().rotation = { 2.0f, 4.0f, 8.0f };
+    sourceEntity.GetTransform().scale = { 3.0f, 5.0f, 1.0f };
+    sourceEntity.SetSpriteComponent(Xelqoria::Game::SpriteComponent{
+        Xelqoria::Core::AssetId("sprites/player"),
+        {
+            true,
+            7,
+            0.5f
+        },
+        Xelqoria::Game::SpriteAssetReferenceState::Resolved,
+        {}
+    });
+
+    const auto expectedTransform = sourceEntity.GetTransform();
+    const auto expectedSpriteComponent = sourceEntity.GetSpriteComponent()->get();
+
+    const auto result =
+        Xelqoria::Editor::SceneEditingOperations::DuplicateSelectedEntity(scene, sourceEntity.GetId());
+
+    ASSERT_TRUE(result.changed);
+    ASSERT_TRUE(result.selectedEntityId.has_value());
+    ASSERT_NE(sourceEntity.GetId(), *result.selectedEntityId);
+    ASSERT_EQ(static_cast<std::size_t>(2), scene.GetEntityCount());
+
+    const auto duplicateEntity = scene.FindEntity(*result.selectedEntityId);
+    ASSERT_TRUE(duplicateEntity.has_value());
+
+    const auto& duplicateTransform = duplicateEntity->get().GetTransform();
+    EXPECT_FLOAT_EQ(expectedTransform.position.x, duplicateTransform.position.x);
+    EXPECT_FLOAT_EQ(expectedTransform.position.y, duplicateTransform.position.y);
+    EXPECT_FLOAT_EQ(expectedTransform.position.z, duplicateTransform.position.z);
+    EXPECT_FLOAT_EQ(expectedTransform.rotation.z, duplicateTransform.rotation.z);
+    EXPECT_FLOAT_EQ(expectedTransform.scale.y, duplicateTransform.scale.y);
+
+    const auto duplicateSpriteComponent = duplicateEntity->get().GetSpriteComponent();
+    ASSERT_TRUE(duplicateSpriteComponent.has_value());
+    EXPECT_EQ(expectedSpriteComponent.spriteAssetRef.GetValue(), duplicateSpriteComponent->get().spriteAssetRef.GetValue());
+    EXPECT_EQ(expectedSpriteComponent.renderSettings.sortOrder, duplicateSpriteComponent->get().renderSettings.sortOrder);
+    EXPECT_FLOAT_EQ(expectedSpriteComponent.renderSettings.opacity, duplicateSpriteComponent->get().renderSettings.opacity);
+}
+
+TEST(SceneEditingOperationsTests, DeleteSelectedEntityChoosesRemainingNeighbor)
+{
+    Xelqoria::Game::Scene scene;
+    const auto firstId = scene.CreateEntity().GetId();
+    const auto secondId = scene.CreateEntity().GetId();
+    const auto thirdId = scene.CreateEntity().GetId();
+
+    const auto result =
+        Xelqoria::Editor::SceneEditingOperations::DeleteSelectedEntity(scene, secondId);
+
+    ASSERT_TRUE(result.changed);
+    ASSERT_EQ(static_cast<std::size_t>(2), scene.GetEntityCount());
+    EXPECT_FALSE(scene.FindEntity(secondId).has_value());
+    ASSERT_TRUE(result.selectedEntityId.has_value());
+    EXPECT_EQ(thirdId, *result.selectedEntityId);
+    EXPECT_TRUE(scene.FindEntity(firstId).has_value());
+}
+
+TEST(SceneEditingOperationsTests, DeleteLastEntityClearsSelection)
+{
+    Xelqoria::Game::Scene scene;
+    const auto entityId = scene.CreateEntity().GetId();
+
+    const auto result =
+        Xelqoria::Editor::SceneEditingOperations::DeleteSelectedEntity(scene, entityId);
+
+    ASSERT_TRUE(result.changed);
+    EXPECT_EQ(static_cast<std::size_t>(0), scene.GetEntityCount());
+    EXPECT_FALSE(result.selectedEntityId.has_value());
+}

--- a/tests/Editor/Xelqoria.Tests.Editor.vcxproj
+++ b/tests/Editor/Xelqoria.Tests.Editor.vcxproj
@@ -20,10 +20,21 @@
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="Source\EditorCamera2DTests.cpp" />
+    <ClCompile Include="..\..\Editor\Source\SceneCommandHistory.cpp" />
+    <ClCompile Include="Source\SceneCommandHistoryTests.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\third_party\googletest\Xelqoria.GoogleTest.vcxproj">
       <Project>{0F71D759-12A2-42D9-B1CA-9F19C4E586C9}</Project>
+    </ProjectReference>
+    <ProjectReference Include="..\..\Core\Xelqoria.Core.vcxproj">
+      <Project>{79E8E826-7407-4766-B731-675CB84F6552}</Project>
+    </ProjectReference>
+    <ProjectReference Include="..\..\Game\Xelqoria.Game.vcxproj">
+      <Project>{B43E8E97-59EF-4CAA-8A27-BD9192D8833A}</Project>
+    </ProjectReference>
+    <ProjectReference Include="..\..\Graphics\Xelqoria.Graphics.vcxproj">
+      <Project>{7693792A-4AD4-445A-98F7-B90D6989A837}</Project>
     </ProjectReference>
   </ItemGroup>
   <PropertyGroup Label="Globals">
@@ -88,7 +99,7 @@
       <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <LanguageStandard>stdcpp20</LanguageStandard>
-      <AdditionalIncludeDirectories>$(RepoRootDir)Editor\Source;$(RepoRootDir)third_party\googletest\googletest\include;$(ProjectDir)Source;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(RepoRootDir)Core\Source;$(RepoRootDir)Game\Source;$(RepoRootDir)Graphics\Source;$(RepoRootDir)Editor\Source;$(RepoRootDir)third_party\googletest\googletest\include;$(ProjectDir)Source;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <AdditionalOptions>/utf-8 %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
@@ -108,7 +119,7 @@
       <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <LanguageStandard>stdcpp20</LanguageStandard>
-      <AdditionalIncludeDirectories>$(RepoRootDir)Editor\Source;$(RepoRootDir)third_party\googletest\googletest\include;$(ProjectDir)Source;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(RepoRootDir)Core\Source;$(RepoRootDir)Game\Source;$(RepoRootDir)Graphics\Source;$(RepoRootDir)Editor\Source;$(RepoRootDir)third_party\googletest\googletest\include;$(ProjectDir)Source;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <AdditionalOptions>/utf-8 %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
@@ -126,7 +137,7 @@
       <PreprocessorDefinitions>_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <LanguageStandard>stdcpp20</LanguageStandard>
-      <AdditionalIncludeDirectories>$(RepoRootDir)Editor\Source;$(RepoRootDir)third_party\googletest\googletest\include;$(ProjectDir)Source;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(RepoRootDir)Core\Source;$(RepoRootDir)Game\Source;$(RepoRootDir)Graphics\Source;$(RepoRootDir)Editor\Source;$(RepoRootDir)third_party\googletest\googletest\include;$(ProjectDir)Source;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <AdditionalOptions>/utf-8 %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
@@ -146,7 +157,7 @@
       <PreprocessorDefinitions>NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <LanguageStandard>stdcpp20</LanguageStandard>
-      <AdditionalIncludeDirectories>$(RepoRootDir)Editor\Source;$(RepoRootDir)third_party\googletest\googletest\include;$(ProjectDir)Source;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(RepoRootDir)Core\Source;$(RepoRootDir)Game\Source;$(RepoRootDir)Graphics\Source;$(RepoRootDir)Editor\Source;$(RepoRootDir)third_party\googletest\googletest\include;$(ProjectDir)Source;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <AdditionalOptions>/utf-8 %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>

--- a/tests/Editor/Xelqoria.Tests.Editor.vcxproj
+++ b/tests/Editor/Xelqoria.Tests.Editor.vcxproj
@@ -21,7 +21,9 @@
   <ItemGroup>
     <ClCompile Include="Source\EditorCamera2DTests.cpp" />
     <ClCompile Include="..\..\Editor\Source\SceneCommandHistory.cpp" />
+    <ClCompile Include="..\..\Editor\Source\SceneEditingOperations.cpp" />
     <ClCompile Include="Source\SceneCommandHistoryTests.cpp" />
+    <ClCompile Include="Source\SceneEditingOperationsTests.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\third_party\googletest\Xelqoria.GoogleTest.vcxproj">

--- a/tests/Game/Source/TransformTests.cpp
+++ b/tests/Game/Source/TransformTests.cpp
@@ -418,3 +418,88 @@ TEST(TransformTests, TransformAndSceneRuntimeApiWorks)
 		EXPECT_FALSE(spriteEntity.HasSpriteComponent());
 		EXPECT_FALSE(spriteEntity.GetSpriteComponent().has_value());
 }
+
+TEST(TransformTests, SceneSerializerRoundTripPreservesMultipleSpritePlacementsAndMissingRefs)
+{
+	Xelqoria::Game::Scene sourceScene;
+
+	auto& playerEntity = sourceScene.CreateEntity();
+	playerEntity.GetTransform().SetPosition(24.0f, -12.0f, 0.0f);
+	playerEntity.GetTransform().scale = { 1.5f, 1.5f, 1.0f };
+	playerEntity.SetSpriteComponent(Xelqoria::Game::SpriteComponent{
+		"sprites/player",
+		{
+			true,
+			1,
+			1.0f
+		}
+	});
+
+	auto& backgroundEntity = sourceScene.CreateEntity();
+	backgroundEntity.GetTransform().SetPosition(-320.0f, 180.0f, 0.0f);
+	backgroundEntity.GetTransform().scale = { 4.0f, 4.0f, 1.0f };
+	backgroundEntity.SetSpriteComponent(Xelqoria::Game::SpriteComponent{
+		"sprites/background",
+		{
+			true,
+			-5,
+			0.9f
+		}
+	});
+
+	auto& missingEntity = sourceScene.CreateEntity();
+	missingEntity.GetTransform().SetPosition(512.0f, 96.0f, 0.0f);
+	missingEntity.SetSpriteComponent(Xelqoria::Game::SpriteComponent{
+		"sprites/missing",
+		{
+			true,
+			3,
+			0.75f
+		}
+	});
+
+	const std::string serializedScene = Xelqoria::Game::SceneSerializer::SaveToText(sourceScene);
+	const auto loadResult = Xelqoria::Game::SceneSerializer::LoadFromText(serializedScene);
+	ASSERT_TRUE(loadResult.IsSuccess());
+	ASSERT_TRUE(loadResult.scene.has_value());
+
+	Xelqoria::Game::Scene loadedScene = *loadResult.scene;
+	EXPECT_EQ(static_cast<std::size_t>(3), loadedScene.GetEntityCount());
+	EXPECT_EQ(serializedScene, Xelqoria::Game::SceneSerializer::SaveToText(loadedScene));
+
+	auto playerTexture = std::make_shared<Xelqoria::Graphics::Texture2D>();
+	playerTexture->SetRHITexture(std::make_shared<FakeTexture>(64, 64));
+	auto backgroundTexture = std::make_shared<Xelqoria::Graphics::Texture2D>();
+	backgroundTexture->SetRHITexture(std::make_shared<FakeTexture>(512, 256));
+
+	Xelqoria::Game::Assets::SpriteAssetRegistry spriteAssetRegistry;
+	spriteAssetRegistry.RegisterSpriteAsset(
+		"sprites/player",
+		Xelqoria::Game::Assets::SpriteAsset{ "textures/player" });
+	spriteAssetRegistry.RegisterSpriteAsset(
+		"sprites/background",
+		Xelqoria::Game::Assets::SpriteAsset{ "textures/background" });
+
+	Xelqoria::Graphics::TextureAssetRegistry textureAssetRegistry;
+	textureAssetRegistry.RegisterTexture("textures/player", playerTexture);
+	textureAssetRegistry.RegisterTexture("textures/background", backgroundTexture);
+
+	loadedScene.ValidateSpriteReferences(spriteAssetRegistry);
+
+	const auto loadedMissingEntity = loadedScene.FindEntity(missingEntity.GetId());
+	ASSERT_TRUE(loadedMissingEntity.has_value());
+	const auto loadedMissingSpriteComponent = loadedMissingEntity->get().GetSpriteComponent();
+	ASSERT_TRUE(loadedMissingSpriteComponent.has_value());
+	EXPECT_EQ(Xelqoria::Game::SpriteAssetReferenceState::Missing, loadedMissingSpriteComponent->get().spriteAssetState);
+	EXPECT_EQ(Xelqoria::Core::AssetId("sprites/missing"), loadedMissingSpriteComponent->get().missingSpriteAssetRef);
+
+	const auto resolvedSprites = loadedScene.ResolveSprites(spriteAssetRegistry, textureAssetRegistry);
+	ASSERT_EQ(static_cast<std::size_t>(2), resolvedSprites.size());
+
+	EXPECT_EQ(Xelqoria::Core::AssetId("textures/player"), resolvedSprites[0].GetTextureAssetId());
+	EXPECT_EQ(Xelqoria::Core::AssetId("textures/background"), resolvedSprites[1].GetTextureAssetId());
+	EXPECT_TRUE(IsEqual(24.0f, resolvedSprites[0].GetPosition().x));
+	EXPECT_TRUE(IsEqual(-12.0f, resolvedSprites[0].GetPosition().y));
+	EXPECT_TRUE(IsEqual(-320.0f, resolvedSprites[1].GetPosition().x));
+	EXPECT_TRUE(IsEqual(180.0f, resolvedSprites[1].GetPosition().y));
+}


### PR DESCRIPTION
## Summary
- add a scene round-trip test that covers multiple sprite placements in one save/load cycle
- verify missing sprite references are still detected correctly after reload
- assert only resolvable sprites are emitted after validating the reloaded scene

## Testing
- '/mnt/c/Program Files/Microsoft Visual Studio/18/Community/MSBuild/Current/Bin/amd64/MSBuild.exe' Tests/Game/Xelqoria.Tests.Game.vcxproj /p:Configuration=Debug /p:Platform=x64 /p:PlatformToolset=v143
- '/mnt/d/github/Xelqoria/artifacts/x64/Debug/Xelqoria.Tests.Game.exe'

## Related
- Parent issue: #94
- Child issue: #104