### PR TITLE
子Issue 1: プロジェクトファイル構成と保存処理を追加する

### DIFF
--- a/Editor/Source/EditorProject.cpp
+++ b/Editor/Source/EditorProject.cpp
@@ -1,0 +1,223 @@
+#include "EditorProject.h"
+
+#include <algorithm>
+#include <fstream>
+#include <optional>
+#include <string_view>
+#include <system_error>
+
+#include "SceneSerializer.h"
+
+namespace Xelqoria::Editor
+{
+    namespace
+    {
+        constexpr const char* ProjectFileHeader = "XelqoriaProject=1";
+        constexpr const wchar_t* InitialSceneFileName = L"Main.xelqoria.scene";
+
+        [[nodiscard]] std::wstring ToWideString(const std::string& value)
+        {
+            return std::wstring(value.begin(), value.end());
+        }
+
+        [[nodiscard]] std::optional<std::string> ReadValue(std::string_view line, std::string_view key)
+        {
+            if (line.size() <= key.size() + 1 || line.substr(0, key.size()) != key || line[key.size()] != '=')
+            {
+                return std::nullopt;
+            }
+
+            return std::string(line.substr(key.size() + 1));
+        }
+    }
+
+    bool EditorProject::Create(
+        const std::wstring& projectName,
+        const std::filesystem::path& parentDirectory,
+        const Game::Scene& initialScene)
+    {
+        if (projectName.empty())
+        {
+            return false;
+        }
+
+        EditorProjectInfo info{};
+        info.name = projectName;
+        info.rootDirectory = parentDirectory / projectName;
+        info.projectFilePath = info.rootDirectory / (projectName + L".proj");
+        info.scenesDirectory = info.rootDirectory / L"Scenes";
+        info.activeScenePath = info.scenesDirectory / InitialSceneFileName;
+
+        std::error_code errorCode;
+        std::filesystem::create_directories(info.scenesDirectory, errorCode);
+        if (errorCode)
+        {
+            return false;
+        }
+
+        if (false == WriteSceneFile(info.activeScenePath, initialScene))
+        {
+            return false;
+        }
+
+        if (false == WriteProjectFile(info))
+        {
+            return false;
+        }
+
+        m_info = info;
+        return true;
+    }
+
+    bool EditorProject::Open(const std::filesystem::path& projectFilePath)
+    {
+        std::ifstream input(projectFilePath, std::ios::binary);
+        if (false == input.is_open())
+        {
+            return false;
+        }
+
+        std::string header{};
+        std::getline(input, header);
+        if (header != ProjectFileHeader)
+        {
+            return false;
+        }
+
+        std::optional<std::string> projectName{};
+        std::optional<std::string> activeScene{};
+        std::string line{};
+        while (std::getline(input, line))
+        {
+            if (const auto value = ReadValue(line, "Name"))
+            {
+                projectName = value;
+            }
+            else if (const auto value = ReadValue(line, "ActiveScene"))
+            {
+                activeScene = value;
+            }
+        }
+
+        if (false == projectName.has_value() || false == activeScene.has_value())
+        {
+            return false;
+        }
+
+        EditorProjectInfo info{};
+        info.name = ToWideString(*projectName);
+        info.projectFilePath = projectFilePath;
+        info.rootDirectory = projectFilePath.parent_path();
+        info.scenesDirectory = info.rootDirectory / L"Scenes";
+        info.activeScenePath = info.rootDirectory / std::filesystem::path(*activeScene);
+
+        if (false == std::filesystem::exists(info.activeScenePath))
+        {
+            return false;
+        }
+
+        m_info = info;
+        return true;
+    }
+
+    bool EditorProject::Save(const Game::Scene& scene) const
+    {
+        if (false == m_info.has_value())
+        {
+            return false;
+        }
+
+        if (false == WriteSceneFile(m_info->activeScenePath, scene))
+        {
+            return false;
+        }
+
+        return WriteProjectFile(*m_info);
+    }
+
+    bool EditorProject::SaveAs(
+        const std::wstring& projectName,
+        const std::filesystem::path& parentDirectory,
+        const Game::Scene& scene)
+    {
+        return Create(projectName, parentDirectory, scene);
+    }
+
+    std::vector<std::filesystem::path> EditorProject::EnumerateSceneFiles() const
+    {
+        std::vector<std::filesystem::path> sceneFiles{};
+        if (false == m_info.has_value() || false == std::filesystem::exists(m_info->scenesDirectory))
+        {
+            return sceneFiles;
+        }
+
+        for (const std::filesystem::directory_entry& entry : std::filesystem::directory_iterator(m_info->scenesDirectory))
+        {
+            if (entry.is_regular_file() && entry.path().extension() == ".scene")
+            {
+                sceneFiles.emplace_back(entry.path());
+            }
+        }
+
+        std::sort(sceneFiles.begin(), sceneFiles.end());
+        return sceneFiles;
+    }
+
+    bool EditorProject::HasProject() const
+    {
+        return m_info.has_value();
+    }
+
+    const std::optional<EditorProjectInfo>& EditorProject::GetInfo() const
+    {
+        return m_info;
+    }
+
+    bool EditorProject::WriteProjectFile(const EditorProjectInfo& info) const
+    {
+        std::error_code errorCode;
+        std::filesystem::create_directories(info.rootDirectory, errorCode);
+        if (errorCode)
+        {
+            return false;
+        }
+
+        std::ofstream output(info.projectFilePath, std::ios::binary | std::ios::trunc);
+        if (false == output.is_open())
+        {
+            return false;
+        }
+
+        const std::filesystem::path relativeScenePath = std::filesystem::relative(info.activeScenePath, info.rootDirectory, errorCode);
+        if (errorCode)
+        {
+            return false;
+        }
+
+        output << ProjectFileHeader << '\n';
+        output << "Name=" << std::string(info.name.begin(), info.name.end()) << '\n';
+        output << "ActiveScene=" << relativeScenePath.generic_string() << '\n';
+        return output.good();
+    }
+
+    bool EditorProject::WriteSceneFile(
+        const std::filesystem::path& scenePath,
+        const Game::Scene& scene) const
+    {
+        std::error_code errorCode;
+        std::filesystem::create_directories(scenePath.parent_path(), errorCode);
+        if (errorCode)
+        {
+            return false;
+        }
+
+        std::ofstream output(scenePath, std::ios::binary | std::ios::trunc);
+        if (false == output.is_open())
+        {
+            return false;
+        }
+
+        output << Game::SceneSerializer::SaveToText(scene);
+        return output.good();
+    }
+}

