### PR TITLE
子Issue 4: ヘッダーのプロジェクトメニューと未保存確認を追加する

### DIFF
--- a/Core/Source/Window.cpp
+++ b/Core/Source/Window.cpp
@@ -1,5 +1,6 @@
 #include "Window.h"
 #include <Windows.h>
+#include <utility>
 
 namespace Xelqoria::Core
 {
@@ -87,6 +88,17 @@ namespace Xelqoria::Core
     { 
         return m_hWnd; 
     }
+
+    void Window::SetCommandHandler(std::function<void(unsigned)> handler)
+    {
+        m_commandHandler = std::move(handler);
+    }
+
+    void Window::SetCloseRequestHandler(std::function<bool()> handler)
+    {
+        m_closeRequestHandler = std::move(handler);
+    }
+
     uint32_t Window::GetWidth() const 
     { 
         return m_width;
@@ -123,7 +135,20 @@ namespace Xelqoria::Core
     {
         switch (msg) 
         {
+        case WM_COMMAND:
+            if (m_commandHandler)
+            {
+                m_commandHandler(LOWORD(wp));
+                return 0;
+            }
+            break;
+
         case WM_CLOSE:
+            if (m_closeRequestHandler && false == m_closeRequestHandler())
+            {
+                return 0;
+            }
+
             DestroyWindow(hWnd);
             return 0;
         
@@ -136,6 +161,11 @@ namespace Xelqoria::Core
         case WM_KEYDOWN:
             if (wp == VK_ESCAPE) 
             {
+                if (m_closeRequestHandler && false == m_closeRequestHandler())
+                {
+                    return 0;
+                }
+
                 DestroyWindow(hWnd);
                 return 0;
             }

--- a/Core/Source/Window.h
+++ b/Core/Source/Window.h
@@ -1,5 +1,6 @@
 #pragma once
 #include <Windows.h>
+#include <functional>
 #include <string>
 
 namespace Xelqoria::Core
@@ -46,6 +47,18 @@ namespace Xelqoria::Core
 		/// ウィンドウハンドルを取得する
 		[[nodiscard]] HWND GetHwnd() const;
 
+		/// <summary>
+		/// WM_COMMAND を受け取るハンドラを設定する。
+		/// </summary>
+		/// <param name="handler">コマンド ID を受け取るハンドラ。</param>
+		void SetCommandHandler(std::function<void(unsigned)> handler);
+
+		/// <summary>
+		/// ウィンドウを閉じる前に呼ばれるハンドラを設定する。
+		/// </summary>
+		/// <param name="handler">閉じてよい場合は true を返すハンドラ。</param>
+		void SetCloseRequestHandler(std::function<bool()> handler);
+
 		/// クライアント領域の幅を取得する
 		[[nodiscard]] uint32_t GetWidth() const;
 
@@ -66,6 +79,8 @@ namespace Xelqoria::Core
 
 		HINSTANCE m_hInstance = nullptr;
 		HWND m_hWnd = nullptr;
+		std::function<void(unsigned)> m_commandHandler{};
+		std::function<bool()> m_closeRequestHandler{};
 
 		std::wstring m_className = L"XelqoriaWindowClass";
 		std::wstring m_title = L"Xelqoria";

--- a/Editor/Source/Application.cpp
+++ b/Editor/Source/Application.cpp
@@ -1,12 +1,78 @@
 #include "Application.h"
 
+#include <array>
 #include <chrono>
+#include <commdlg.h>
+#include <filesystem>
+#include <shlobj.h>
 #include <string>
 
 #include "GraphicsAPI.h"
 
 namespace Xelqoria::Editor
 {
+    namespace
+    {
+        constexpr unsigned ProjectMenuCreateCommandId = 5101;
+        constexpr unsigned ProjectMenuSaveCommandId = 5102;
+        constexpr unsigned ProjectMenuSaveAsCommandId = 5103;
+        constexpr unsigned ProjectMenuOpenCommandId = 5104;
+        constexpr unsigned ProjectMenuSettingsCommandId = 5105;
+
+        [[nodiscard]] std::filesystem::path SelectProjectFile(HWND ownerWindow)
+        {
+            std::array<wchar_t, MAX_PATH> filePath{};
+            OPENFILENAMEW openFileName{};
+            openFileName.lStructSize = sizeof(openFileName);
+            openFileName.hwndOwner = ownerWindow;
+            openFileName.lpstrFilter = L"Xelqoria Project (*.proj)\0*.proj\0All Files (*.*)\0*.*\0";
+            openFileName.lpstrFile = filePath.data();
+            openFileName.nMaxFile = static_cast<DWORD>(filePath.size());
+            openFileName.Flags = OFN_FILEMUSTEXIST | OFN_PATHMUSTEXIST;
+            if (GetOpenFileNameW(&openFileName))
+            {
+                return filePath.data();
+            }
+
+            return {};
+        }
+
+        [[nodiscard]] std::filesystem::path SelectFolder(HWND ownerWindow, const wchar_t* title)
+        {
+            BROWSEINFOW browseInfo{};
+            browseInfo.hwndOwner = ownerWindow;
+            browseInfo.lpszTitle = title;
+            browseInfo.ulFlags = BIF_RETURNONLYFSDIRS | BIF_NEWDIALOGSTYLE;
+
+            PIDLIST_ABSOLUTE itemList = SHBrowseForFolderW(&browseInfo);
+            if (nullptr == itemList)
+            {
+                return {};
+            }
+
+            std::filesystem::path folderPath{};
+            std::array<wchar_t, MAX_PATH> selectedPath{};
+            if (SHGetPathFromIDListW(itemList, selectedPath.data()))
+            {
+                folderPath = selectedPath.data();
+            }
+
+            CoTaskMemFree(itemList);
+            return folderPath;
+        }
+
+        [[nodiscard]] std::wstring BuildNewProjectName(const std::filesystem::path& parentDirectory)
+        {
+            std::wstring projectName = L"NewProject";
+            for (int index = 1; std::filesystem::exists(parentDirectory / projectName); ++index)
+            {
+                projectName = L"NewProject" + std::to_wstring(index);
+            }
+
+            return projectName;
+        }
+    }
+
     Application::Application(HINSTANCE hInstance)
         : m_hInstance(hInstance)
     {
@@ -56,6 +122,18 @@ namespace Xelqoria::Editor
         {
             return false;
         }
+
+        InitializeProjectMenu();
+        m_window.SetCommandHandler(
+            [this](unsigned commandId)
+            {
+                HandleProjectMenuCommand(commandId);
+            });
+        m_window.SetCloseRequestHandler(
+            [this]()
+            {
+                return HandleCloseRequest();
+            });
 
         if (false == m_startupScreenController.Initialize(m_window.GetHwnd(), m_hInstance))
         {
@@ -122,6 +200,52 @@ namespace Xelqoria::Editor
         return true;
     }
 
+    void Application::InitializeProjectMenu()
+    {
+        m_projectMenu = CreatePopupMenu();
+        AppendMenuW(m_projectMenu, MF_STRING, ProjectMenuCreateCommandId, L"プロジェクトを作成する");
+        AppendMenuW(m_projectMenu, MF_STRING, ProjectMenuSaveCommandId, L"プロジェクトを保存する");
+        AppendMenuW(m_projectMenu, MF_STRING, ProjectMenuSaveAsCommandId, L"プロジェクトを別名で保存する");
+        AppendMenuW(m_projectMenu, MF_STRING, ProjectMenuOpenCommandId, L"プロジェクトを開く");
+        AppendMenuW(m_projectMenu, MF_STRING, ProjectMenuSettingsCommandId, L"プロジェクトの設定を開く");
+
+        HMENU menuBar = CreateMenu();
+        AppendMenuW(menuBar, MF_POPUP, reinterpret_cast<UINT_PTR>(m_projectMenu), L"プロジェクト");
+        SetMenu(m_window.GetHwnd(), menuBar);
+    }
+
+    void Application::HandleProjectMenuCommand(unsigned commandId)
+    {
+        switch (commandId)
+        {
+        case ProjectMenuCreateCommandId:
+            CreateProjectFromMenu();
+            break;
+        case ProjectMenuSaveCommandId:
+            SaveProjectFromMenu();
+            break;
+        case ProjectMenuSaveAsCommandId:
+            SaveProjectAsFromMenu();
+            break;
+        case ProjectMenuOpenCommandId:
+            OpenProjectFromMenu();
+            break;
+        case ProjectMenuSettingsCommandId:
+            if (m_editorInitialized)
+            {
+                SetWindowTextW(m_editorShell.GetSceneViewPlanLabel(), L"プロジェクト設定画面は未実装です。");
+            }
+            break;
+        default:
+            break;
+        }
+    }
+
+    bool Application::HandleCloseRequest()
+    {
+        return ConfirmSaveIfDirty();
+    }
+
     bool Application::EnterEditorWithNewProject()
     {
         if (false == InitializeEditorWorkspace())
@@ -139,6 +263,7 @@ namespace Xelqoria::Editor
 
         RecordCurrentProject();
         m_projectPanelController.Refresh(m_sceneDocument);
+        ClearProjectDirty();
         m_startupScreenController.Hide();
         return true;
     }
@@ -160,8 +285,157 @@ namespace Xelqoria::Editor
         const bool canAddSpriteComponent = m_assetsPanelController.HasVisibleSpriteAssets();
         m_projectPanelController.Refresh(m_sceneDocument);
         ApplySelectionChange(std::nullopt, canAddSpriteComponent, true, true);
+        ClearProjectDirty();
         m_startupScreenController.Hide();
         return true;
+    }
+
+    void Application::CreateProjectFromMenu()
+    {
+        if (false == ConfirmSaveIfDirty())
+        {
+            return;
+        }
+
+        if (false == InitializeEditorWorkspace())
+        {
+            return;
+        }
+
+        const std::filesystem::path parentDirectory = SelectFolder(m_window.GetHwnd(), L"プロジェクトの保存先フォルダを選択");
+        if (parentDirectory.empty())
+        {
+            return;
+        }
+
+        const std::wstring projectName = BuildNewProjectName(parentDirectory);
+        if (false == m_sceneDocument.CreateProject(projectName, parentDirectory))
+        {
+            SetWindowTextW(m_editorShell.GetSceneViewPlanLabel(), L"プロジェクト作成に失敗しました。");
+            return;
+        }
+
+        RecordCurrentProject();
+        m_projectPanelController.Refresh(m_sceneDocument);
+        ApplySelectionChange(std::nullopt, m_assetsPanelController.HasVisibleSpriteAssets(), true, true);
+        m_editorCommandController.Reset(m_sceneDocument, m_hierarchyPanelController.GetSelectedEntityId());
+        m_startupScreenController.Hide();
+        ClearProjectDirty();
+        SetWindowTextW(m_editorShell.GetSceneViewPlanLabel(), L"プロジェクトを作成しました。");
+    }
+
+    void Application::OpenProjectFromMenu()
+    {
+        if (false == ConfirmSaveIfDirty())
+        {
+            return;
+        }
+
+        if (false == InitializeEditorWorkspace())
+        {
+            return;
+        }
+
+        const std::filesystem::path projectFilePath = SelectProjectFile(m_window.GetHwnd());
+        if (projectFilePath.empty())
+        {
+            return;
+        }
+
+        if (false == m_sceneDocument.OpenProject(projectFilePath))
+        {
+            SetWindowTextW(m_editorShell.GetSceneViewPlanLabel(), L"プロジェクトを開けませんでした。");
+            return;
+        }
+
+        RecordCurrentProject();
+        m_projectPanelController.Refresh(m_sceneDocument);
+        ApplySelectionChange(std::nullopt, m_assetsPanelController.HasVisibleSpriteAssets(), true, true);
+        m_editorCommandController.Reset(m_sceneDocument, m_hierarchyPanelController.GetSelectedEntityId());
+        m_startupScreenController.Hide();
+        ClearProjectDirty();
+        SetWindowTextW(m_editorShell.GetSceneViewPlanLabel(), L"プロジェクトを開きました。");
+    }
+
+    bool Application::SaveProjectFromMenu()
+    {
+        if (false == m_editorInitialized)
+        {
+            return false;
+        }
+
+        if (false == m_sceneDocument.Save())
+        {
+            SetWindowTextW(m_editorShell.GetSceneViewPlanLabel(), L"プロジェクトの保存に失敗しました。");
+            return false;
+        }
+
+        m_editorCommandController.PushSnapshot(m_sceneDocument, m_hierarchyPanelController.GetSelectedEntityId());
+        m_projectPanelController.Refresh(m_sceneDocument);
+        ClearProjectDirty();
+        SetWindowTextW(m_editorShell.GetSceneViewPlanLabel(), L"プロジェクトを保存しました。");
+        return true;
+    }
+
+    void Application::SaveProjectAsFromMenu()
+    {
+        if (false == m_editorInitialized)
+        {
+            return;
+        }
+
+        const std::filesystem::path parentDirectory = SelectFolder(m_window.GetHwnd(), L"別名保存先フォルダを選択");
+        if (parentDirectory.empty())
+        {
+            return;
+        }
+
+        std::wstring projectName = L"NewProject";
+        if (m_sceneDocument.GetProjectInfo().has_value())
+        {
+            projectName = m_sceneDocument.GetProjectInfo()->name + L"_Copy";
+        }
+
+        if (false == m_sceneDocument.SaveProjectAs(projectName, parentDirectory))
+        {
+            SetWindowTextW(m_editorShell.GetSceneViewPlanLabel(), L"プロジェクトの別名保存に失敗しました。");
+            return;
+        }
+
+        RecordCurrentProject();
+        m_projectPanelController.Refresh(m_sceneDocument);
+        ClearProjectDirty();
+        SetWindowTextW(m_editorShell.GetSceneViewPlanLabel(), L"プロジェクトを別名で保存しました。");
+    }
+
+    bool Application::ConfirmSaveIfDirty()
+    {
+        if (false == m_projectDirty)
+        {
+            return true;
+        }
+
+        const int result = MessageBoxW(
+            m_window.GetHwnd(),
+            L"プロジェクトを保存しますか？",
+            L"保存確認",
+            MB_YESNO | MB_ICONQUESTION);
+        if (result == IDYES)
+        {
+            SaveProjectFromMenu();
+        }
+
+        return true;
+    }
+
+    void Application::MarkProjectDirty()
+    {
+        m_projectDirty = true;
+    }
+
+    void Application::ClearProjectDirty()
+    {
+        m_projectDirty = false;
     }
 
     void Application::Shutdown()
@@ -212,6 +486,7 @@ namespace Xelqoria::Editor
             const bool canAddSpriteComponentAfterSceneLoad = m_assetsPanelController.HasVisibleSpriteAssets();
             ApplySelectionChange(std::nullopt, canAddSpriteComponentAfterSceneLoad, true, true);
             m_editorCommandController.Reset(m_sceneDocument, m_hierarchyPanelController.GetSelectedEntityId());
+            MarkProjectDirty();
             SetWindowTextW(m_editorShell.GetSceneViewPlanLabel(), L"選択した Scene を読み込みました。");
         }
 
@@ -260,6 +535,7 @@ namespace Xelqoria::Editor
 
         if (true == interactionResult.sceneChanged)
         {
+            MarkProjectDirty();
             RefreshEditorPanels(canAddSpriteComponent, false);
             RefreshSceneViewSelectionStatus();
         }
@@ -299,6 +575,7 @@ namespace Xelqoria::Editor
             m_editorShell.GetSceneViewPlanLabel());
         if (true == commandResult.changed)
         {
+            MarkProjectDirty();
             ApplySelectionChange(commandResult.selectedEntityId, canAddSpriteComponent, true, true);
         }
     }
@@ -368,10 +645,12 @@ namespace Xelqoria::Editor
 
             SetWindowTextW(m_editorShell.GetSceneViewPlanLabel(), successMessage);
             m_projectPanelController.Refresh(m_sceneDocument);
+            ClearProjectDirty();
             return true;
         }
 
         SetWindowTextW(m_editorShell.GetSceneViewPlanLabel(), failureMessage);
+        MarkProjectDirty();
         return false;
     }
 

