### PR TITLE
子Issue 2: 起動時の初期画面と最近使ったプロジェクト一覧を追加する

### DIFF
--- a/Editor/Source/Application.cpp
+++ b/Editor/Source/Application.cpp
@@ -50,14 +50,31 @@ namespace Xelqoria::Editor
     {
         constexpr auto clientWidth = 1600u;
         constexpr auto clientHeight = 900u;
-        constexpr RHI::GraphicsAPI api = RHI::GraphicsAPI::D3D11;
 
-        std::wstring title = L"Xelqoria Editor - ";
-        title += RHI::GraphicsAPIToString(api);
+        const std::wstring title = L"Xelqoria Editor";
         if (false == m_window.Create(m_hInstance, title.c_str(), clientWidth, clientHeight))
         {
             return false;
         }
+
+        if (false == m_startupScreenController.Initialize(m_window.GetHwnd(), m_hInstance))
+        {
+            return false;
+        }
+
+        m_startupScreenController.UpdateLayout(m_window.GetHwnd());
+        m_window.Show();
+        return true;
+    }
+
+    bool Application::InitializeEditorWorkspace()
+    {
+        if (m_editorInitialized)
+        {
+            return true;
+        }
+
+        constexpr RHI::GraphicsAPI api = RHI::GraphicsAPI::D3D11;
 
         if (false == m_editorShell.Initialize(m_window.GetHwnd(), m_hInstance))
         {
@@ -76,8 +93,6 @@ namespace Xelqoria::Editor
                 m_editorShell.GetSceneViewWidth(),
                 m_editorShell.GetSceneViewHeight());
         }