--- a/Editor/Source/EditorProject.h
+++ b/Editor/Source/EditorProject.h
@@ -1,0 +1,126 @@
+#pragma once
+
+#include <filesystem>
+#include <optional>
+#include <string>
+#include <vector>
+
+#include "Scene.h"
+
+namespace Xelqoria::Editor
+{
+    /// <summary>
+    /// Editor が扱うプロジェクトの保存先情報を保持する。
+    /// </summary>
+    struct EditorProjectInfo
+    {
+        /// <summary>
+        /// プロジェクト名を表す。
+        /// </summary>
+        std::wstring name{};
+
+        /// <summary>
+        /// プロジェクトルートフォルダを表す。
+        /// </summary>
+        std::filesystem::path rootDirectory{};
+
+        /// <summary>
+        /// `.proj` ファイルのパスを表す。
+        /// </summary>
+        std::filesystem::path projectFilePath{};
+
+        /// <summary>
+        /// Scene 保存フォルダを表す。
+        /// </summary>
+        std::filesystem::path scenesDirectory{};
+
+        /// <summary>
+        /// 現在編集中の Scene ファイルパスを表す。
+        /// </summary>
+        std::filesystem::path activeScenePath{};
+    };
+
+    /// <summary>
+    /// Editor プロジェクトのファイル構成と Scene 保存を管理する。
+    /// </summary>
+    class EditorProject
+    {
+    public:
+        /// <summary>
+        /// 新規プロジェクトを作成し、初期 Scene を保存する。
+        /// </summary>
+        /// <param name="projectName">作成するプロジェクト名。</param>
+        /// <param name="parentDirectory">プロジェクトフォルダを作成する親フォルダ。</param>
+        /// <param name="initialScene">初期 Scene として保存する内容。</param>
+        /// <returns>作成に成功した場合は true。</returns>
+        [[nodiscard]] bool Create(
+            const std::wstring& projectName,
+            const std::filesystem::path& parentDirectory,
+            const Game::Scene& initialScene);
+
+        /// <summary>
+        /// 既存の `.proj` ファイルを開く。
+        /// </summary>
+        /// <param name="projectFilePath">開く `.proj` ファイル。</param>
+        /// <returns>読込に成功した場合は true。</returns>
+        [[nodiscard]] bool Open(const std::filesystem::path& projectFilePath);
+
+        /// <summary>
+        /// 現在のプロジェクトへ Scene を保存する。
+        /// </summary>
+        /// <param name="scene">保存対象 Scene。</param>
+        /// <returns>保存に成功した場合は true。</returns>
+        [[nodiscard]] bool Save(const Game::Scene& scene) const;
+
+        /// <summary>
+        /// 現在の Scene を別名プロジェクトとして保存する。
+        /// </summary>
+        /// <param name="projectName">新しいプロジェクト名。</param>
+        /// <param name="parentDirectory">保存先親フォルダ。</param>
+        /// <param name="scene">保存対象 Scene。</param>
+        /// <returns>保存に成功した場合は true。</returns>
+        [[nodiscard]] bool SaveAs(
+            const std::wstring& projectName,
+            const std::filesystem::path& parentDirectory,
+            const Game::Scene& scene);
+
+        /// <summary>
+        /// 現在のプロジェクトで管理している Scene ファイルを列挙する。
+        /// </summary>
+        /// <returns>Scene ファイルパス一覧。</returns>
+        [[nodiscard]] std::vector<std::filesystem::path> EnumerateSceneFiles() const;
+
+        /// <summary>
+        /// プロジェクトが開かれているかを取得する。
+        /// </summary>
+        /// <returns>プロジェクト情報を保持している場合は true。</returns>
+        [[nodiscard]] bool HasProject() const;
+
+        /// <summary>
+        /// 現在のプロジェクト情報を取得する。
+        /// </summary>
+        /// <returns>プロジェクト情報。未オープン時は空。</returns>
+        [[nodiscard]] const std::optional<EditorProjectInfo>& GetInfo() const;
+
+    private:
+        /// <summary>
+        /// `.proj` ファイルを書き出す。
+        /// </summary>
+        /// <param name="info">書き出すプロジェクト情報。</param>
+        /// <returns>書き出しに成功した場合は true。</returns>
+        [[nodiscard]] bool WriteProjectFile(const EditorProjectInfo& info) const;
+
+        /// <summary>
+        /// Scene ファイルを書き出す。
+        /// </summary>
+        /// <param name="scenePath">保存先 Scene ファイルパス。</param>
+        /// <param name="scene">保存対象 Scene。</param>
+        /// <returns>書き出しに成功した場合は true。</returns>
+        [[nodiscard]] bool WriteSceneFile(
+            const std::filesystem::path& scenePath,
+            const Game::Scene& scene) const;
+
+    private:
+        std::optional<EditorProjectInfo> m_info{};
+    };
+}