--- a/Editor/Source/Application.cpp
+++ b/Editor/Source/Application.cpp
@@ -50,14 +50,31 @@ namespace Xelqoria::Editor
     {
         constexpr auto clientWidth = 1600u;
         constexpr auto clientHeight = 900u;
-        constexpr RHI::GraphicsAPI api = RHI::GraphicsAPI::D3D11;
 
-        std::wstring title = L"Xelqoria Editor - ";
-        title += RHI::GraphicsAPIToString(api);
+        const std::wstring title = L"Xelqoria Editor";
         if (false == m_window.Create(m_hInstance, title.c_str(), clientWidth, clientHeight))
         {
             return false;
         }
+
+        if (false == m_startupScreenController.Initialize(m_window.GetHwnd(), m_hInstance))
+        {
+            return false;
+        }
+
+        m_startupScreenController.UpdateLayout(m_window.GetHwnd());
+        m_window.Show();
+        return true;
+    }
+
+    bool Application::InitializeEditorWorkspace()
+    {
+        if (m_editorInitialized)
+        {
+            return true;
+        }
+
+        constexpr RHI::GraphicsAPI api = RHI::GraphicsAPI::D3D11;
 
         if (false == m_editorShell.Initialize(m_window.GetHwnd(), m_hInstance))
         {
@@ -76,8 +93,6 @@ namespace Xelqoria::Editor
                 m_editorShell.GetSceneViewWidth(),
                 m_editorShell.GetSceneViewHeight());
         }
-
-        m_window.Show();
 
         if (false == m_sceneViewRenderer.Initialize(
                 m_hInstance,
@@ -102,6 +117,47 @@ namespace Xelqoria::Editor
         RefreshEditorPanels(canAddSpriteComponent, false);
         RefreshSceneViewSelectionStatus();
         m_editorCommandController.Reset(m_sceneDocument, m_hierarchyPanelController.GetSelectedEntityId());
+        m_editorInitialized = true;
+        return true;
+    }
+
+    bool Application::EnterEditorWithNewProject()
+    {
+        if (false == InitializeEditorWorkspace())
+        {
+            return false;
+        }
+
+        if (false == m_sceneDocument.CreateProject(
+                m_startupScreenController.GetProjectName(),
+                m_startupScreenController.GetProjectParentDirectory()))
+        {
+            SetWindowTextW(m_editorShell.GetSceneViewPlanLabel(), L"プロジェクト作成に失敗しました。");
+            return false;
+        }
+
+        RecordCurrentProject();
+        m_startupScreenController.Hide();
+        return true;
+    }
+
+    bool Application::EnterEditorWithExistingProject()
+    {
+        if (false == InitializeEditorWorkspace())
+        {
+            return false;
+        }
+
+        if (false == m_sceneDocument.OpenProject(m_startupScreenController.GetOpenProjectFilePath()))
+        {
+            SetWindowTextW(m_editorShell.GetSceneViewPlanLabel(), L"プロジェクトを開けませんでした。");
+            return false;
+        }
+
+        RecordCurrentProject();
+        const bool canAddSpriteComponent = m_assetsPanelController.HasVisibleSpriteAssets();
+        ApplySelectionChange(std::nullopt, canAddSpriteComponent, true, true);
+        m_startupScreenController.Hide();
         return true;
     }
 
@@ -113,6 +169,28 @@ namespace Xelqoria::Editor
     void Application::Update(float deltaTime)
     {
         (void)deltaTime;
+
+        if (false == m_editorInitialized)
+        {
+            m_startupScreenController.UpdateLayout(m_window.GetHwnd());
+            m_startupScreenController.Update();
+            if (m_startupScreenController.HasCreateRequest())
+            {
+                if (EnterEditorWithNewProject())
+                {
+                    m_startupScreenController.ClearRequests();
+                }
+            }
+            else if (m_startupScreenController.HasOpenRequest())
+            {
+                if (EnterEditorWithExistingProject())
+                {
+                    m_startupScreenController.ClearRequests();
+                }
+            }
+
+            return;
+        }
 
         const bool sceneViewSizeChanged = m_editorShell.UpdateLayout(m_window.GetHwnd());
         if (true == sceneViewSizeChanged)
@@ -216,6 +294,11 @@ namespace Xelqoria::Editor
 
     void Application::Render()
     {
+        if (false == m_editorInitialized)
+        {
+            return;
+        }
+
         m_sceneViewRenderer.RenderFrame(
             m_sceneDocument.GetScene(),
             m_sceneDocument.GetSpriteAssetRegistry(),
@@ -278,5 +361,13 @@ namespace Xelqoria::Editor
 
         SetWindowTextW(m_editorShell.GetSceneViewPlanLabel(), failureMessage);
         return false;
+    }
+
+    void Application::RecordCurrentProject()
+    {
+        if (m_sceneDocument.GetProjectInfo().has_value())
+        {
+            m_recentProjectsStore.Record(*m_sceneDocument.GetProjectInfo());
+        }
     }
 }

--- a/Editor/Source/Application.cpp
+++ b/Editor/Source/Application.cpp
@@ -84,6 +84,7 @@ namespace Xelqoria::Editor
         m_assetsPanelController.Bind(m_editorShell);
         m_hierarchyPanelController.Bind(m_editorShell);
         m_inspectorPanelController.Bind(m_editorShell);
+        m_projectPanelController.Bind(m_editorShell);
         m_sceneViewController.Bind(m_editorShell);
 
         const bool sceneViewSizeChanged = m_editorShell.UpdateLayout(m_window.GetHwnd());
@@ -137,6 +138,7 @@ namespace Xelqoria::Editor
         }
 
         RecordCurrentProject();
+        m_projectPanelController.Refresh(m_sceneDocument);
         m_startupScreenController.Hide();
         return true;
     }