-
-        m_window.Show();
 
         if (false == m_sceneViewRenderer.Initialize(
                 m_hInstance,
@@ -102,6 +117,47 @@ namespace Xelqoria::Editor
         RefreshEditorPanels(canAddSpriteComponent, false);
         RefreshSceneViewSelectionStatus();
         m_editorCommandController.Reset(m_sceneDocument, m_hierarchyPanelController.GetSelectedEntityId());
+        m_editorInitialized = true;
+        return true;
+    }
+
+    bool Application::EnterEditorWithNewProject()
+    {
+        if (false == InitializeEditorWorkspace())
+        {
+            return false;
+        }
+
+        if (false == m_sceneDocument.CreateProject(
+                m_startupScreenController.GetProjectName(),
+                m_startupScreenController.GetProjectParentDirectory()))
+        {
+            SetWindowTextW(m_editorShell.GetSceneViewPlanLabel(), L"プロジェクト作成に失敗しました。");
+            return false;
+        }
+
+        RecordCurrentProject();
+        m_startupScreenController.Hide();
+        return true;
+    }
+
+    bool Application::EnterEditorWithExistingProject()
+    {
+        if (false == InitializeEditorWorkspace())
+        {
+            return false;
+        }
+
+        if (false == m_sceneDocument.OpenProject(m_startupScreenController.GetOpenProjectFilePath()))
+        {
+            SetWindowTextW(m_editorShell.GetSceneViewPlanLabel(), L"プロジェクトを開けませんでした。");
+            return false;
+        }
+
+        RecordCurrentProject();
+        const bool canAddSpriteComponent = m_assetsPanelController.HasVisibleSpriteAssets();
+        ApplySelectionChange(std::nullopt, canAddSpriteComponent, true, true);
+        m_startupScreenController.Hide();
         return true;
     }
 
@@ -113,6 +169,28 @@ namespace Xelqoria::Editor
     void Application::Update(float deltaTime)
     {
         (void)deltaTime;
+
+        if (false == m_editorInitialized)
+        {
+            m_startupScreenController.UpdateLayout(m_window.GetHwnd());
+            m_startupScreenController.Update();
+            if (m_startupScreenController.HasCreateRequest())
+            {
+                if (EnterEditorWithNewProject())
+                {
+                    m_startupScreenController.ClearRequests();
+                }
+            }
+            else if (m_startupScreenController.HasOpenRequest())
+            {
+                if (EnterEditorWithExistingProject())
+                {
+                    m_startupScreenController.ClearRequests();
+                }
+            }
+
+            return;
+        }
 
         const bool sceneViewSizeChanged = m_editorShell.UpdateLayout(m_window.GetHwnd());
         if (true == sceneViewSizeChanged)
@@ -216,6 +294,11 @@ namespace Xelqoria::Editor
 
     void Application::Render()
     {
+        if (false == m_editorInitialized)
+        {
+            return;
+        }
+
         m_sceneViewRenderer.RenderFrame(
             m_sceneDocument.GetScene(),
             m_sceneDocument.GetSpriteAssetRegistry(),
@@ -278,5 +361,13 @@ namespace Xelqoria::Editor
 
         SetWindowTextW(m_editorShell.GetSceneViewPlanLabel(), failureMessage);
         return false;
+    }
+
+    void Application::RecordCurrentProject()
+    {
+        if (m_sceneDocument.GetProjectInfo().has_value())
+        {
+            m_recentProjectsStore.Record(*m_sceneDocument.GetProjectInfo());
+        }
     }
 }

--- a/Editor/Source/Application.h
+++ b/Editor/Source/Application.h
@@ -11,6 +11,8 @@
 #include "InspectorPanelController.h"
 #include "SceneViewController.h"
 #include "SceneViewRenderer.h"
+#include "StartupScreenController.h"
+#include "RecentProjectsStore.h"
 
 namespace Xelqoria::Editor
 {
@@ -48,6 +50,24 @@ namespace Xelqoria::Editor
         /// </summary>
         /// <returns>初期化に成功した場合は true。</returns>
         bool Initialize();
+
+        /// <summary>
+        /// Editor 本体画面を初期化する。
+        /// </summary>
+        /// <returns>初期化に成功した場合は true。</returns>
+        bool InitializeEditorWorkspace();
+
+        /// <summary>
+        /// 起動画面から新規プロジェクトを作成して Editor へ遷移する。
+        /// </summary>
+        /// <returns>遷移に成功した場合は true。</returns>
+        bool EnterEditorWithNewProject();
+
+        /// <summary>
+        /// 起動画面から既存プロジェクトを開いて Editor へ遷移する。
+        /// </summary>
+        /// <returns>遷移に成功した場合は true。</returns>
+        bool EnterEditorWithExistingProject();
 
         /// <summary>
         /// 終了時のクリーンアップを行う。
@@ -102,11 +122,19 @@ namespace Xelqoria::Editor
             const wchar_t* failureMessage,
             bool pushHistory);
 
+        /// <summary>
+        /// 現在のプロジェクトを最近使った一覧へ記録する。
+        /// </summary>
+        void RecordCurrentProject();
+
     private:
         HINSTANCE m_hInstance = nullptr;
         Core::Window m_window{};
         bool m_running = true;
+        bool m_editorInitialized = false;
         EditorShell m_editorShell{};
+        StartupScreenController m_startupScreenController{};
+        RecentProjectsStore m_recentProjectsStore{};
         EditorSceneDocument m_sceneDocument{};
         AssetsPanelController m_assetsPanelController{};
         HierarchyPanelController m_hierarchyPanelController{};

--- a/Editor/Source/RecentProjectsStore.cpp
+++ b/Editor/Source/RecentProjectsStore.cpp
@@ -1,0 +1,113 @@
+#include "RecentProjectsStore.h"
+
+#include <algorithm>
+#include <fstream>
+#include <string>
+#include <system_error>
+
+namespace Xelqoria::Editor
+{
+    namespace
+    {
+        constexpr std::size_t MaxRecentProjectCount = 5;
+
+        [[nodiscard]] std::wstring ToWideString(const std::string& value)
+        {
+            return std::wstring(value.begin(), value.end());
+        }
+
+        [[nodiscard]] std::string ToNarrowString(const std::wstring& value)
+        {
+            return std::string(value.begin(), value.end());
+        }
+    }
+
+    std::vector<EditorProjectInfo> RecentProjectsStore::Load() const
+    {
+        std::vector<EditorProjectInfo> projects{};
+        std::ifstream input(GetStorePath(), std::ios::binary);
+        if (false == input.is_open())
+        {
+            return projects;
+        }
+
+        std::string line{};
+        while (std::getline(input, line) && projects.size() < MaxRecentProjectCount)
+        {
+            const std::size_t separator = line.find('|');
+            if (separator == std::string::npos)
+            {
+                continue;
+            }
+
+            const std::wstring name = ToWideString(line.substr(0, separator));
+            const std::filesystem::path projectFilePath = ToWideString(line.substr(separator + 1));
+            if (false == std::filesystem::exists(projectFilePath))
+            {
+                continue;
+            }
+
+            EditorProjectInfo info{};
+            info.name = name;
+            info.projectFilePath = projectFilePath;
+            info.rootDirectory = projectFilePath.parent_path();
+            info.scenesDirectory = info.rootDirectory / L"Scenes";
+            projects.emplace_back(info);
+        }
+
+        return projects;
+    }
+
+    bool RecentProjectsStore::Record(const EditorProjectInfo& projectInfo) const
+    {
+        if (projectInfo.name.empty() || projectInfo.projectFilePath.empty())
+        {
+            return false;
+        }
+
+        std::vector<EditorProjectInfo> projects = Load();
+        projects.erase(
+            std::remove_if(
+                projects.begin(),
+                projects.end(),
+                [&projectInfo](const EditorProjectInfo& existingProject)
+                {
+                    return existingProject.projectFilePath == projectInfo.projectFilePath;
+                }),
+            projects.end());
+        projects.insert(projects.begin(), projectInfo);
+        if (projects.size() > MaxRecentProjectCount)
+        {
+            projects.resize(MaxRecentProjectCount);
+        }
+
+        const std::filesystem::path storePath = GetStorePath();
+        std::error_code errorCode;
+        std::filesystem::create_directories(storePath.parent_path(), errorCode);
+        if (errorCode)
+        {
+            return false;
+        }
+
+        std::ofstream output(storePath, std::ios::binary | std::ios::trunc);
+        if (false == output.is_open())
+        {
+            return false;
+        }
+
+        for (const EditorProjectInfo& project : projects)
+        {
+            output << ToNarrowString(project.name)
+                << '|'
+                << project.projectFilePath.generic_string()
+                << '\n';
+        }
+
+        return output.good();
+    }
+
+    std::filesystem::path RecentProjectsStore::GetStorePath() const
+    {
+        return std::filesystem::path("Saved") / "RecentProjects.txt";
+    }
+}

--- a/Editor/Source/RecentProjectsStore.h
+++ b/Editor/Source/RecentProjectsStore.h
@@ -1,0 +1,36 @@
+#pragma once
+
+#include <filesystem>
+#include <vector>
+
+#include "EditorProject.h"
+
+namespace Xelqoria::Editor
+{
+    /// <summary>
+    /// 最近使ったプロジェクト一覧の永続化を行う。
+    /// </summary>
+    class RecentProjectsStore
+    {
+    public:
+        /// <summary>
+        /// 最近使ったプロジェクト一覧を読み込む。
+        /// </summary>
+        /// <returns>存在する `.proj` のみを含むプロジェクト情報一覧。</returns>
+        [[nodiscard]] std::vector<EditorProjectInfo> Load() const;
+
+        /// <summary>
+        /// 指定プロジェクトを先頭へ記録する。
+        /// </summary>
+        /// <param name="projectInfo">記録するプロジェクト情報。</param>
+        /// <returns>保存に成功した場合は true。</returns>
+        [[nodiscard]] bool Record(const EditorProjectInfo& projectInfo) const;
+
+    private:
+        /// <summary>
+        /// 最近使ったプロジェクト一覧の保存先を取得する。
+        /// </summary>
+        /// <returns>保存先ファイルパス。</returns>
+        [[nodiscard]] std::filesystem::path GetStorePath() const;
+    };
+}

--- a/Editor/Source/StartupScreenController.cpp
+++ b/Editor/Source/StartupScreenController.cpp
@@ -1,0 +1,270 @@
+#include "StartupScreenController.h"
+
+#include <algorithm>
+#include <array>
+#include <commdlg.h>
+#include <cwchar>
+#include <shlobj.h>
+#include <string>
+
+namespace Xelqoria::Editor
+{
+    namespace
+    {
+        constexpr int CreateProjectButtonId = 4301;
+        constexpr int OpenProjectButtonId = 4302;
+        constexpr int BrowseFolderButtonId = 4303;
+
+        [[nodiscard]] std::wstring BuildRecentProjectLabel(const EditorProjectInfo& project)
+        {
+            return project.name + L" - " + project.projectFilePath.parent_path().wstring();
+        }
+    }
+
+    bool StartupScreenController::Initialize(HWND parentWindow, HINSTANCE hInstance)
+    {
+        m_defaultFont = static_cast<HFONT>(GetStockObject(DEFAULT_GUI_FONT));
+        m_titleLabel = CreateChildWindow(parentWindow, hInstance, L"Static", L"Xelqoria Editor", WS_CHILD | WS_VISIBLE);
+        m_nameLabel = CreateChildWindow(parentWindow, hInstance, L"Static", L"プロジェクト名", WS_CHILD | WS_VISIBLE);
+        m_projectNameEdit = CreateChildWindow(parentWindow, hInstance, L"Edit", L"NewProject", WS_CHILD | WS_VISIBLE | WS_BORDER | ES_AUTOHSCROLL);
+        m_folderLabel = CreateChildWindow(parentWindow, hInstance, L"Static", L"保存先フォルダ", WS_CHILD | WS_VISIBLE);
+        m_projectFolderEdit = CreateChildWindow(parentWindow, hInstance, L"Edit", L".", WS_CHILD | WS_VISIBLE | WS_BORDER | ES_AUTOHSCROLL);
+        m_browseFolderButton = CreateChildWindow(parentWindow, hInstance, L"Button", L"参照", WS_CHILD | WS_VISIBLE | BS_PUSHBUTTON);
+        m_createButton = CreateChildWindow(parentWindow, hInstance, L"Button", L"プロジェクト作成", WS_CHILD | WS_VISIBLE | BS_PUSHBUTTON);
+        m_openButton = CreateChildWindow(parentWindow, hInstance, L"Button", L"プロジェクトオープン", WS_CHILD | WS_VISIBLE | BS_PUSHBUTTON);
+        m_recentLabel = CreateChildWindow(parentWindow, hInstance, L"Static", L"最近使ったプロジェクト一覧", WS_CHILD | WS_VISIBLE);
+        m_recentListBox = CreateChildWindow(
+            parentWindow,
+            hInstance,
+            L"ListBox",
+            L"",
+            WS_CHILD | WS_VISIBLE | WS_VSCROLL | LBS_NOTIFY | LBS_NOINTEGRALHEIGHT | WS_BORDER);
+
+        if (nullptr == m_titleLabel
+            || nullptr == m_nameLabel
+            || nullptr == m_projectNameEdit
+            || nullptr == m_folderLabel
+            || nullptr == m_projectFolderEdit
+            || nullptr == m_browseFolderButton
+            || nullptr == m_createButton
+            || nullptr == m_openButton
+            || nullptr == m_recentLabel
+            || nullptr == m_recentListBox)
+        {
+            return false;
+        }
+
+        SetWindowLongPtrW(m_createButton, GWLP_ID, CreateProjectButtonId);
+        SetWindowLongPtrW(m_openButton, GWLP_ID, OpenProjectButtonId);
+        SetWindowLongPtrW(m_browseFolderButton, GWLP_ID, BrowseFolderButtonId);
+        RefreshRecentProjects();
+        return true;
+    }
+
+    void StartupScreenController::UpdateLayout(HWND parentWindow)
+    {
+        RECT clientRect{};
+        GetClientRect(parentWindow, &clientRect);
+        const int clientWidth = clientRect.right - clientRect.left;
+        const int clientHeight = clientRect.bottom - clientRect.top;
+        const int panelWidth = 520;
+        const int panelLeft = (std::max)(24, (clientWidth - panelWidth) / 2);
+        const int top = (std::max)(24, (clientHeight - 420) / 2);
+
+        MoveWindow(m_titleLabel, panelLeft, top, panelWidth, 36, TRUE);
+        MoveWindow(m_nameLabel, panelLeft, top + 56, 160, 24, TRUE);
+        MoveWindow(m_projectNameEdit, panelLeft + 160, top + 52, panelWidth - 160, 28, TRUE);
+        MoveWindow(m_folderLabel, panelLeft, top + 96, 160, 24, TRUE);
+        MoveWindow(m_projectFolderEdit, panelLeft + 160, top + 92, panelWidth - 238, 28, TRUE);
+        MoveWindow(m_browseFolderButton, panelLeft + panelWidth - 72, top + 92, 72, 28, TRUE);
+        MoveWindow(m_createButton, panelLeft, top + 140, 250, 32, TRUE);
+        MoveWindow(m_openButton, panelLeft + 270, top + 140, 250, 32, TRUE);
+        MoveWindow(m_recentLabel, panelLeft, top + 196, panelWidth, 24, TRUE);
+        MoveWindow(m_recentListBox, panelLeft, top + 224, panelWidth, 180, TRUE);
+    }
+
+    void StartupScreenController::Update()
+    {
+        const bool isLeftMouseDown = 0 != (GetAsyncKeyState(VK_LBUTTON) & 0x8000);
+        if (false == m_wasLeftMouseDown || isLeftMouseDown)
+        {
+            m_wasLeftMouseDown = isLeftMouseDown;
+            return;
+        }
+
+        m_wasLeftMouseDown = false;
+
+        POINT cursorPosition{};
+        GetCursorPos(&cursorPosition);
+        const HWND clickedWindow = WindowFromPoint(cursorPosition);
+        if (clickedWindow == m_createButton)
+        {
+            m_createRequested = true;
+            return;
+        }
+
+        if (clickedWindow == m_browseFolderButton)
+        {
+            BROWSEINFOW browseInfo{};
+            browseInfo.hwndOwner = GetParent(m_browseFolderButton);
+            browseInfo.lpszTitle = L"プロジェクトの保存先フォルダを選択";
+            browseInfo.ulFlags = BIF_RETURNONLYFSDIRS | BIF_NEWDIALOGSTYLE;
+
+            PIDLIST_ABSOLUTE itemList = SHBrowseForFolderW(&browseInfo);
+            if (nullptr != itemList)
+            {
+                std::array<wchar_t, MAX_PATH> folderPath{};
+                if (SHGetPathFromIDListW(itemList, folderPath.data()))
+                {
+                    SetWindowTextW(m_projectFolderEdit, folderPath.data());
+                }
+
+                CoTaskMemFree(itemList);
+            }
+
+            return;
+        }
+
+        if (clickedWindow == m_openButton)
+        {
+            const std::optional<EditorProjectInfo> selectedProject = GetSelectedRecentProject();
+            if (selectedProject.has_value())
+            {
+                m_openProjectFilePath = selectedProject->projectFilePath;
+                return;
+            }
+
+            std::array<wchar_t, MAX_PATH> filePath{};
+            OPENFILENAMEW openFileName{};
+            openFileName.lStructSize = sizeof(openFileName);
+            openFileName.hwndOwner = GetParent(m_openButton);
+            openFileName.lpstrFilter = L"Xelqoria Project (*.proj)\0*.proj\0All Files (*.*)\0*.*\0";
+            openFileName.lpstrFile = filePath.data();
+            openFileName.nMaxFile = static_cast<DWORD>(filePath.size());
+            openFileName.Flags = OFN_FILEMUSTEXIST | OFN_PATHMUSTEXIST;
+            if (GetOpenFileNameW(&openFileName))
+            {
+                m_openProjectFilePath = filePath.data();
+            }
+        }
+    }
+
+    void StartupScreenController::Hide()
+    {
+        std::array<HWND, 10> controls{
+            m_titleLabel,
+            m_nameLabel,
+            m_projectNameEdit,
+            m_folderLabel,
+            m_projectFolderEdit,
+            m_browseFolderButton,
+            m_createButton,
+            m_openButton,
+            m_recentLabel,
+            m_recentListBox
+        };
+
+        for (HWND control : controls)
+        {
+            ShowWindow(control, SW_HIDE);
+        }
+    }
+
+    bool StartupScreenController::HasCreateRequest() const
+    {
+        return m_createRequested;
+    }
+
+    bool StartupScreenController::HasOpenRequest() const
+    {
+        return false == m_openProjectFilePath.empty();
+    }
+
+    std::wstring StartupScreenController::GetProjectName() const
+    {
+        return GetText(m_projectNameEdit);
+    }
+
+    std::filesystem::path StartupScreenController::GetProjectParentDirectory() const
+    {
+        return std::filesystem::path(GetText(m_projectFolderEdit));
+    }
+
+    std::filesystem::path StartupScreenController::GetOpenProjectFilePath() const
+    {
+        return m_openProjectFilePath;
+    }
+
+    void StartupScreenController::ClearRequests()
+    {
+        m_createRequested = false;
+        m_openProjectFilePath.clear();
+    }
+
+    void StartupScreenController::RefreshRecentProjects()
+    {
+        m_recentProjects = m_recentProjectsStore.Load();
+        SendMessageW(m_recentListBox, LB_RESETCONTENT, 0, 0);
+        for (const EditorProjectInfo& project : m_recentProjects)
+        {
+            const std::wstring label = BuildRecentProjectLabel(project);
+            SendMessageW(m_recentListBox, LB_ADDSTRING, 0, reinterpret_cast<LPARAM>(label.c_str()));
+        }
+    }
+
+    std::optional<EditorProjectInfo> StartupScreenController::GetSelectedRecentProject() const
+    {
+        const LRESULT selectedIndex = SendMessageW(m_recentListBox, LB_GETCURSEL, 0, 0);
+        if (selectedIndex == LB_ERR || selectedIndex < 0)
+        {
+            return std::nullopt;
+        }
+
+        const auto index = static_cast<std::size_t>(selectedIndex);
+        if (index >= m_recentProjects.size())
+        {
+            return std::nullopt;
+        }
+
+        return m_recentProjects[index];
+    }
+
+    HWND StartupScreenController::CreateChildWindow(
+        HWND parentWindow,
+        HINSTANCE hInstance,
+        const wchar_t* className,
+        const wchar_t* text,
+        DWORD style,
+        DWORD exStyle) const
+    {
+        HWND handle = CreateWindowExW(
+            exStyle,
+            className,
+            text,
+            style,
+            0,
+            0,
+            0,
+            0,
+            parentWindow,
+            nullptr,
+            hInstance,
+            nullptr);
+
+        if (nullptr != handle && nullptr != m_defaultFont)
+        {
+            SendMessageW(handle, WM_SETFONT, reinterpret_cast<WPARAM>(m_defaultFont), TRUE);
+        }
+
+        return handle;
+    }
+
+    std::wstring StartupScreenController::GetText(HWND control) const
+    {
+        const int length = GetWindowTextLengthW(control);
+        std::wstring text(static_cast<std::size_t>(length) + 1u, L'\0');
+        GetWindowTextW(control, text.data(), length + 1);
+        text.resize(static_cast<std::size_t>(length));
+        return text;
+    }
+}

--- a/Editor/Source/StartupScreenController.h
+++ b/Editor/Source/StartupScreenController.h
@@ -1,0 +1,124 @@
+#pragma once
+
+#include <Windows.h>
+#include <filesystem>
+#include <optional>
+#include <vector>
+
+#include "EditorProject.h"
+#include "RecentProjectsStore.h"
+
+namespace Xelqoria::Editor
+{
+    /// <summary>
+    /// 起動時のプロジェクト選択画面を管理する。
+    /// </summary>
+    class StartupScreenController
+    {
+    public:
+        /// <summary>
+        /// 起動画面を初期化する。
+        /// </summary>
+        /// <param name="parentWindow">親ウィンドウ。</param>
+        /// <param name="hInstance">アプリケーションインスタンス。</param>
+        /// <returns>初期化に成功した場合は true。</returns>
+        bool Initialize(HWND parentWindow, HINSTANCE hInstance);
+
+        /// <summary>
+        /// 起動画面を現在のウィンドウサイズへ合わせる。
+        /// </summary>
+        /// <param name="parentWindow">親ウィンドウ。</param>
+        void UpdateLayout(HWND parentWindow);
+
+        /// <summary>
+        /// 入力状態を更新し、プロジェクト操作要求を検出する。
+        /// </summary>
+        void Update();
+
+        /// <summary>
+        /// 起動画面を非表示にする。
+        /// </summary>
+        void Hide();
+
+        /// <summary>
+        /// 新規作成要求があるかを取得する。
+        /// </summary>
+        /// <returns>新規作成要求がある場合は true。</returns>
+        [[nodiscard]] bool HasCreateRequest() const;
+
+        /// <summary>
+        /// 開く要求があるかを取得する。
+        /// </summary>
+        /// <returns>開く要求がある場合は true。</returns>
+        [[nodiscard]] bool HasOpenRequest() const;
+
+        /// <summary>
+        /// 入力されたプロジェクト名を取得する。
+        /// </summary>
+        /// <returns>プロジェクト名。</returns>
+        [[nodiscard]] std::wstring GetProjectName() const;
+
+        /// <summary>
+        /// 入力された保存先フォルダを取得する。
+        /// </summary>
+        /// <returns>保存先親フォルダ。</returns>
+        [[nodiscard]] std::filesystem::path GetProjectParentDirectory() const;
+
+        /// <summary>
+        /// 開く対象の `.proj` ファイルを取得する。
+        /// </summary>
+        /// <returns>開く対象パス。</returns>
+        [[nodiscard]] std::filesystem::path GetOpenProjectFilePath() const;
+
+        /// <summary>
+        /// 処理済み要求をクリアする。
+        /// </summary>
+        void ClearRequests();
+
+    private:
+        /// <summary>
+        /// 最近使ったプロジェクト一覧を再表示する。
+        /// </summary>
+        void RefreshRecentProjects();
+
+        /// <summary>
+        /// ListBox の選択行に対応するプロジェクトを取得する。
+        /// </summary>
+        /// <returns>選択中プロジェクト。未選択時は空。</returns>
+        [[nodiscard]] std::optional<EditorProjectInfo> GetSelectedRecentProject() const;
+
+        /// <summary>
+        /// 子ウィンドウを生成する。
+        /// </summary>
+        HWND CreateChildWindow(
+            HWND parentWindow,
+            HINSTANCE hInstance,
+            const wchar_t* className,
+            const wchar_t* text,
+            DWORD style,
+            DWORD exStyle = 0) const;
+
+        /// <summary>
+        /// Edit の文字列を取得する。
+        /// </summary>
+        [[nodiscard]] std::wstring GetText(HWND control) const;
+
+    private:
+        HFONT m_defaultFont = nullptr;
+        HWND m_titleLabel = nullptr;
+        HWND m_nameLabel = nullptr;
+        HWND m_projectNameEdit = nullptr;
+        HWND m_folderLabel = nullptr;
+        HWND m_projectFolderEdit = nullptr;
+        HWND m_browseFolderButton = nullptr;
+        HWND m_createButton = nullptr;
+        HWND m_openButton = nullptr;
+        HWND m_recentLabel = nullptr;
+        HWND m_recentListBox = nullptr;
+        RecentProjectsStore m_recentProjectsStore{};
+        std::vector<EditorProjectInfo> m_recentProjects{};
+        bool m_createRequested = false;
+        bool m_wasLeftMouseDown = false;
+        std::filesystem::path m_openProjectFilePath{};
+    };
+}

--- a/Editor/Xelqoria.Editor.vcxproj
+++ b/Editor/Xelqoria.Editor.vcxproj
@@ -28,6 +28,7 @@
     <ClCompile Include="Source\Entry.cpp" />
     <ClCompile Include="Source\HierarchyPanelController.cpp" />
     <ClCompile Include="Source\InspectorPanelController.cpp" />
+    <ClCompile Include="Source\RecentProjectsStore.cpp" />
     <ClCompile Include="Source\RenderBackendBootstrap.cpp" />
     <ClCompile Include="Source\SceneDropPlacementService.cpp" />
     <ClCompile Include="Source\SceneCommandHistory.cpp" />
@@ -36,6 +37,7 @@
     <ClCompile Include="Source\SceneViewInputTracker.cpp" />
     <ClCompile Include="Source\SceneViewRenderer.cpp" />
     <ClCompile Include="Source\SceneViewStatusPresenter.cpp" />
+    <ClCompile Include="Source\StartupScreenController.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="Source\Application.h" />
@@ -48,7 +50,9 @@
     <ClInclude Include="Source\EditorCamera2D.h" />
     <ClInclude Include="Source\HierarchyPanelController.h" />
     <ClInclude Include="Source\InspectorPanelController.h" />
+    <ClInclude Include="Source\RecentProjectsStore.h" />
     <ClInclude Include="Source\RenderBackendBootstrap.h" />
+    <ClInclude Include="Source\StartupScreenController.h" />
     <ClInclude Include="Source\SceneDropPlacementService.h" />
     <ClInclude Include="Source\SceneCommandHistory.h" />
     <ClInclude Include="Source\SceneEditingOperations.h" />
@@ -149,7 +153,7 @@
     <Link>
       <SubSystem>Windows</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalDependencies>d3d11.lib;dxgi.lib;dxguid.lib;d3d12.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>d3d11.lib;dxgi.lib;dxguid.lib;d3d12.lib;comdlg32.lib;shell32.lib;ole32.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
@@ -167,7 +171,7 @@
     <Link>
       <SubSystem>Windows</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalDependencies>d3d11.lib;dxgi.lib;dxguid.lib;d3d12.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>d3d11.lib;dxgi.lib;dxguid.lib;d3d12.lib;comdlg32.lib;shell32.lib;ole32.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
@@ -183,7 +187,7 @@
     <Link>
       <SubSystem>Windows</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalDependencies>d3d11.lib;dxgi.lib;dxguid.lib;d3d12.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>d3d11.lib;dxgi.lib;dxguid.lib;d3d12.lib;comdlg32.lib;shell32.lib;ole32.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
@@ -201,7 +205,7 @@
     <Link>
       <SubSystem>Windows</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalDependencies>d3d11.lib;dxgi.lib;dxguid.lib;d3d12.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>d3d11.lib;dxgi.lib;dxguid.lib;d3d12.lib;comdlg32.lib;shell32.lib;ole32.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />

--- a/Editor/Xelqoria.Editor.vcxproj.filters
+++ b/Editor/Xelqoria.Editor.vcxproj.filters
@@ -33,7 +33,13 @@
     <ClCompile Include="Source\InspectorPanelController.cpp">
       <Filter>Source</Filter>
     </ClCompile>
+    <ClCompile Include="Source\RecentProjectsStore.cpp">
+      <Filter>Source</Filter>
+    </ClCompile>
     <ClCompile Include="Source\RenderBackendBootstrap.cpp">
+      <Filter>Source</Filter>
+    </ClCompile>
+    <ClCompile Include="Source\StartupScreenController.cpp">
       <Filter>Source</Filter>
     </ClCompile>
     <ClCompile Include="Source\SceneDropPlacementService.cpp">
@@ -89,7 +95,13 @@
     <ClInclude Include="Source\InspectorPanelController.h">
       <Filter>Source</Filter>
     </ClInclude>
+    <ClInclude Include="Source\RecentProjectsStore.h">
+      <Filter>Source</Filter>
+    </ClInclude>
     <ClInclude Include="Source\RenderBackendBootstrap.h">
+      <Filter>Source</Filter>
+    </ClInclude>
+    <ClInclude Include="Source\StartupScreenController.h">
       <Filter>Source</Filter>
     </ClInclude>
     <ClInclude Include="Source\SceneDropPlacementService.h">

--- a/tests/Editor/Source/RecentProjectsStoreTests.cpp
+++ b/tests/Editor/Source/RecentProjectsStoreTests.cpp
@@ -1,0 +1,50 @@
+#include "RecentProjectsStore.h"
+
+#include <filesystem>
+#include <fstream>
+#include <string>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+namespace
+{
+    [[nodiscard]] std::filesystem::path MakeTempDirectory(const std::wstring& name)
+    {
+        const std::filesystem::path directory = std::filesystem::temp_directory_path() / name;
+        std::filesystem::remove_all(directory);
+        std::filesystem::create_directories(directory);
+        return directory;
+    }
+}
+
+TEST(RecentProjectsStoreTests, RecordKeepsMostRecentFiveExistingProjects)
+{
+    const std::filesystem::path originalCurrentPath = std::filesystem::current_path();
+    const std::filesystem::path tempDirectory = MakeTempDirectory(L"XelqoriaRecentProjectsStoreTests");
+    std::filesystem::current_path(tempDirectory);
+
+    Xelqoria::Editor::RecentProjectsStore store{};
+    for (int index = 0; index < 6; ++index)
+    {
+        const std::wstring projectName = L"Project" + std::to_wstring(index);
+        const std::filesystem::path projectRoot = tempDirectory / projectName;
+        std::filesystem::create_directories(projectRoot);
+        const std::filesystem::path projectFilePath = projectRoot / (projectName + L".proj");
+        std::ofstream(projectFilePath).put('\n');
+
+        Xelqoria::Editor::EditorProjectInfo info{};
+        info.name = projectName;
+        info.projectFilePath = projectFilePath;
+        info.rootDirectory = projectRoot;
+        EXPECT_TRUE(store.Record(info));
+    }
+
+    const std::vector<Xelqoria::Editor::EditorProjectInfo> projects = store.Load();
+    ASSERT_EQ(5u, projects.size());
+    EXPECT_EQ(L"Project5", projects[0].name);
+    EXPECT_EQ(L"Project1", projects[4].name);
+
+    std::filesystem::current_path(originalCurrentPath);
+    std::filesystem::remove_all(tempDirectory);
+}

--- a/tests/Editor/Xelqoria.Tests.Editor.vcxproj
+++ b/tests/Editor/Xelqoria.Tests.Editor.vcxproj
@@ -21,11 +21,13 @@
   <ItemGroup>
     <ClCompile Include="Source\EditorCamera2DTests.cpp" />
     <ClCompile Include="..\..\Editor\Source\EditorProject.cpp" />
+    <ClCompile Include="..\..\Editor\Source\RecentProjectsStore.cpp" />
     <ClCompile Include="..\..\Editor\Source\SceneCommandHistory.cpp" />
     <ClCompile Include="..\..\Editor\Source\SceneEditingOperations.cpp" />
     <ClCompile Include="Source\EditorProjectTests.cpp" />
     <ClCompile Include="Source\HierarchyPanelControllerTests.cpp" />
     <ClCompile Include="Source\InspectorPanelControllerTests.cpp" />
+    <ClCompile Include="Source\RecentProjectsStoreTests.cpp" />
     <ClCompile Include="Source\SceneCommandHistoryTests.cpp" />
     <ClCompile Include="Source\SceneEditingOperationsTests.cpp" />
   </ItemGroup>

--- a/tests/Editor/Xelqoria.Tests.Editor.vcxproj.filters
+++ b/tests/Editor/Xelqoria.Tests.Editor.vcxproj.filters
@@ -15,7 +15,13 @@
     <ClCompile Include="Source\EditorProjectTests.cpp">
       <Filter>Source</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\Editor\Source\RecentProjectsStore.cpp">
+      <Filter>Source</Filter>
+    </ClCompile>
     <ClCompile Include="Source\InspectorPanelControllerTests.cpp">
+      <Filter>Source</Filter>
+    </ClCompile>
+    <ClCompile Include="Source\RecentProjectsStoreTests.cpp">
       <Filter>Source</Filter>
     </ClCompile>
   </ItemGroup>


### PR DESCRIPTION
## 概要
- 親 Issue: #141
- 対応子 Issue: #143

## 変更内容
- Editor 起動時にプロジェクト作成/オープン用の初期画面を表示するようにしました。
- 最近使ったプロジェクト一覧を `Saved/RecentProjects.txt` に保存し、存在する `.proj` のみを一覧表示するようにしました。
- 新規作成/既存プロジェクトオープン後に Editor 本体へ遷移し、最近使った一覧へ記録するようにしました。
- `RecentProjectsStore` の単体テストを追加しました。

## 検証
- `git diff --check origin/issue-141..HEAD`

## 未実行
- ローカル環境に `msbuild` / `cl.exe` が見つからないため、Visual Studio ビルドと GoogleTest 実行は未実行です。