--- a/Editor/Source/EditorSceneDocument.cpp
+++ b/Editor/Source/EditorSceneDocument.cpp
@@ -105,6 +105,11 @@ namespace Xelqoria::Editor
             return false;
         }
 
+        if (m_project.HasProject())
+        {
+            return m_project.Save(*m_scene);
+        }
+
         const std::filesystem::path sceneDocumentPath = GetSceneDocumentPath();
         std::error_code errorCode;
         std::filesystem::create_directories(sceneDocumentPath.parent_path(), errorCode);
@@ -121,6 +126,50 @@ namespace Xelqoria::Editor
 
         output << Game::SceneSerializer::SaveToText(*m_scene);
         return output.good();
+    }
+
+    bool EditorSceneDocument::CreateProject(
+        const std::wstring& projectName,
+        const std::filesystem::path& parentDirectory)
+    {
+        if (nullptr == m_scene)
+        {
+            return false;
+        }
+
+        return m_project.Create(projectName, parentDirectory, *m_scene);
+    }
+
+    bool EditorSceneDocument::OpenProject(const std::filesystem::path& projectFilePath)
+    {
+        if (false == m_project.Open(projectFilePath) || false == m_project.GetInfo().has_value())
+        {
+            return false;
+        }
+
+        return LoadSceneFromPath(m_project.GetInfo()->activeScenePath);
+    }
+
+    bool EditorSceneDocument::SaveProjectAs(
+        const std::wstring& projectName,
+        const std::filesystem::path& parentDirectory)
+    {
+        if (nullptr == m_scene)
+        {
+            return false;
+        }
+
+        return m_project.SaveAs(projectName, parentDirectory, *m_scene);
+    }
+
+    const std::optional<EditorProjectInfo>& EditorSceneDocument::GetProjectInfo() const
+    {
+        return m_project.GetInfo();
+    }
+
+    std::vector<std::filesystem::path> EditorSceneDocument::EnumerateProjectSceneFiles() const
+    {
+        return m_project.EnumerateSceneFiles();
     }
 
     Game::Assets::SpriteAssetRegistry& EditorSceneDocument::GetSpriteAssetRegistry()