@@ -156,6 +158,7 @@ namespace Xelqoria::Editor
 
         RecordCurrentProject();
         const bool canAddSpriteComponent = m_assetsPanelController.HasVisibleSpriteAssets();
+        m_projectPanelController.Refresh(m_sceneDocument);
         ApplySelectionChange(std::nullopt, canAddSpriteComponent, true, true);
         m_startupScreenController.Hide();
         return true;
@@ -204,6 +207,14 @@ namespace Xelqoria::Editor
         }
 
         m_assetsPanelController.SyncSelection();
+        if (true == m_projectPanelController.Update(m_sceneDocument))
+        {
+            const bool canAddSpriteComponentAfterSceneLoad = m_assetsPanelController.HasVisibleSpriteAssets();
+            ApplySelectionChange(std::nullopt, canAddSpriteComponentAfterSceneLoad, true, true);
+            m_editorCommandController.Reset(m_sceneDocument, m_hierarchyPanelController.GetSelectedEntityId());
+            SetWindowTextW(m_editorShell.GetSceneViewPlanLabel(), L"選択した Scene を読み込みました。");
+        }
+
         m_assetsPanelController.UpdateDragState();
         const bool canAddSpriteComponent = m_assetsPanelController.HasVisibleSpriteAssets();
 
@@ -356,6 +367,7 @@ namespace Xelqoria::Editor
             }
 
             SetWindowTextW(m_editorShell.GetSceneViewPlanLabel(), successMessage);
+            m_projectPanelController.Refresh(m_sceneDocument);
             return true;
         }
 

--- a/Editor/Source/Application.h
+++ b/Editor/Source/Application.h
@@ -11,6 +11,8 @@
 #include "InspectorPanelController.h"
 #include "SceneViewController.h"
 #include "SceneViewRenderer.h"
+#include "StartupScreenController.h"
+#include "RecentProjectsStore.h"
 
 namespace Xelqoria::Editor
 {
@@ -48,6 +50,24 @@ namespace Xelqoria::Editor
         /// </summary>
         /// <returns>初期化に成功した場合は true。</returns>
         bool Initialize();
+
+        /// <summary>
+        /// Editor 本体画面を初期化する。
+        /// </summary>
+        /// <returns>初期化に成功した場合は true。</returns>
+        bool InitializeEditorWorkspace();
+
+        /// <summary>
+        /// 起動画面から新規プロジェクトを作成して Editor へ遷移する。
+        /// </summary>
+        /// <returns>遷移に成功した場合は true。</returns>
+        bool EnterEditorWithNewProject();
+
+        /// <summary>
+        /// 起動画面から既存プロジェクトを開いて Editor へ遷移する。
+        /// </summary>
+        /// <returns>遷移に成功した場合は true。</returns>
+        bool EnterEditorWithExistingProject();
 
         /// <summary>
         /// 終了時のクリーンアップを行う。
@@ -102,11 +122,19 @@ namespace Xelqoria::Editor
             const wchar_t* failureMessage,
             bool pushHistory);
 
+        /// <summary>
+        /// 現在のプロジェクトを最近使った一覧へ記録する。
+        /// </summary>
+        void RecordCurrentProject();
+
     private:
         HINSTANCE m_hInstance = nullptr;
         Core::Window m_window{};
         bool m_running = true;
+        bool m_editorInitialized = false;
         EditorShell m_editorShell{};
+        StartupScreenController m_startupScreenController{};
+        RecentProjectsStore m_recentProjectsStore{};
         EditorSceneDocument m_sceneDocument{};
         AssetsPanelController m_assetsPanelController{};
         HierarchyPanelController m_hierarchyPanelController{};

--- a/Editor/Source/Application.h
+++ b/Editor/Source/Application.h
@@ -9,6 +9,7 @@
 #include "EditorShell.h"
 #include "HierarchyPanelController.h"
 #include "InspectorPanelController.h"
+#include "ProjectPanelController.h"
 #include "SceneViewController.h"
 #include "SceneViewRenderer.h"
 #include "StartupScreenController.h"
@@ -139,6 +140,7 @@ namespace Xelqoria::Editor
         AssetsPanelController m_assetsPanelController{};
         HierarchyPanelController m_hierarchyPanelController{};
         InspectorPanelController m_inspectorPanelController{};
+        ProjectPanelController m_projectPanelController{};
         SceneViewController m_sceneViewController{};
         SceneViewRenderer m_sceneViewRenderer{};
         EditorCommandController m_editorCommandController{};

--- a/Editor/Source/Application.h
+++ b/Editor/Source/Application.h
@@ -59,6 +59,23 @@ namespace Xelqoria::Editor
         bool InitializeEditorWorkspace();
 
         /// <summary>
+        /// ヘッダーのプロジェクトメニューを初期化する。
+        /// </summary>
+        void InitializeProjectMenu();
+
+        /// <summary>
+        /// プロジェクトメニューのコマンドを処理する。
+        /// </summary>
+        /// <param name="commandId">選択されたコマンド ID。</param>
+        void HandleProjectMenuCommand(unsigned commandId);
+
+        /// <summary>
+        /// 終了要求を処理する。
+        /// </summary>
+        /// <returns>終了を継続してよい場合は true。</returns>
+        bool HandleCloseRequest();
+
+        /// <summary>
         /// 起動画面から新規プロジェクトを作成して Editor へ遷移する。
         /// </summary>
         /// <returns>遷移に成功した場合は true。</returns>
@@ -69,6 +86,43 @@ namespace Xelqoria::Editor
         /// </summary>
         /// <returns>遷移に成功した場合は true。</returns>
         bool EnterEditorWithExistingProject();
+
+        /// <summary>
+        /// ヘッダー操作から新規プロジェクトを作成する。
+        /// </summary>
+        void CreateProjectFromMenu();
+
+        /// <summary>
+        /// ヘッダー操作から既存プロジェクトを開く。
+        /// </summary>
+        void OpenProjectFromMenu();
+
+        /// <summary>
+        /// 現在のプロジェクトを保存する。
+        /// </summary>
+        /// <returns>保存に成功した場合は true。</returns>
+        bool SaveProjectFromMenu();
+
+        /// <summary>
+        /// 現在のプロジェクトを別名で保存する。
+        /// </summary>
+        void SaveProjectAsFromMenu();
+
+        /// <summary>
+        /// 未保存変更があれば保存確認を表示する。
+        /// </summary>
+        /// <returns>後続操作を継続してよい場合は true。</returns>
+        bool ConfirmSaveIfDirty();
+
+        /// <summary>
+        /// Scene に未保存変更があることを記録する。
+        /// </summary>
+        void MarkProjectDirty();
+
+        /// <summary>
+        /// Scene の未保存変更が保存されたことを記録する。
+        /// </summary>
+        void ClearProjectDirty();
 
         /// <summary>
         /// 終了時のクリーンアップを行う。
@@ -133,6 +187,8 @@ namespace Xelqoria::Editor
         Core::Window m_window{};
         bool m_running = true;
         bool m_editorInitialized = false;
+        bool m_projectDirty = false;
+        HMENU m_projectMenu = nullptr;
         EditorShell m_editorShell{};
         StartupScreenController m_startupScreenController{};
         RecentProjectsStore m_recentProjectsStore{};

--- a/Editor/Source/EditorProject.cpp
+++ b/Editor/Source/EditorProject.cpp
@@ -143,6 +143,29 @@ namespace Xelqoria::Editor
         return Create(projectName, parentDirectory, scene);
     }
 