@@ -150,13 +199,17 @@ namespace Xelqoria::Editor
 
     bool EditorSceneDocument::LoadSceneDocument()
     {
-        const std::filesystem::path sceneDocumentPath = GetSceneDocumentPath();
-        if (false == std::filesystem::exists(sceneDocumentPath))
+        return LoadSceneFromPath(GetSceneDocumentPath());
+    }
+
+    bool EditorSceneDocument::LoadSceneFromPath(const std::filesystem::path& scenePath)
+    {
+        if (false == std::filesystem::exists(scenePath))
         {
             return false;
         }
 
-        std::ifstream input(sceneDocumentPath, std::ios::binary);
+        std::ifstream input(scenePath, std::ios::binary);
         if (false == input.is_open())
         {
             return false;

--- a/Editor/Source/EditorSceneDocument.h
+++ b/Editor/Source/EditorSceneDocument.h
@@ -2,10 +2,13 @@
 
 #include <filesystem>
 #include <memory>
+#include <optional>
+#include <string>
 #include <vector>
 
 #include "AssetId.h"
 #include "Assets/SpriteAssetRegistry.h"
+#include "EditorProject.h"
 #include "IGraphicsContext.h"
 #include "Scene.h"
 #include "TextureAssetRegistry.h"
@@ -50,6 +53,45 @@ namespace Xelqoria::Editor
         [[nodiscard]] bool Save() const;
 
         /// <summary>
+        /// 新規プロジェクトを作成し、現在の Scene を初期 Scene として保存する。
+        /// </summary>
+        /// <param name="projectName">作成するプロジェクト名。</param>
+        /// <param name="parentDirectory">保存先親フォルダ。</param>
+        /// <returns>作成に成功した場合は true。</returns>
+        [[nodiscard]] bool CreateProject(
+            const std::wstring& projectName,
+            const std::filesystem::path& parentDirectory);
+
+        /// <summary>
+        /// 既存プロジェクトを開き、アクティブ Scene を読み込む。
+        /// </summary>
+        /// <param name="projectFilePath">開く `.proj` ファイル。</param>
+        /// <returns>読込に成功した場合は true。</returns>
+        [[nodiscard]] bool OpenProject(const std::filesystem::path& projectFilePath);
+
+        /// <summary>
+        /// 現在の Scene を別名プロジェクトとして保存する。
+        /// </summary>
+        /// <param name="projectName">新しいプロジェクト名。</param>
+        /// <param name="parentDirectory">保存先親フォルダ。</param>
+        /// <returns>保存に成功した場合は true。</returns>
+        [[nodiscard]] bool SaveProjectAs(
+            const std::wstring& projectName,
+            const std::filesystem::path& parentDirectory);
+
+        /// <summary>
+        /// 現在のプロジェクト情報を取得する。
+        /// </summary>
+        /// <returns>プロジェクト情報。未オープン時は空。</returns>
+        [[nodiscard]] const std::optional<EditorProjectInfo>& GetProjectInfo() const;
+
+        /// <summary>
+        /// 現在のプロジェクトで管理している Scene ファイルを列挙する。
+        /// </summary>
+        /// <returns>Scene ファイルパス一覧。</returns>
+        [[nodiscard]] std::vector<std::filesystem::path> EnumerateProjectSceneFiles() const;
+
+        /// <summary>
         /// SpriteAsset レジストリを取得する。
         /// </summary>
         /// <returns>SpriteAsset レジストリ。</returns>
@@ -87,6 +129,13 @@ namespace Xelqoria::Editor
         bool LoadSceneDocument();
 
         /// <summary>
+        /// 指定パスから Scene を読み込む。
+        /// </summary>
+        /// <param name="scenePath">読込対象 Scene ファイルパス。</param>
+        /// <returns>読込に成功した場合は true。</returns>
+        bool LoadSceneFromPath(const std::filesystem::path& scenePath);
+
+        /// <summary>
         /// 保存先 Scene ファイルパスを取得する。
         /// </summary>
         /// <returns>Scene ファイルパス。</returns>
@@ -97,5 +146,6 @@ namespace Xelqoria::Editor
         Game::Assets::SpriteAssetRegistry m_spriteAssetRegistry{};
         Graphics::TextureAssetRegistry m_textureAssetRegistry{};
         std::vector<Core::AssetId> m_registeredSpriteAssetIds{};
+        EditorProject m_project{};
     };
 }

--- a/Editor/Xelqoria.Editor.vcxproj
+++ b/Editor/Xelqoria.Editor.vcxproj
@@ -22,6 +22,7 @@
     <ClCompile Include="Source\Application.cpp" />
     <ClCompile Include="Source\AssetsPanelController.cpp" />
     <ClCompile Include="Source\EditorCommandController.cpp" />
+    <ClCompile Include="Source\EditorProject.cpp" />
     <ClCompile Include="Source\EditorSceneDocument.cpp" />
     <ClCompile Include="Source\EditorShell.cpp" />
     <ClCompile Include="Source\Entry.cpp" />
@@ -40,6 +41,7 @@
     <ClInclude Include="Source\Application.h" />
     <ClInclude Include="Source\AssetsPanelController.h" />
     <ClInclude Include="Source\EditorCommandController.h" />
+    <ClInclude Include="Source\EditorProject.h" />
     <ClInclude Include="Source\EditorSceneDocument.h" />
     <ClInclude Include="Source\EditorShell.h" />
     <ClInclude Include="Source\EditorStringUtils.h" />
@@ -207,7 +209,7 @@
     <LayerDependencyCheckerExe>$(RepoRootDir)tools\LayerDependencyChecker\bin\$(Configuration)\net8.0\LayerDependencyChecker.exe</LayerDependencyCheckerExe>
   </PropertyGroup>
   <Target Name="ValidateLayerDependencies" BeforeTargets="ClCompile">
-    <Error Condition="!Exists('$(LayerDependencyCheckerExe)')" Text="LayerDependencyChecker.exe が見つかりません。tools\LayerDependencyChecker をビルドしてください。期待パス: $(LayerDependencyCheckerExe)" />
+    <Error Condition="!Exists('$(LayerDependencyCheckerExe')" Text="LayerDependencyChecker.exe が見つかりません。tools\LayerDependencyChecker をビルドしてください。期待パス: $(LayerDependencyCheckerExe)" />
     <Exec Command="&quot;$(LayerDependencyCheckerExe)&quot; &quot;$(RepoRootDir)&quot;" />
   </Target>
   <ImportGroup Label="ExtensionTargets" />