+    bool EditorProject::SelectSceneFile(const std::filesystem::path& scenePath)
+    {
+        if (false == m_info.has_value())
+        {
+            return false;
+        }
+
+        std::filesystem::path selectedScenePath = scenePath;
+        if (false == selectedScenePath.is_absolute())
+        {
+            selectedScenePath = m_info->rootDirectory / selectedScenePath;
+        }
+
+        if (false == std::filesystem::is_regular_file(selectedScenePath)
+            || selectedScenePath.extension() != ".scene")
+        {
+            return false;
+        }
+
+        m_info->activeScenePath = selectedScenePath;
+        return true;
+    }
+
     std::vector<std::filesystem::path> EditorProject::EnumerateSceneFiles() const
     {
         std::vector<std::filesystem::path> sceneFiles{};

--- a/Editor/Source/EditorProject.h
+++ b/Editor/Source/EditorProject.h
@@ -85,6 +85,13 @@ namespace Xelqoria::Editor
             const Game::Scene& scene);
 
         /// <summary>
+        /// 現在のプロジェクトで開く Scene ファイルを選択する。
+        /// </summary>
+        /// <param name="scenePath">選択する Scene ファイルパス。</param>
+        /// <returns>選択に成功した場合は true。</returns>
+        [[nodiscard]] bool SelectSceneFile(const std::filesystem::path& scenePath);
+
+        /// <summary>
         /// 現在のプロジェクトで管理している Scene ファイルを列挙する。
         /// </summary>
         /// <returns>Scene ファイルパス一覧。</returns>

--- a/Editor/Source/EditorSceneDocument.cpp
+++ b/Editor/Source/EditorSceneDocument.cpp
@@ -162,6 +162,16 @@ namespace Xelqoria::Editor
         return m_project.SaveAs(projectName, parentDirectory, *m_scene);
     }
 
+    bool EditorSceneDocument::OpenProjectScene(const std::filesystem::path& scenePath)
+    {
+        if (false == m_project.SelectSceneFile(scenePath))
+        {
+            return false;
+        }
+
+        return LoadSceneFromPath(scenePath);
+    }
+
     const std::optional<EditorProjectInfo>& EditorSceneDocument::GetProjectInfo() const
     {
         return m_project.GetInfo();

--- a/Editor/Source/EditorSceneDocument.h
+++ b/Editor/Source/EditorSceneDocument.h
@@ -80,6 +80,13 @@ namespace Xelqoria::Editor
             const std::filesystem::path& parentDirectory);
 
         /// <summary>
+        /// 現在のプロジェクト内 Scene を開く。
+        /// </summary>
+        /// <param name="scenePath">開く Scene ファイルパス。</param>
+        /// <returns>読込に成功した場合は true。</returns>
+        [[nodiscard]] bool OpenProjectScene(const std::filesystem::path& scenePath);
+
+        /// <summary>
         /// 現在のプロジェクト情報を取得する。
         /// </summary>
         /// <returns>プロジェクト情報。未オープン時は空。</returns>

--- a/Editor/Source/EditorShell.cpp
+++ b/Editor/Source/EditorShell.cpp
@@ -41,6 +41,8 @@ namespace Xelqoria::Editor
         int spriteSectionTop = 0;
         int spriteRefTop = 0;
         int sceneInnerWidth = 0;
+        int projectSceneListTop = 0;
+        int projectSceneListHeight = 0;
         int sceneHostHeight = 0;
     };
 
@@ -89,7 +91,16 @@ namespace Xelqoria::Editor
             metrics.transformSectionTop + metrics.labelHeight + 4 + 3 * (metrics.inspectorRowHeight + metrics.inspectorRowSpacing) + metrics.inspectorSectionSpacing;
         metrics.spriteRefTop = metrics.spriteSectionTop + metrics.labelHeight + 4;
         metrics.sceneInnerWidth = (std::max)(120, metrics.centerWidth - (metrics.outerPadding * 2));
-        metrics.sceneHostHeight = (std::max)(160, metrics.scenePanelHeight - metrics.groupHeaderHeight - metrics.labelHeight - (metrics.outerPadding * 3));
+        metrics.projectSceneListTop = metrics.outerPadding + metrics.groupHeaderHeight + (metrics.labelHeight * 2) + 8;
+        metrics.projectSceneListHeight = 96;
+        metrics.sceneHostHeight = (std::max)(
+            160,
+            metrics.scenePanelHeight
+                - metrics.groupHeaderHeight
+                - (metrics.labelHeight * 4)
+                - metrics.projectSceneListHeight
+                - (metrics.outerPadding * 3)
+                - metrics.panelSpacing);
 
         LayoutHierarchyPanel(metrics);
         LayoutAssetsPanel(metrics);
@@ -310,6 +321,39 @@ namespace Xelqoria::Editor
             return false;
         }
 
+        m_projectSummaryLabel = CreateChildWindow(
+            parentWindow,
+            hInstance,
+            L"Static",
+            L"Project: pending",
+            WS_CHILD | WS_VISIBLE);
+        if (nullptr == m_projectSummaryLabel)
+        {
+            return false;
+        }
+
+        m_projectSceneListBox = CreateChildWindow(
+            parentWindow,
+            hInstance,
+            L"ListBox",
+            L"",
+            WS_CHILD | WS_VISIBLE | WS_VSCROLL | LBS_NOTIFY | LBS_NOINTEGRALHEIGHT | WS_BORDER);
+        if (nullptr == m_projectSceneListBox)
+        {
+            return false;
+        }
+
+        m_projectSceneDetailLabel = CreateChildWindow(
+            parentWindow,
+            hInstance,
+            L"Static",
+            L"Scene: pending",
+            WS_CHILD | WS_VISIBLE);
+        if (nullptr == m_projectSceneDetailLabel)
+        {
+            return false;
+        }
+
         m_sceneViewHost = CreateChildWindow(
             parentWindow,
             hInstance,
@@ -482,16 +526,37 @@ namespace Xelqoria::Editor
             metrics.labelHeight,
             TRUE);
         MoveWindow(
+            m_projectSummaryLabel,
+            metrics.centerX + metrics.outerPadding,
+            metrics.outerPadding + metrics.groupHeaderHeight + metrics.labelHeight + 4,
+            metrics.sceneInnerWidth,
+            metrics.labelHeight,
+            TRUE);
+        MoveWindow(
+            m_projectSceneListBox,
+            metrics.centerX + metrics.outerPadding,
+            metrics.projectSceneListTop,
+            metrics.sceneInnerWidth,
+            metrics.projectSceneListHeight,
+            TRUE);
+        MoveWindow(
+            m_projectSceneDetailLabel,
+            metrics.centerX + metrics.outerPadding,
+            metrics.projectSceneListTop + metrics.projectSceneListHeight + 6,
+            metrics.sceneInnerWidth,
+            metrics.labelHeight,
+            TRUE);
+        MoveWindow(
             m_sceneViewHost,
             metrics.centerX + metrics.outerPadding,
-            metrics.outerPadding + metrics.groupHeaderHeight + metrics.labelHeight + metrics.panelSpacing,
+            metrics.projectSceneListTop + metrics.projectSceneListHeight + metrics.labelHeight + metrics.panelSpacing,
             metrics.sceneInnerWidth,
             metrics.sceneHostHeight,
             TRUE);
         MoveWindow(
             m_sceneViewSizeLabel,
             metrics.centerX + metrics.outerPadding,
-            metrics.outerPadding + metrics.groupHeaderHeight + metrics.labelHeight + metrics.panelSpacing + metrics.sceneHostHeight + 6,
+            metrics.projectSceneListTop + metrics.projectSceneListHeight + metrics.labelHeight + metrics.panelSpacing + metrics.sceneHostHeight + 6,
             metrics.sceneInnerWidth,
             metrics.labelHeight,
             TRUE);
@@ -611,6 +676,21 @@ namespace Xelqoria::Editor
     HWND EditorShell::GetSceneViewPlanLabel() const
     {
         return m_sceneViewPlanLabel;
+    }
+
+    HWND EditorShell::GetProjectSummaryLabel() const
+    {
+        return m_projectSummaryLabel;
+    }
+
+    HWND EditorShell::GetProjectSceneListBox() const
+    {
+        return m_projectSceneListBox;
+    }
+
+    HWND EditorShell::GetProjectSceneDetailLabel() const
+    {
+        return m_projectSceneDetailLabel;
     }
 
     HWND EditorShell::GetSceneViewHost() const

--- a/Editor/Source/EditorShell.h
+++ b/Editor/Source/EditorShell.h
@@ -136,6 +136,24 @@ namespace Xelqoria::Editor
         [[nodiscard]] HWND GetSceneViewPlanLabel() const;
 
         /// <summary>
+        /// プロジェクト概要ラベルを取得する。
+        /// </summary>
+        /// <returns>プロジェクト概要ラベルの HWND。</returns>
+        [[nodiscard]] HWND GetProjectSummaryLabel() const;
+
+        /// <summary>
+        /// プロジェクト内 Scene 一覧 ListBox を取得する。
+        /// </summary>
+        /// <returns>Scene 一覧 ListBox の HWND。</returns>
+        [[nodiscard]] HWND GetProjectSceneListBox() const;
+
+        /// <summary>
+        /// 選択 Scene 詳細ラベルを取得する。
+        /// </summary>
+        /// <returns>選択 Scene 詳細ラベルの HWND。</returns>
+        [[nodiscard]] HWND GetProjectSceneDetailLabel() const;
+
+        /// <summary>
         /// SceneView 描画先 child window を取得する。
         /// </summary>
         /// <returns>SceneView host の HWND。</returns>
@@ -231,6 +249,9 @@ namespace Xelqoria::Editor
         HWND m_inspectorPanel = nullptr;
         HWND m_sceneViewPanel = nullptr;
         HWND m_sceneViewPlanLabel = nullptr;
+        HWND m_projectSummaryLabel = nullptr;
+        HWND m_projectSceneListBox = nullptr;
+        HWND m_projectSceneDetailLabel = nullptr;
         HWND m_sceneViewHost = nullptr;
         HWND m_sceneViewSizeLabel = nullptr;
         HWND m_assetsListBox = nullptr;

--- a/Editor/Source/ProjectPanelController.cpp
+++ b/Editor/Source/ProjectPanelController.cpp
@@ -1,0 +1,116 @@
+#include "ProjectPanelController.h"
+
+#include <cstdio>
+#include <filesystem>
+#include <iterator>
+#include <string>
+
+namespace Xelqoria::Editor
+{
+    namespace
+    {
+        [[nodiscard]] std::wstring BuildSceneLabel(const std::filesystem::path& scenePath)
+        {
+            return scenePath.filename().wstring();
+        }
+    }
+
+    void ProjectPanelController::Bind(const EditorShell& shell)
+    {
+        m_projectSummaryLabel = shell.GetProjectSummaryLabel();
+        m_projectSceneListBox = shell.GetProjectSceneListBox();
+        m_projectSceneDetailLabel = shell.GetProjectSceneDetailLabel();
+    }
+
+    void ProjectPanelController::Refresh(const EditorSceneDocument& document)
+    {
+        m_sceneFiles = document.EnumerateProjectSceneFiles();
+        SendMessageW(m_projectSceneListBox, LB_RESETCONTENT, 0, 0);
+
+        for (const std::filesystem::path& scenePath : m_sceneFiles)
+        {
+            const std::wstring label = BuildSceneLabel(scenePath);
+            SendMessageW(m_projectSceneListBox, LB_ADDSTRING, 0, reinterpret_cast<LPARAM>(label.c_str()));
+        }
+
+        const auto& projectInfo = document.GetProjectInfo();
+        if (false == projectInfo.has_value())
+        {
+            m_selectedScenePath.clear();
+            SetWindowTextW(m_projectSummaryLabel, L"Project: not opened");
+            SetWindowTextW(m_projectSceneDetailLabel, L"Scene: not selected");
+            return;
+        }
+
+        m_selectedScenePath = projectInfo->activeScenePath;
+        int selectedIndex = LB_ERR;
+        for (std::size_t index = 0; index < m_sceneFiles.size(); ++index)
+        {
+            if (m_sceneFiles[index] == m_selectedScenePath)
+            {
+                selectedIndex = static_cast<int>(index);
+                break;
+            }
+        }
+
+        if (selectedIndex != LB_ERR)
+        {
+            SendMessageW(m_projectSceneListBox, LB_SETCURSEL, static_cast<WPARAM>(selectedIndex), 0);
+        }
+
+        const std::wstring summary =
+            L"Project: " + projectInfo->name
+            + L" / Scenes: " + std::to_wstring(m_sceneFiles.size())
+            + L" / Root: " + projectInfo->rootDirectory.wstring();
+        SetWindowTextW(m_projectSummaryLabel, summary.c_str());
+        RefreshSelectedSceneDetail(document);
+    }
+
+    bool ProjectPanelController::Update(EditorSceneDocument& document)
+    {
+        const LRESULT selectedIndex = SendMessageW(m_projectSceneListBox, LB_GETCURSEL, 0, 0);
+        if (selectedIndex == LB_ERR)
+        {
+            return false;
+        }
+
+        const auto index = static_cast<std::size_t>(selectedIndex);
+        if (index >= m_sceneFiles.size() || m_sceneFiles[index] == m_selectedScenePath)
+        {
+            return false;
+        }
+
+        const std::filesystem::path previousScenePath = m_selectedScenePath;
+        m_selectedScenePath = m_sceneFiles[index];
+        if (false == document.OpenProjectScene(m_selectedScenePath))
+        {
+            m_selectedScenePath = previousScenePath;
+            SetWindowTextW(m_projectSceneDetailLabel, L"Scene: 読み込みに失敗しました。");
+            return false;
+        }
+
+        Refresh(document);
+        return true;
+    }
+
+    void ProjectPanelController::RefreshSelectedSceneDetail(const EditorSceneDocument& document)
+    {
+        const Game::Scene* scene = document.GetScene();
+        const unsigned entityCount = nullptr != scene
+            ? static_cast<unsigned>(scene->GetEntities().size())
+            : 0u;
+
+        const std::wstring sceneName = m_selectedScenePath.empty()
+            ? std::wstring(L"not selected")
+            : m_selectedScenePath.filename().wstring();
+
+        wchar_t detailText[512]{};
+        std::swprintf(
+            detailText,
+            std::size(detailText),
+            L"Scene: %ls / Entities: %u",
+            sceneName.c_str(),
+            entityCount);
+        SetWindowTextW(m_projectSceneDetailLabel, detailText);
+    }
+}

--- a/Editor/Source/ProjectPanelController.h
+++ b/Editor/Source/ProjectPanelController.h
@@ -1,0 +1,51 @@
+#pragma once
+
+#include <Windows.h>
+#include <filesystem>
+#include <vector>
+
+#include "EditorSceneDocument.h"
+#include "EditorShell.h"
+
+namespace Xelqoria::Editor
+{
+    /// <summary>
+    /// 現在のプロジェクト内容と Scene 一覧の表示を管理する。
+    /// </summary>
+    class ProjectPanelController
+    {
+    public:
+        /// <summary>
+        /// EditorShell の HWND 群へ接続する。
+        /// </summary>
+        /// <param name="shell">接続先の EditorShell。</param>
+        void Bind(const EditorShell& shell);
+
+        /// <summary>
+        /// プロジェクト情報と Scene 一覧を再表示する。
+        /// </summary>
+        /// <param name="document">表示対象のドキュメント。</param>
+        void Refresh(const EditorSceneDocument& document);
+
+        /// <summary>
+        /// Scene 一覧の選択を監視し、選択 Scene を読み込む。
+        /// </summary>
+        /// <param name="document">更新対象のドキュメント。</param>
+        /// <returns>Scene が読み替えられた場合は true。</returns>
+        [[nodiscard]] bool Update(EditorSceneDocument& document);
+
+    private:
+        /// <summary>
+        /// 選択中 Scene の概要を表示する。
+        /// </summary>
+        /// <param name="document">表示対象のドキュメント。</param>
+        void RefreshSelectedSceneDetail(const EditorSceneDocument& document);
+
+    private:
+        HWND m_projectSummaryLabel = nullptr;
+        HWND m_projectSceneListBox = nullptr;
+        HWND m_projectSceneDetailLabel = nullptr;
+        std::vector<std::filesystem::path> m_sceneFiles{};
+        std::filesystem::path m_selectedScenePath{};
+    };
+}

--- a/Editor/Source/RecentProjectsStore.cpp
+++ b/Editor/Source/RecentProjectsStore.cpp
@@ -1,0 +1,113 @@
+#include "RecentProjectsStore.h"
+
+#include <algorithm>
+#include <fstream>
+#include <string>
+#include <system_error>
+
+namespace Xelqoria::Editor
+{
+    namespace
+    {
+        constexpr std::size_t MaxRecentProjectCount = 5;
+
+        [[nodiscard]] std::wstring ToWideString(const std::string& value)
+        {
+            return std::wstring(value.begin(), value.end());
+        }
+
+        [[nodiscard]] std::string ToNarrowString(const std::wstring& value)
+        {
+            return std::string(value.begin(), value.end());
+        }
+    }
+
+    std::vector<EditorProjectInfo> RecentProjectsStore::Load() const
+    {
+        std::vector<EditorProjectInfo> projects{};
+        std::ifstream input(GetStorePath(), std::ios::binary);
+        if (false == input.is_open())
+        {
+            return projects;
+        }
+
+        std::string line{};
+        while (std::getline(input, line) && projects.size() < MaxRecentProjectCount)
+        {
+            const std::size_t separator = line.find('|');
+            if (separator == std::string::npos)
+            {
+                continue;
+            }
+
+            const std::wstring name = ToWideString(line.substr(0, separator));
+            const std::filesystem::path projectFilePath = ToWideString(line.substr(separator + 1));
+            if (false == std::filesystem::exists(projectFilePath))
+            {
+                continue;
+            }
+
+            EditorProjectInfo info{};
+            info.name = name;
+            info.projectFilePath = projectFilePath;
+            info.rootDirectory = projectFilePath.parent_path();
+            info.scenesDirectory = info.rootDirectory / L"Scenes";
+            projects.emplace_back(info);
+        }
+
+        return projects;
+    }
+
+    bool RecentProjectsStore::Record(const EditorProjectInfo& projectInfo) const
+    {
+        if (projectInfo.name.empty() || projectInfo.projectFilePath.empty())
+        {
+            return false;
+        }
+
+        std::vector<EditorProjectInfo> projects = Load();
+        projects.erase(
+            std::remove_if(
+                projects.begin(),
+                projects.end(),
+                [&projectInfo](const EditorProjectInfo& existingProject)
+                {
+                    return existingProject.projectFilePath == projectInfo.projectFilePath;
+                }),
+            projects.end());
+        projects.insert(projects.begin(), projectInfo);
+        if (projects.size() > MaxRecentProjectCount)
+        {
+            projects.resize(MaxRecentProjectCount);
+        }
+
+        const std::filesystem::path storePath = GetStorePath();
+        std::error_code errorCode;
+        std::filesystem::create_directories(storePath.parent_path(), errorCode);
+        if (errorCode)
+        {
+            return false;
+        }
+
+        std::ofstream output(storePath, std::ios::binary | std::ios::trunc);
+        if (false == output.is_open())
+        {
+            return false;
+        }
+
+        for (const EditorProjectInfo& project : projects)
+        {
+            output << ToNarrowString(project.name)
+                << '|'
+                << project.projectFilePath.generic_string()
+                << '\n';
+        }
+
+        return output.good();
+    }
+
+    std::filesystem::path RecentProjectsStore::GetStorePath() const
+    {
+        return std::filesystem::path("Saved") / "RecentProjects.txt";
+    }
+}