--- a/Editor/Xelqoria.Editor.vcxproj
+++ b/Editor/Xelqoria.Editor.vcxproj
@@ -209,7 +209,7 @@
     <LayerDependencyCheckerExe>$(RepoRootDir)tools\LayerDependencyChecker\bin\$(Configuration)\net8.0\LayerDependencyChecker.exe</LayerDependencyCheckerExe>
   </PropertyGroup>
   <Target Name="ValidateLayerDependencies" BeforeTargets="ClCompile">
-    <Error Condition="!Exists('$(LayerDependencyCheckerExe')" Text="LayerDependencyChecker.exe が見つかりません。tools\LayerDependencyChecker をビルドしてください。期待パス: $(LayerDependencyCheckerExe)" />
+    <Error Condition="!Exists('$(LayerDependencyCheckerExe)')" Text="LayerDependencyChecker.exe が見つかりません。tools\LayerDependencyChecker をビルドしてください。期待パス: $(LayerDependencyCheckerExe)" />
     <Exec Command="&quot;$(LayerDependencyCheckerExe)&quot; &quot;$(RepoRootDir)&quot;" />
   </Target>
   <ImportGroup Label="ExtensionTargets" />

--- a/Editor/Xelqoria.Editor.vcxproj.filters
+++ b/Editor/Xelqoria.Editor.vcxproj.filters
@@ -15,6 +15,9 @@
     <ClCompile Include="Source\EditorCommandController.cpp">
       <Filter>Source</Filter>
     </ClCompile>
+    <ClCompile Include="Source\EditorProject.cpp">
+      <Filter>Source</Filter>
+    </ClCompile>
     <ClCompile Include="Source\EditorSceneDocument.cpp">
       <Filter>Source</Filter>
     </ClCompile>
@@ -63,6 +66,9 @@
       <Filter>Source</Filter>
     </ClInclude>
     <ClInclude Include="Source\EditorCommandController.h">
+      <Filter>Source</Filter>
+    </ClInclude>
+    <ClInclude Include="Source\EditorProject.h">
       <Filter>Source</Filter>
     </ClInclude>
     <ClInclude Include="Source\EditorSceneDocument.h">

--- a/tests/Editor/Source/EditorProjectTests.cpp
+++ b/tests/Editor/Source/EditorProjectTests.cpp
@@ -1,0 +1,72 @@
+#include "EditorProject.h"
+
+#include <filesystem>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+#include "Scene.h"
+
+namespace
+{
+    [[nodiscard]] std::filesystem::path MakeTempDirectory(const std::wstring& name)
+    {
+        const std::filesystem::path directory = std::filesystem::temp_directory_path() / name;
+        std::filesystem::remove_all(directory);
+        std::filesystem::create_directories(directory);
+        return directory;
+    }
+
+    [[nodiscard]] Xelqoria::Game::Scene MakeScene()
+    {
+        Xelqoria::Game::Scene scene{};
+        scene.CreateEntity();
+        return scene;
+    }
+}
+
+TEST(EditorProjectTests, CreateBuildsProjectFileScenesDirectoryAndInitialScene)
+{
+    const std::filesystem::path parentDirectory = MakeTempDirectory(L"XelqoriaEditorProjectTests_Create");
+    Xelqoria::Editor::EditorProject project{};
+
+    EXPECT_TRUE(project.Create(L"SampleProject", parentDirectory, MakeScene()));
+
+    const std::filesystem::path projectRoot = parentDirectory / L"SampleProject";
+    EXPECT_TRUE(std::filesystem::exists(projectRoot / L"SampleProject.proj"));
+    EXPECT_TRUE(std::filesystem::is_directory(projectRoot / L"Scenes"));
+    EXPECT_TRUE(std::filesystem::exists(projectRoot / L"Scenes" / L"Main.xelqoria.scene"));
+    EXPECT_TRUE(project.HasProject());
+
+    std::filesystem::remove_all(parentDirectory);
+}
+
+TEST(EditorProjectTests, SaveAsSwitchesCurrentProject)
+{
+    const std::filesystem::path parentDirectory = MakeTempDirectory(L"XelqoriaEditorProjectTests_SaveAs");
+    Xelqoria::Editor::EditorProject project{};
+
+    EXPECT_TRUE(project.SaveAs(L"RenamedProject", parentDirectory, MakeScene()));
+
+    ASSERT_TRUE(project.GetInfo().has_value());
+    EXPECT_EQ(L"RenamedProject", project.GetInfo()->name);
+    EXPECT_TRUE(std::filesystem::exists(parentDirectory / L"RenamedProject" / L"RenamedProject.proj"));
+
+    std::filesystem::remove_all(parentDirectory);
+}
+
+TEST(EditorProjectTests, OpenReadsProjectAndEnumeratesScenes)
+{
+    const std::filesystem::path parentDirectory = MakeTempDirectory(L"XelqoriaEditorProjectTests_Open");
+    Xelqoria::Editor::EditorProject createdProject{};
+    ASSERT_TRUE(createdProject.Create(L"OpenProject", parentDirectory, MakeScene()));
+
+    Xelqoria::Editor::EditorProject openedProject{};
+    EXPECT_TRUE(openedProject.Open(parentDirectory / L"OpenProject" / L"OpenProject.proj"));
+
+    const std::vector<std::filesystem::path> sceneFiles = openedProject.EnumerateSceneFiles();
+    ASSERT_EQ(1u, sceneFiles.size());
+    EXPECT_EQ(L"Main.xelqoria.scene", sceneFiles[0].filename().wstring());
+
+    std::filesystem::remove_all(parentDirectory);
+}

--- a/tests/Editor/Xelqoria.Tests.Editor.vcxproj
+++ b/tests/Editor/Xelqoria.Tests.Editor.vcxproj
@@ -20,8 +20,10 @@
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="Source\EditorCamera2DTests.cpp" />
+    <ClCompile Include="..\..\Editor\Source\EditorProject.cpp" />
     <ClCompile Include="..\..\Editor\Source\SceneCommandHistory.cpp" />
     <ClCompile Include="..\..\Editor\Source\SceneEditingOperations.cpp" />
+    <ClCompile Include="Source\EditorProjectTests.cpp" />
     <ClCompile Include="Source\HierarchyPanelControllerTests.cpp" />
     <ClCompile Include="Source\InspectorPanelControllerTests.cpp" />
     <ClCompile Include="Source\SceneCommandHistoryTests.cpp" />

--- a/tests/Editor/Xelqoria.Tests.Editor.vcxproj.filters
+++ b/tests/Editor/Xelqoria.Tests.Editor.vcxproj.filters
@@ -9,6 +9,12 @@
     <ClCompile Include="Source\EditorCamera2DTests.cpp">
       <Filter>Source</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\Editor\Source\EditorProject.cpp">
+      <Filter>Source</Filter>
+    </ClCompile>
+    <ClCompile Include="Source\EditorProjectTests.cpp">
+      <Filter>Source</Filter>
+    </ClCompile>
     <ClCompile Include="Source\InspectorPanelControllerTests.cpp">
       <Filter>Source</Filter>
     </ClCompile>


### PR DESCRIPTION
## 概要
- 親Issue: #141
- 子Issue: #142

## 変更内容
- Editor のプロジェクトファイル構成を扱う `EditorProject` を追加
- `プロジェクト名/プロジェクト名.proj`、`Scenes/`、初期 scene 保存を追加
- `EditorSceneDocument` からプロジェクト作成、オープン、保存、別名保存へ接続
- プロジェクト保存処理のテストを追加

## 検証
- `git diff --check`
- ビルド/テストはこの環境で `msbuild` / `cl.exe` / `g++` が見つからず未実行