--- a/Editor/Source/RecentProjectsStore.h
+++ b/Editor/Source/RecentProjectsStore.h
@@ -1,0 +1,36 @@
+#pragma once
+
+#include <filesystem>
+#include <vector>
+
+#include "EditorProject.h"
+
+namespace Xelqoria::Editor
+{
+    /// <summary>
+    /// 最近使ったプロジェクト一覧の永続化を行う。
+    /// </summary>
+    class RecentProjectsStore
+    {
+    public:
+        /// <summary>
+        /// 最近使ったプロジェクト一覧を読み込む。
+        /// </summary>
+        /// <returns>存在する `.proj` のみを含むプロジェクト情報一覧。</returns>
+        [[nodiscard]] std::vector<EditorProjectInfo> Load() const;
+
+        /// <summary>
+        /// 指定プロジェクトを先頭へ記録する。
+        /// </summary>
+        /// <param name="projectInfo">記録するプロジェクト情報。</param>
+        /// <returns>保存に成功した場合は true。</returns>
+        [[nodiscard]] bool Record(const EditorProjectInfo& projectInfo) const;
+
+    private:
+        /// <summary>
+        /// 最近使ったプロジェクト一覧の保存先を取得する。
+        /// </summary>
+        /// <returns>保存先ファイルパス。</returns>
+        [[nodiscard]] std::filesystem::path GetStorePath() const;
+    };
+}

--- a/Editor/Source/StartupScreenController.cpp
+++ b/Editor/Source/StartupScreenController.cpp
@@ -1,0 +1,270 @@
+#include "StartupScreenController.h"
+
+#include <algorithm>
+#include <array>
+#include <commdlg.h>
+#include <cwchar>
+#include <shlobj.h>
+#include <string>
+
+namespace Xelqoria::Editor
+{
+    namespace
+    {
+        constexpr int CreateProjectButtonId = 4301;
+        constexpr int OpenProjectButtonId = 4302;
+        constexpr int BrowseFolderButtonId = 4303;
+
+        [[nodiscard]] std::wstring BuildRecentProjectLabel(const EditorProjectInfo& project)
+        {
+            return project.name + L" - " + project.projectFilePath.parent_path().wstring();
+        }
+    }
+
+    bool StartupScreenController::Initialize(HWND parentWindow, HINSTANCE hInstance)
+    {
+        m_defaultFont = static_cast<HFONT>(GetStockObject(DEFAULT_GUI_FONT));
+        m_titleLabel = CreateChildWindow(parentWindow, hInstance, L"Static", L"Xelqoria Editor", WS_CHILD | WS_VISIBLE);
+        m_nameLabel = CreateChildWindow(parentWindow, hInstance, L"Static", L"プロジェクト名", WS_CHILD | WS_VISIBLE);
+        m_projectNameEdit = CreateChildWindow(parentWindow, hInstance, L"Edit", L"NewProject", WS_CHILD | WS_VISIBLE | WS_BORDER | ES_AUTOHSCROLL);
+        m_folderLabel = CreateChildWindow(parentWindow, hInstance, L"Static", L"保存先フォルダ", WS_CHILD | WS_VISIBLE);
+        m_projectFolderEdit = CreateChildWindow(parentWindow, hInstance, L"Edit", L".", WS_CHILD | WS_VISIBLE | WS_BORDER | ES_AUTOHSCROLL);
+        m_browseFolderButton = CreateChildWindow(parentWindow, hInstance, L"Button", L"参照", WS_CHILD | WS_VISIBLE | BS_PUSHBUTTON);
+        m_createButton = CreateChildWindow(parentWindow, hInstance, L"Button", L"プロジェクト作成", WS_CHILD | WS_VISIBLE | BS_PUSHBUTTON);
+        m_openButton = CreateChildWindow(parentWindow, hInstance, L"Button", L"プロジェクトオープン", WS_CHILD | WS_VISIBLE | BS_PUSHBUTTON);
+        m_recentLabel = CreateChildWindow(parentWindow, hInstance, L"Static", L"最近使ったプロジェクト一覧", WS_CHILD | WS_VISIBLE);
+        m_recentListBox = CreateChildWindow(
+            parentWindow,
+            hInstance,
+            L"ListBox",
+            L"",
+            WS_CHILD | WS_VISIBLE | WS_VSCROLL | LBS_NOTIFY | LBS_NOINTEGRALHEIGHT | WS_BORDER);
+
+        if (nullptr == m_titleLabel
+            || nullptr == m_nameLabel
+            || nullptr == m_projectNameEdit
+            || nullptr == m_folderLabel
+            || nullptr == m_projectFolderEdit
+            || nullptr == m_browseFolderButton
+            || nullptr == m_createButton
+            || nullptr == m_openButton
+            || nullptr == m_recentLabel
+            || nullptr == m_recentListBox)
+        {
+            return false;
+        }
+
+        SetWindowLongPtrW(m_createButton, GWLP_ID, CreateProjectButtonId);
+        SetWindowLongPtrW(m_openButton, GWLP_ID, OpenProjectButtonId);
+        SetWindowLongPtrW(m_browseFolderButton, GWLP_ID, BrowseFolderButtonId);
+        RefreshRecentProjects();
+        return true;
+    }
+
+    void StartupScreenController::UpdateLayout(HWND parentWindow)
+    {
+        RECT clientRect{};
+        GetClientRect(parentWindow, &clientRect);
+        const int clientWidth = clientRect.right - clientRect.left;
+        const int clientHeight = clientRect.bottom - clientRect.top;
+        const int panelWidth = 520;
+        const int panelLeft = (std::max)(24, (clientWidth - panelWidth) / 2);
+        const int top = (std::max)(24, (clientHeight - 420) / 2);
+
+        MoveWindow(m_titleLabel, panelLeft, top, panelWidth, 36, TRUE);
+        MoveWindow(m_nameLabel, panelLeft, top + 56, 160, 24, TRUE);
+        MoveWindow(m_projectNameEdit, panelLeft + 160, top + 52, panelWidth - 160, 28, TRUE);
+        MoveWindow(m_folderLabel, panelLeft, top + 96, 160, 24, TRUE);
+        MoveWindow(m_projectFolderEdit, panelLeft + 160, top + 92, panelWidth - 238, 28, TRUE);
+        MoveWindow(m_browseFolderButton, panelLeft + panelWidth - 72, top + 92, 72, 28, TRUE);
+        MoveWindow(m_createButton, panelLeft, top + 140, 250, 32, TRUE);
+        MoveWindow(m_openButton, panelLeft + 270, top + 140, 250, 32, TRUE);
+        MoveWindow(m_recentLabel, panelLeft, top + 196, panelWidth, 24, TRUE);
+        MoveWindow(m_recentListBox, panelLeft, top + 224, panelWidth, 180, TRUE);
+    }
+
+    void StartupScreenController::Update()
+    {
+        const bool isLeftMouseDown = 0 != (GetAsyncKeyState(VK_LBUTTON) & 0x8000);
+        if (false == m_wasLeftMouseDown || isLeftMouseDown)
+        {
+            m_wasLeftMouseDown = isLeftMouseDown;
+            return;
+        }
+
+        m_wasLeftMouseDown = false;
+
+        POINT cursorPosition{};
+        GetCursorPos(&cursorPosition);
+        const HWND clickedWindow = WindowFromPoint(cursorPosition);
+        if (clickedWindow == m_createButton)
+        {
+            m_createRequested = true;
+            return;
+        }
+
+        if (clickedWindow == m_browseFolderButton)
+        {
+            BROWSEINFOW browseInfo{};
+            browseInfo.hwndOwner = GetParent(m_browseFolderButton);
+            browseInfo.lpszTitle = L"プロジェクトの保存先フォルダを選択";
+            browseInfo.ulFlags = BIF_RETURNONLYFSDIRS | BIF_NEWDIALOGSTYLE;
+
+            PIDLIST_ABSOLUTE itemList = SHBrowseForFolderW(&browseInfo);
+            if (nullptr != itemList)
+            {
+                std::array<wchar_t, MAX_PATH> folderPath{};
+                if (SHGetPathFromIDListW(itemList, folderPath.data()))
+                {
+                    SetWindowTextW(m_projectFolderEdit, folderPath.data());
+                }
+
+                CoTaskMemFree(itemList);
+            }
+
+            return;
+        }
+
+        if (clickedWindow == m_openButton)
+        {
+            const std::optional<EditorProjectInfo> selectedProject = GetSelectedRecentProject();
+            if (selectedProject.has_value())
+            {
+                m_openProjectFilePath = selectedProject->projectFilePath;
+                return;
+            }
+
+            std::array<wchar_t, MAX_PATH> filePath{};
+            OPENFILENAMEW openFileName{};
+            openFileName.lStructSize = sizeof(openFileName);
+            openFileName.hwndOwner = GetParent(m_openButton);
+            openFileName.lpstrFilter = L"Xelqoria Project (*.proj)\0*.proj\0All Files (*.*)\0*.*\0";
+            openFileName.lpstrFile = filePath.data();
+            openFileName.nMaxFile = static_cast<DWORD>(filePath.size());
+            openFileName.Flags = OFN_FILEMUSTEXIST | OFN_PATHMUSTEXIST;
+            if (GetOpenFileNameW(&openFileName))
+            {
+                m_openProjectFilePath = filePath.data();
+            }
+        }
+    }
+
+    void StartupScreenController::Hide()
+    {
+        std::array<HWND, 10> controls{
+            m_titleLabel,
+            m_nameLabel,
+            m_projectNameEdit,
+            m_folderLabel,
+            m_projectFolderEdit,
+            m_browseFolderButton,
+            m_createButton,
+            m_openButton,
+            m_recentLabel,
+            m_recentListBox
+        };
+
+        for (HWND control : controls)
+        {
+            ShowWindow(control, SW_HIDE);
+        }
+    }
+
+    bool StartupScreenController::HasCreateRequest() const
+    {
+        return m_createRequested;
+    }
+
+    bool StartupScreenController::HasOpenRequest() const
+    {
+        return false == m_openProjectFilePath.empty();
+    }
+
+    std::wstring StartupScreenController::GetProjectName() const
+    {
+        return GetText(m_projectNameEdit);
+    }
+
+    std::filesystem::path StartupScreenController::GetProjectParentDirectory() const
+    {
+        return std::filesystem::path(GetText(m_projectFolderEdit));
+    }
+
+    std::filesystem::path StartupScreenController::GetOpenProjectFilePath() const
+    {
+        return m_openProjectFilePath;
+    }
+
+    void StartupScreenController::ClearRequests()
+    {
+        m_createRequested = false;
+        m_openProjectFilePath.clear();
+    }
+
+    void StartupScreenController::RefreshRecentProjects()
+    {
+        m_recentProjects = m_recentProjectsStore.Load();
+        SendMessageW(m_recentListBox, LB_RESETCONTENT, 0, 0);
+        for (const EditorProjectInfo& project : m_recentProjects)
+        {
+            const std::wstring label = BuildRecentProjectLabel(project);
+            SendMessageW(m_recentListBox, LB_ADDSTRING, 0, reinterpret_cast<LPARAM>(label.c_str()));
+        }
+    }
+
+    std::optional<EditorProjectInfo> StartupScreenController::GetSelectedRecentProject() const
+    {
+        const LRESULT selectedIndex = SendMessageW(m_recentListBox, LB_GETCURSEL, 0, 0);
+        if (selectedIndex == LB_ERR || selectedIndex < 0)
+        {
+            return std::nullopt;
+        }
+
+        const auto index = static_cast<std::size_t>(selectedIndex);
+        if (index >= m_recentProjects.size())
+        {
+            return std::nullopt;
+        }
+
+        return m_recentProjects[index];
+    }
+
+    HWND StartupScreenController::CreateChildWindow(
+        HWND parentWindow,
+        HINSTANCE hInstance,
+        const wchar_t* className,
+        const wchar_t* text,
+        DWORD style,
+        DWORD exStyle) const
+    {
+        HWND handle = CreateWindowExW(
+            exStyle,
+            className,
+            text,
+            style,
+            0,
+            0,
+            0,
+            0,
+            parentWindow,
+            nullptr,
+            hInstance,
+            nullptr);
+
+        if (nullptr != handle && nullptr != m_defaultFont)
+        {
+            SendMessageW(handle, WM_SETFONT, reinterpret_cast<WPARAM>(m_defaultFont), TRUE);
+        }
+
+        return handle;
+    }
+
+    std::wstring StartupScreenController::GetText(HWND control) const
+    {
+        const int length = GetWindowTextLengthW(control);
+        std::wstring text(static_cast<std::size_t>(length) + 1u, L'\0');
+        GetWindowTextW(control, text.data(), length + 1);
+        text.resize(static_cast<std::size_t>(length));
+        return text;
+    }
+}

--- a/Editor/Source/StartupScreenController.h
+++ b/Editor/Source/StartupScreenController.h
@@ -1,0 +1,124 @@
+#pragma once
+
+#include <Windows.h>
+#include <filesystem>
+#include <optional>
+#include <vector>
+
+#include "EditorProject.h"
+#include "RecentProjectsStore.h"
+
+namespace Xelqoria::Editor
+{
+    /// <summary>
+    /// 起動時のプロジェクト選択画面を管理する。
+    /// </summary>
+    class StartupScreenController
+    {
+    public:
+        /// <summary>
+        /// 起動画面を初期化する。
+        /// </summary>
+        /// <param name="parentWindow">親ウィンドウ。</param>
+        /// <param name="hInstance">アプリケーションインスタンス。</param>
+        /// <returns>初期化に成功した場合は true。</returns>
+        bool Initialize(HWND parentWindow, HINSTANCE hInstance);
+
+        /// <summary>
+        /// 起動画面を現在のウィンドウサイズへ合わせる。
+        /// </summary>
+        /// <param name="parentWindow">親ウィンドウ。</param>
+        void UpdateLayout(HWND parentWindow);
+
+        /// <summary>
+        /// 入力状態を更新し、プロジェクト操作要求を検出する。
+        /// </summary>
+        void Update();
+
+        /// <summary>
+        /// 起動画面を非表示にする。
+        /// </summary>
+        void Hide();
+
+        /// <summary>
+        /// 新規作成要求があるかを取得する。
+        /// </summary>
+        /// <returns>新規作成要求がある場合は true。</returns>
+        [[nodiscard]] bool HasCreateRequest() const;
+
+        /// <summary>
+        /// 開く要求があるかを取得する。
+        /// </summary>
+        /// <returns>開く要求がある場合は true。</returns>
+        [[nodiscard]] bool HasOpenRequest() const;
+
+        /// <summary>
+        /// 入力されたプロジェクト名を取得する。
+        /// </summary>
+        /// <returns>プロジェクト名。</returns>
+        [[nodiscard]] std::wstring GetProjectName() const;
+
+        /// <summary>
+        /// 入力された保存先フォルダを取得する。
+        /// </summary>
+        /// <returns>保存先親フォルダ。</returns>
+        [[nodiscard]] std::filesystem::path GetProjectParentDirectory() const;
+
+        /// <summary>
+        /// 開く対象の `.proj` ファイルを取得する。
+        /// </summary>
+        /// <returns>開く対象パス。</returns>
+        [[nodiscard]] std::filesystem::path GetOpenProjectFilePath() const;
+
+        /// <summary>
+        /// 処理済み要求をクリアする。
+        /// </summary>
+        void ClearRequests();
+
+    private:
+        /// <summary>
+        /// 最近使ったプロジェクト一覧を再表示する。
+        /// </summary>
+        void RefreshRecentProjects();
+
+        /// <summary>
+        /// ListBox の選択行に対応するプロジェクトを取得する。
+        /// </summary>
+        /// <returns>選択中プロジェクト。未選択時は空。</returns>
+        [[nodiscard]] std::optional<EditorProjectInfo> GetSelectedRecentProject() const;
+
+        /// <summary>
+        /// 子ウィンドウを生成する。
+        /// </summary>
+        HWND CreateChildWindow(
+            HWND parentWindow,
+            HINSTANCE hInstance,
+            const wchar_t* className,
+            const wchar_t* text,
+            DWORD style,
+            DWORD exStyle = 0) const;
+
+        /// <summary>
+        /// Edit の文字列を取得する。
+        /// </summary>
+        [[nodiscard]] std::wstring GetText(HWND control) const;
+
+    private:
+        HFONT m_defaultFont = nullptr;
+        HWND m_titleLabel = nullptr;
+        HWND m_nameLabel = nullptr;
+        HWND m_projectNameEdit = nullptr;
+        HWND m_folderLabel = nullptr;
+        HWND m_projectFolderEdit = nullptr;
+        HWND m_browseFolderButton = nullptr;
+        HWND m_createButton = nullptr;
+        HWND m_openButton = nullptr;
+        HWND m_recentLabel = nullptr;
+        HWND m_recentListBox = nullptr;
+        RecentProjectsStore m_recentProjectsStore{};
+        std::vector<EditorProjectInfo> m_recentProjects{};
+        bool m_createRequested = false;
+        bool m_wasLeftMouseDown = false;
+        std::filesystem::path m_openProjectFilePath{};
+    };
+}

--- a/Editor/Xelqoria.Editor.vcxproj
+++ b/Editor/Xelqoria.Editor.vcxproj
@@ -28,6 +28,7 @@
     <ClCompile Include="Source\Entry.cpp" />
     <ClCompile Include="Source\HierarchyPanelController.cpp" />
     <ClCompile Include="Source\InspectorPanelController.cpp" />
+    <ClCompile Include="Source\RecentProjectsStore.cpp" />
     <ClCompile Include="Source\RenderBackendBootstrap.cpp" />
     <ClCompile Include="Source\SceneDropPlacementService.cpp" />
     <ClCompile Include="Source\SceneCommandHistory.cpp" />
@@ -36,6 +37,7 @@
     <ClCompile Include="Source\SceneViewInputTracker.cpp" />
     <ClCompile Include="Source\SceneViewRenderer.cpp" />
     <ClCompile Include="Source\SceneViewStatusPresenter.cpp" />
+    <ClCompile Include="Source\StartupScreenController.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="Source\Application.h" />
@@ -48,7 +50,9 @@
     <ClInclude Include="Source\EditorCamera2D.h" />
     <ClInclude Include="Source\HierarchyPanelController.h" />
     <ClInclude Include="Source\InspectorPanelController.h" />
+    <ClInclude Include="Source\RecentProjectsStore.h" />
     <ClInclude Include="Source\RenderBackendBootstrap.h" />
+    <ClInclude Include="Source\StartupScreenController.h" />
     <ClInclude Include="Source\SceneDropPlacementService.h" />
     <ClInclude Include="Source\SceneCommandHistory.h" />
     <ClInclude Include="Source\SceneEditingOperations.h" />
@@ -149,7 +153,7 @@
     <Link>
       <SubSystem>Windows</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalDependencies>d3d11.lib;dxgi.lib;dxguid.lib;d3d12.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>d3d11.lib;dxgi.lib;dxguid.lib;d3d12.lib;comdlg32.lib;shell32.lib;ole32.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
@@ -167,7 +171,7 @@
     <Link>
       <SubSystem>Windows</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalDependencies>d3d11.lib;dxgi.lib;dxguid.lib;d3d12.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>d3d11.lib;dxgi.lib;dxguid.lib;d3d12.lib;comdlg32.lib;shell32.lib;ole32.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
@@ -183,7 +187,7 @@
     <Link>
       <SubSystem>Windows</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalDependencies>d3d11.lib;dxgi.lib;dxguid.lib;d3d12.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>d3d11.lib;dxgi.lib;dxguid.lib;d3d12.lib;comdlg32.lib;shell32.lib;ole32.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
@@ -201,7 +205,7 @@
     <Link>
       <SubSystem>Windows</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalDependencies>d3d11.lib;dxgi.lib;dxguid.lib;d3d12.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>d3d11.lib;dxgi.lib;dxguid.lib;d3d12.lib;comdlg32.lib;shell32.lib;ole32.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />

--- a/Editor/Xelqoria.Editor.vcxproj
+++ b/Editor/Xelqoria.Editor.vcxproj
@@ -28,6 +28,7 @@
     <ClCompile Include="Source\Entry.cpp" />
     <ClCompile Include="Source\HierarchyPanelController.cpp" />
     <ClCompile Include="Source\InspectorPanelController.cpp" />
+    <ClCompile Include="Source\ProjectPanelController.cpp" />
     <ClCompile Include="Source\RecentProjectsStore.cpp" />
     <ClCompile Include="Source\RenderBackendBootstrap.cpp" />
     <ClCompile Include="Source\SceneDropPlacementService.cpp" />
@@ -50,6 +51,7 @@
     <ClInclude Include="Source\EditorCamera2D.h" />
     <ClInclude Include="Source\HierarchyPanelController.h" />
     <ClInclude Include="Source\InspectorPanelController.h" />
+    <ClInclude Include="Source\ProjectPanelController.h" />
     <ClInclude Include="Source\RecentProjectsStore.h" />
     <ClInclude Include="Source\RenderBackendBootstrap.h" />
     <ClInclude Include="Source\StartupScreenController.h" />

--- a/Editor/Xelqoria.Editor.vcxproj.filters
+++ b/Editor/Xelqoria.Editor.vcxproj.filters
@@ -33,7 +33,13 @@
     <ClCompile Include="Source\InspectorPanelController.cpp">
       <Filter>Source</Filter>
     </ClCompile>
+    <ClCompile Include="Source\RecentProjectsStore.cpp">
+      <Filter>Source</Filter>
+    </ClCompile>
     <ClCompile Include="Source\RenderBackendBootstrap.cpp">
+      <Filter>Source</Filter>
+    </ClCompile>
+    <ClCompile Include="Source\StartupScreenController.cpp">
       <Filter>Source</Filter>
     </ClCompile>
     <ClCompile Include="Source\SceneDropPlacementService.cpp">
@@ -89,7 +95,13 @@
     <ClInclude Include="Source\InspectorPanelController.h">
       <Filter>Source</Filter>
     </ClInclude>
+    <ClInclude Include="Source\RecentProjectsStore.h">
+      <Filter>Source</Filter>
+    </ClInclude>
     <ClInclude Include="Source\RenderBackendBootstrap.h">
+      <Filter>Source</Filter>
+    </ClInclude>
+    <ClInclude Include="Source\StartupScreenController.h">
       <Filter>Source</Filter>
     </ClInclude>
     <ClInclude Include="Source\SceneDropPlacementService.h">

--- a/Editor/Xelqoria.Editor.vcxproj.filters
+++ b/Editor/Xelqoria.Editor.vcxproj.filters
@@ -33,6 +33,9 @@
     <ClCompile Include="Source\InspectorPanelController.cpp">
       <Filter>Source</Filter>
     </ClCompile>
+    <ClCompile Include="Source\ProjectPanelController.cpp">
+      <Filter>Source</Filter>
+    </ClCompile>
     <ClCompile Include="Source\RecentProjectsStore.cpp">
       <Filter>Source</Filter>
     </ClCompile>
@@ -93,6 +96,9 @@
       <Filter>Source</Filter>
     </ClInclude>
     <ClInclude Include="Source\InspectorPanelController.h">
+      <Filter>Source</Filter>
+    </ClInclude>
+    <ClInclude Include="Source\ProjectPanelController.h">
       <Filter>Source</Filter>
     </ClInclude>
     <ClInclude Include="Source\RecentProjectsStore.h">

--- a/tests/Editor/Source/EditorProjectTests.cpp
+++ b/tests/Editor/Source/EditorProjectTests.cpp
@@ -70,3 +70,20 @@ TEST(EditorProjectTests, OpenReadsProjectAndEnumeratesScenes)
 
     std::filesystem::remove_all(parentDirectory);
 }
+
+TEST(EditorProjectTests, SelectSceneFileUpdatesActiveScene)
+{
+    const std::filesystem::path parentDirectory = MakeTempDirectory(L"XelqoriaEditorProjectTests_SelectScene");
+    Xelqoria::Editor::EditorProject project{};
+    ASSERT_TRUE(project.Create(L"SceneProject", parentDirectory, MakeScene()));
+
+    const std::filesystem::path mainScenePath = project.GetInfo()->activeScenePath;
+    const std::filesystem::path secondScenePath = project.GetInfo()->scenesDirectory / L"Second.xelqoria.scene";
+    std::filesystem::copy_file(mainScenePath, secondScenePath);
+
+    EXPECT_TRUE(project.SelectSceneFile(secondScenePath));
+    ASSERT_TRUE(project.GetInfo().has_value());
+    EXPECT_EQ(secondScenePath, project.GetInfo()->activeScenePath);
+
+    std::filesystem::remove_all(parentDirectory);
+}

--- a/tests/Editor/Source/RecentProjectsStoreTests.cpp
+++ b/tests/Editor/Source/RecentProjectsStoreTests.cpp
@@ -1,0 +1,50 @@
+#include "RecentProjectsStore.h"
+
+#include <filesystem>
+#include <fstream>
+#include <string>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+namespace
+{
+    [[nodiscard]] std::filesystem::path MakeTempDirectory(const std::wstring& name)
+    {
+        const std::filesystem::path directory = std::filesystem::temp_directory_path() / name;
+        std::filesystem::remove_all(directory);
+        std::filesystem::create_directories(directory);
+        return directory;
+    }
+}
+
+TEST(RecentProjectsStoreTests, RecordKeepsMostRecentFiveExistingProjects)
+{
+    const std::filesystem::path originalCurrentPath = std::filesystem::current_path();
+    const std::filesystem::path tempDirectory = MakeTempDirectory(L"XelqoriaRecentProjectsStoreTests");
+    std::filesystem::current_path(tempDirectory);
+
+    Xelqoria::Editor::RecentProjectsStore store{};
+    for (int index = 0; index < 6; ++index)
+    {
+        const std::wstring projectName = L"Project" + std::to_wstring(index);
+        const std::filesystem::path projectRoot = tempDirectory / projectName;
+        std::filesystem::create_directories(projectRoot);
+        const std::filesystem::path projectFilePath = projectRoot / (projectName + L".proj");
+        std::ofstream(projectFilePath).put('\n');
+
+        Xelqoria::Editor::EditorProjectInfo info{};
+        info.name = projectName;
+        info.projectFilePath = projectFilePath;
+        info.rootDirectory = projectRoot;
+        EXPECT_TRUE(store.Record(info));
+    }
+
+    const std::vector<Xelqoria::Editor::EditorProjectInfo> projects = store.Load();
+    ASSERT_EQ(5u, projects.size());
+    EXPECT_EQ(L"Project5", projects[0].name);
+    EXPECT_EQ(L"Project1", projects[4].name);
+
+    std::filesystem::current_path(originalCurrentPath);
+    std::filesystem::remove_all(tempDirectory);
+}

--- a/tests/Editor/Xelqoria.Tests.Editor.vcxproj
+++ b/tests/Editor/Xelqoria.Tests.Editor.vcxproj
@@ -21,11 +21,13 @@
   <ItemGroup>
     <ClCompile Include="Source\EditorCamera2DTests.cpp" />
     <ClCompile Include="..\..\Editor\Source\EditorProject.cpp" />
+    <ClCompile Include="..\..\Editor\Source\RecentProjectsStore.cpp" />
     <ClCompile Include="..\..\Editor\Source\SceneCommandHistory.cpp" />
     <ClCompile Include="..\..\Editor\Source\SceneEditingOperations.cpp" />
     <ClCompile Include="Source\EditorProjectTests.cpp" />
     <ClCompile Include="Source\HierarchyPanelControllerTests.cpp" />
     <ClCompile Include="Source\InspectorPanelControllerTests.cpp" />
+    <ClCompile Include="Source\RecentProjectsStoreTests.cpp" />
     <ClCompile Include="Source\SceneCommandHistoryTests.cpp" />
     <ClCompile Include="Source\SceneEditingOperationsTests.cpp" />
   </ItemGroup>

--- a/tests/Editor/Xelqoria.Tests.Editor.vcxproj.filters
+++ b/tests/Editor/Xelqoria.Tests.Editor.vcxproj.filters
@@ -15,7 +15,13 @@
     <ClCompile Include="Source\EditorProjectTests.cpp">
       <Filter>Source</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\Editor\Source\RecentProjectsStore.cpp">
+      <Filter>Source</Filter>
+    </ClCompile>
     <ClCompile Include="Source\InspectorPanelControllerTests.cpp">
+      <Filter>Source</Filter>
+    </ClCompile>
+    <ClCompile Include="Source\RecentProjectsStoreTests.cpp">
       <Filter>Source</Filter>
     </ClCompile>
   </ItemGroup>


### PR DESCRIPTION
## 概要
- 親 Issue: #141
- 対応子 Issue: #145
- 前段 PR: #148

## 変更内容
- `issue-145` ブランチに前段 `issue-144` の内容を取り込んだうえで実装しました。
- ヘッダーの「プロジェクト」メニューを追加し、作成/保存/別名保存/開く/設定表示の項目を追加しました。
- `WM_COMMAND` と close request を `Core::Window` から Editor 側へ通知できる汎用 callback を追加しました。
- 未保存状態で閉じる、またはメニューからプロジェクトを開く前に「プロジェクトを保存しますか？」の `はい/いいえ` 確認を表示するようにしました。
- 「はい」は保存して継続、「いいえ」は保存せず継続します。キャンセルは表示しません。
- 「プロジェクトの設定を開く」は表示のみで、未実装メッセージ表示に留めています。

## 検証
- `git diff --check origin/issue-144..HEAD`

## 未実行
- ローカル環境に `msbuild` / `cl.exe` が見つからないため、Visual Studio ビルドと GoogleTest 実行は未実行です。

## 注意
- 前段 `issue-143` / `issue-144` が未マージの間は、このPRの差分に前段PRの変更も含まれます。