### PR TITLE
Script Asset の Visual Studio 起動連携を実装する

### DIFF
--- a/Editor/Source/Application.cpp
+++ b/Editor/Source/Application.cpp
@@ -619,6 +619,25 @@ namespace Xelqoria::Editor
             }
         }
 
+        if (true == m_assetsPanelController.HasCreateScriptRequest())
+        {
+            const std::filesystem::path createScriptTargetDirectory =
+                m_assetsPanelController.GetCreateScriptTargetDirectory();
+            m_assetsPanelController.ClearCreateScriptRequest();
+
+            const ScriptAssetCreationResult createScriptResult =
+                m_sceneDocument.CreateScriptAssetFile(createScriptTargetDirectory);
+            if (true == createScriptResult.succeeded)
+            {
+                m_assetsPanelController.Refresh(m_sceneDocument.GetProjectInfo());
+                SetWindowTextW(m_editorShell.GetSceneViewPlanLabel(), L"Script Asset を作成しました。");
+            }
+            else
+            {
+                SetWindowTextW(m_editorShell.GetSceneViewPlanLabel(), L"Script Asset の作成に失敗しました。");
+            }
+        }
+
         if (true == m_hierarchyPanelController.SyncSelection())
         {
             RefreshEditorPanels(canAddSpriteComponent, true);

--- a/Editor/Source/AssetsPanelController.cpp
+++ b/Editor/Source/AssetsPanelController.cpp
@@ -15,6 +15,7 @@
 
 #include "EditorAssetPathUtils.h"
 #include "EditorPathSecurity.h"
+#include "ScriptAssetService.h"
 
 namespace Xelqoria::Editor
 {
@@ -753,7 +754,7 @@ namespace Xelqoria::Editor
         const AssetListEntry entry = m_visibleEntries[entryIndex];
         if (false == entry.isDirectory)
         {
-            return false;
+            return TryOpenScriptAssetSource(entry);
         }
 
         if (entry.isParentLink && m_currentDirectory == m_assetsRootDirectory)
@@ -778,6 +779,46 @@ namespace Xelqoria::Editor
         RebuildVisibleEntries();
         RefreshListView();
         RefreshSummaryLabel();
+        return true;
+    }
+
+    bool AssetsPanelController::TryOpenScriptAssetSource(const AssetListEntry& entry)
+    {
+        if (entry.isDirectory
+            || entry.isParentLink
+            || false == ScriptAssetService::IsScriptAssetFile(entry.path)
+            || false == EditorPathSecurity::IsPathInsideOrEqual(entry.path, m_assetsRootDirectory))
+        {
+            return false;
+        }
+
+        const auto sourcePath = ScriptAssetService::ResolveSourcePath(m_assetsRootDirectory, entry.path);
+        if (false == sourcePath.has_value() || false == std::filesystem::exists(*sourcePath))
+        {
+            MessageBoxW(
+                m_assetsListView,
+                L"Script Asset に対応する C++ コードファイルを開けませんでした。",
+                L"Assets",
+                MB_OK | MB_ICONERROR);
+            return true;
+        }
+
+        const HINSTANCE executeResult = ShellExecuteW(
+            m_assetsListView,
+            L"open",
+            sourcePath->c_str(),
+            nullptr,
+            sourcePath->parent_path().c_str(),
+            SW_SHOWNORMAL);
+        if (reinterpret_cast<INT_PTR>(executeResult) <= 32)
+        {
+            MessageBoxW(
+                m_assetsListView,
+                L"Visual Studio または関連付けられたエディタを起動できませんでした。",
+                L"Assets",
+                MB_OK | MB_ICONERROR);
+        }
+
         return true;
     }
 

--- a/Editor/Source/AssetsPanelController.cpp
+++ b/Editor/Source/AssetsPanelController.cpp
@@ -241,6 +241,11 @@ namespace Xelqoria::Editor
         constexpr UINT_PTR CreateSpriteMenuCommandId = 1;
 
         /// <summary>
+        /// Assets の右クリックメニューから Script Asset を作成するコマンド ID を表す。
+        /// </summary>
+        constexpr UINT_PTR CreateScriptMenuCommandId = 3;
+
+        /// <summary>
         /// Assets 項目の削除メニューから実行されたコマンド ID を表す。
         /// </summary>
         constexpr UINT_PTR DeleteEntryMenuCommandId = 2;
@@ -268,6 +273,8 @@ namespace Xelqoria::Editor
             m_canPlaceDraggingAssetInScene = false;
             m_createSpriteRequested = false;
             m_createSpriteTargetDirectory.clear();
+            m_createScriptRequested = false;
+            m_createScriptTargetDirectory.clear();
             EndDragImage();
             RefreshListView();
             RefreshSummaryLabel();
@@ -354,7 +361,7 @@ namespace Xelqoria::Editor
                 return false;
             }
 
-            return ShowCreateSpriteContextMenu(createSpriteTargetDirectory, menuPoint);
+            return ShowCreateAssetContextMenu(createSpriteTargetDirectory, menuPoint);
         }
 
         if (notifyHeader->code == LVN_KEYDOWN)
@@ -537,9 +544,25 @@ namespace Xelqoria::Editor
         m_createSpriteTargetDirectory.clear();
     }
 
+    bool AssetsPanelController::HasCreateScriptRequest() const
+    {
+        return m_createScriptRequested;
+    }
+
+    void AssetsPanelController::ClearCreateScriptRequest()
+    {
+        m_createScriptRequested = false;
+        m_createScriptTargetDirectory.clear();
+    }
+
     const std::filesystem::path& AssetsPanelController::GetCreateSpriteTargetDirectory() const
     {
         return m_createSpriteTargetDirectory;
+    }
+
+    const std::filesystem::path& AssetsPanelController::GetCreateScriptTargetDirectory() const
+    {
+        return m_createScriptTargetDirectory;
     }
 
     void AssetsPanelController::InitializeListView()
@@ -874,7 +897,7 @@ namespace Xelqoria::Editor
         return DeleteEntry(entryIndex);
     }
 
-    bool AssetsPanelController::ShowCreateSpriteContextMenu(
+    bool AssetsPanelController::ShowCreateAssetContextMenu(
         const std::filesystem::path& targetDirectory,
         POINT screenPoint)
     {
@@ -895,6 +918,7 @@ namespace Xelqoria::Editor
         }
 
         AppendMenuW(popupMenu, MF_STRING, CreateSpriteMenuCommandId, L"Spriteを作成");
+        AppendMenuW(popupMenu, MF_STRING, CreateScriptMenuCommandId, L"Scriptを作成");
 
         const UINT command = TrackPopupMenu(
             popupMenu,
@@ -906,14 +930,26 @@ namespace Xelqoria::Editor
             nullptr);
         DestroyMenu(popupMenu);
 
-        if (CreateSpriteMenuCommandId != command)
+        if (CreateSpriteMenuCommandId == command)
+        {
+            m_createSpriteRequested = true;
+            m_createSpriteTargetDirectory = targetDirectory;
+            return true;
+        }
+
+        if (CreateScriptMenuCommandId == command)
+        {
+            m_createScriptRequested = true;
+            m_createScriptTargetDirectory = targetDirectory;
+            return true;
+        }
+
+        if (0 != command)
         {
             return false;
         }
 
-        m_createSpriteRequested = true;
-        m_createSpriteTargetDirectory = targetDirectory;
-        return true;
+        return false;
     }
 
     bool AssetsPanelController::DeleteEntry(std::size_t entryIndex)

--- a/Editor/Source/AssetsPanelController.h
+++ b/Editor/Source/AssetsPanelController.h
@@ -161,10 +161,27 @@ namespace Xelqoria::Editor
         void ClearCreateSpriteRequest();
 
         /// <summary>
+        /// Assets 空白右クリックから Script 作成が要求されたかを取得する。
+        /// </summary>
+        /// <returns>Script 作成要求がある場合は true。</returns>
+        [[nodiscard]] bool HasCreateScriptRequest() const;
+
+        /// <summary>
+        /// Script 作成要求を消費する。
+        /// </summary>
+        void ClearCreateScriptRequest();
+
+        /// <summary>
         /// Sprite アセットファイルの作成先フォルダを取得する。
         /// </summary>
         /// <returns>作成先フォルダ。未指定時は空。</returns>
         [[nodiscard]] const std::filesystem::path& GetCreateSpriteTargetDirectory() const;
+
+        /// <summary>
+        /// Script Asset ファイルの作成先フォルダを取得する。
+        /// </summary>
+        /// <returns>作成先フォルダ。未指定時は空。</returns>
+        [[nodiscard]] const std::filesystem::path& GetCreateScriptTargetDirectory() const;
 
     private:
         /// <summary>
@@ -241,10 +258,10 @@ namespace Xelqoria::Editor
         /// <summary>
         /// Assets 空白またはフォルダ用の作成メニューを表示する。
         /// </summary>
-        /// <param name="targetDirectory">Sprite 作成先フォルダ。</param>
+        /// <param name="targetDirectory">作成先フォルダ。</param>
         /// <param name="screenPoint">メニュー表示位置のスクリーン座標。</param>
         /// <returns>操作を処理した場合は true。</returns>
-        [[nodiscard]] bool ShowCreateSpriteContextMenu(
+        [[nodiscard]] bool ShowCreateAssetContextMenu(
             const std::filesystem::path& targetDirectory,
             POINT screenPoint);
 
@@ -335,6 +352,8 @@ namespace Xelqoria::Editor
         bool m_assetDragReleasedThisFrame = false;
         bool m_createSpriteRequested = false;
         std::filesystem::path m_createSpriteTargetDirectory{};
+        bool m_createScriptRequested = false;
+        std::filesystem::path m_createScriptTargetDirectory{};
         bool m_listViewInitialized = false;
         HIMAGELIST m_dragImageList = nullptr;
         bool m_isDragImageVisible = false;

--- a/Editor/Source/AssetsPanelController.h
+++ b/Editor/Source/AssetsPanelController.h
@@ -222,6 +222,13 @@ namespace Xelqoria::Editor
         [[nodiscard]] bool TryOpenEntry(std::size_t entryIndex);
 
         /// <summary>
+        /// Script Asset の管理 C++ ソースを関連付けられたアプリケーションで開く。
+        /// </summary>
+        /// <param name="entry">対象 Script Asset 項目。</param>
+        /// <returns>処理対象の Script Asset だった場合は true。</returns>
+        [[nodiscard]] bool TryOpenScriptAssetSource(const AssetListEntry& entry);
+
+        /// <summary>
         /// 現在選択しているフォルダ項目を開く。
         /// </summary>
         /// <returns>フォルダ移動した場合は true。</returns>

--- a/Editor/Source/EditorSceneDocument.cpp
+++ b/Editor/Source/EditorSceneDocument.cpp
@@ -25,6 +25,7 @@
 #include "EditorAssetPathUtils.h"
 #include "EditorPathSecurity.h"
 #include "EditorStringUtils.h"
+#include "ScriptAssetService.h"
 
 namespace Xelqoria::Editor
 {
@@ -373,6 +374,19 @@ namespace Xelqoria::Editor
 
         output << text.str();
         return static_cast<bool>(output);
+    }
+
+    ScriptAssetCreationResult EditorSceneDocument::CreateScriptAssetFile(
+        const std::filesystem::path& targetDirectory)
+    {
+        if (false == m_project.GetInfo().has_value())
+        {
+            return {};
+        }
+
+        return ScriptAssetService::CreateScriptAsset(
+            m_project.GetInfo()->projectFilePath.parent_path(),
+            targetDirectory);
     }
 
     const std::optional<EditorProjectInfo>& EditorSceneDocument::GetProjectInfo() const

--- a/Editor/Source/EditorSceneDocument.h
+++ b/Editor/Source/EditorSceneDocument.h
@@ -12,6 +12,7 @@
 #include "EditorProject.h"
 #include "IGraphicsContext.h"
 #include "Scene.h"
+#include "ScriptAssetService.h"
 #include "TextureAssetRegistry.h"
 
 namespace Xelqoria::Editor
@@ -107,6 +108,14 @@ namespace Xelqoria::Editor
         /// <returns>作成または既存ファイル確認に成功した場合は true。</returns>
         [[nodiscard]] bool CreateSpriteAssetFile(
             const Game::Entity& entity,
+            const std::filesystem::path& targetDirectory);
+
+        /// <summary>
+        /// 現在のプロジェクト配下へ Script Asset と初期 C++ コードを作成する。
+        /// </summary>
+        /// <param name="targetDirectory">Script Asset 作成先フォルダ。空またはプロジェクト外の場合は作成しない。</param>
+        /// <returns>Script Asset 作成結果。</returns>
+        [[nodiscard]] ScriptAssetCreationResult CreateScriptAssetFile(
             const std::filesystem::path& targetDirectory);
 
         /// <summary>

--- a/Editor/Source/ScriptAssetService.cpp
+++ b/Editor/Source/ScriptAssetService.cpp
@@ -1,0 +1,206 @@
+#include "ScriptAssetService.h"
+
+#include <fstream>
+#include <iomanip>
+#include <sstream>
+#include <string>
+#include <system_error>
+
+#include "EditorPathSecurity.h"
+#include "EditorStringUtils.h"
+
+namespace Xelqoria::Editor
+{
+    namespace
+    {
+        constexpr const wchar_t* DefaultScriptName = L"NewScript";
+        constexpr const wchar_t* ScriptAssetExtension = L".script";
+        constexpr const wchar_t* ManagedScriptsDirectory = L".xelqoria/Scripts";
+
+        /// <summary>
+        /// Script Asset の既定名から未使用ファイルパスを取得する。
+        /// </summary>
+        /// <param name="targetDirectory">作成先ディレクトリ。</param>
+        /// <returns>未使用の Script Asset ファイルパス。</returns>
+        [[nodiscard]] std::filesystem::path FindAvailableScriptAssetPath(
+            const std::filesystem::path& targetDirectory)
+        {
+            std::filesystem::path candidate = targetDirectory / (std::wstring(DefaultScriptName) + ScriptAssetExtension);
+            for (int index = 1; std::filesystem::exists(candidate); ++index)
+            {
+                candidate = targetDirectory
+                    / (std::wstring(DefaultScriptName) + std::to_wstring(index) + ScriptAssetExtension);
+            }
+
+            return candidate;
+        }
+
+        /// <summary>
+        /// 管理コードファイル名に使えない文字を置換する。
+        /// </summary>
+        /// <param name="value">変換対象文字列。</param>
+        /// <returns>安全なファイル名要素。</returns>
+        [[nodiscard]] std::wstring SanitizeManagedCodeStem(std::wstring value)
+        {
+            for (wchar_t& character : value)
+            {
+                if (character == L'/'
+                    || character == L'\\'
+                    || character == L':'
+                    || character == L'*'
+                    || character == L'?'
+                    || character == L'"'
+                    || character == L'<'
+                    || character == L'>'
+                    || character == L'|')
+                {
+                    character = L'_';
+                }
+            }
+
+            return value;
+        }
+
+        /// <summary>
+        /// Script Asset への相対パスから管理 C++ ソースの相対パスを構築する。
+        /// </summary>
+        /// <param name="relativeAssetPath">プロジェクトルート基準の Script Asset パス。</param>
+        /// <returns>プロジェクトルート基準の C++ ソースパス。</returns>
+        [[nodiscard]] std::filesystem::path BuildManagedSourceRelativePath(
+            const std::filesystem::path& relativeAssetPath)
+        {
+            std::filesystem::path sourceStem = relativeAssetPath;
+            sourceStem.replace_extension();
+            const std::wstring sourceFileName =
+                SanitizeManagedCodeStem(sourceStem.generic_wstring()) + L".cpp";
+            return std::filesystem::path(ManagedScriptsDirectory) / sourceFileName;
+        }
+
+        /// <summary>
+        /// Script AssetId を構築する。
+        /// </summary>
+        /// <param name="relativeAssetPath">プロジェクトルート基準の Script Asset パス。</param>
+        /// <returns>Script AssetId。</returns>
+        [[nodiscard]] Core::AssetId BuildScriptAssetId(const std::filesystem::path& relativeAssetPath)
+        {
+            return Core::AssetId("scripts/" + ToNarrowString(relativeAssetPath.generic_wstring()));
+        }
+
+        /// <summary>
+        /// Script Asset マニフェストを書き出す。
+        /// </summary>
+        /// <param name="assetPath">書き出し先 Script Asset ファイル。</param>
+        /// <param name="scriptName">Script 表示名。</param>
+        /// <param name="sourceRelativePath">管理 C++ ソースの相対パス。</param>
+        /// <returns>書き出しに成功した場合は true。</returns>
+        [[nodiscard]] bool WriteScriptAssetManifest(
+            const std::filesystem::path& assetPath,
+            const std::wstring& scriptName,
+            const std::filesystem::path& sourceRelativePath)
+        {
+            std::ofstream output(assetPath, std::ios::binary | std::ios::trunc);
+            if (false == output.is_open())
+            {
+                return false;
+            }
+
+            output << "magic=XelqoriaScriptAsset\n";
+            output << "version=1\n";
+            output << "language=cpp\n";
+            output << "name=" << std::quoted(ToNarrowString(scriptName)) << "\n";
+            output << "source=" << std::quoted(ToNarrowString(sourceRelativePath.generic_wstring())) << "\n";
+            return output.good();
+        }
+
+        /// <summary>
+        /// Start / Update を含む初期 C++ コードを書き出す。
+        /// </summary>
+        /// <param name="sourcePath">書き出し先 C++ ソースファイル。</param>
+        /// <returns>書き出しに成功した場合は true。</returns>
+        [[nodiscard]] bool WriteInitialScriptSource(const std::filesystem::path& sourcePath)
+        {
+            std::ofstream output(sourcePath, std::ios::binary | std::ios::trunc);
+            if (false == output.is_open())
+            {
+                return false;
+            }
+
+            output
+                << "void Start()\n"
+                << "{\n"
+                << "}\n"
+                << "\n"
+                << "void Update(float deltaTime)\n"
+                << "{\n"
+                << "    (void)deltaTime;\n"
+                << "}\n";
+            return output.good();
+        }
+    }
+
+    bool ScriptAssetService::IsScriptAssetFile(const std::filesystem::path& path)
+    {
+        return path.extension() == ScriptAssetExtension;
+    }
+
+    ScriptAssetCreationResult ScriptAssetService::CreateScriptAsset(
+        const std::filesystem::path& projectRootDirectory,
+        const std::filesystem::path& targetDirectory)
+    {
+        ScriptAssetCreationResult result{};
+        if (projectRootDirectory.empty() || targetDirectory.empty())
+        {
+            return result;
+        }
+
+        if (false == EditorPathSecurity::IsPathInsideOrEqual(targetDirectory, projectRootDirectory))
+        {
+            return result;
+        }
+
+        std::error_code errorCode;
+        if (false == std::filesystem::is_directory(targetDirectory, errorCode) || errorCode)
+        {
+            return result;
+        }
+
+        const std::filesystem::path assetPath = FindAvailableScriptAssetPath(targetDirectory);
+        const std::filesystem::path relativeAssetPath =
+            std::filesystem::relative(assetPath, projectRootDirectory, errorCode);
+        if (errorCode || false == EditorPathSecurity::IsSafeRelativePath(relativeAssetPath))
+        {
+            return result;
+        }
+
+        const std::filesystem::path sourceRelativePath = BuildManagedSourceRelativePath(relativeAssetPath);
+        if (false == EditorPathSecurity::IsSafeRelativePath(sourceRelativePath))
+        {
+            return result;
+        }
+
+        const std::filesystem::path sourcePath = projectRootDirectory / sourceRelativePath;
+        std::filesystem::create_directories(sourcePath.parent_path(), errorCode);
+        if (errorCode)
+        {
+            return result;
+        }
+
+        const std::wstring scriptName = assetPath.stem().wstring();
+        if (false == WriteScriptAssetManifest(assetPath, scriptName, sourceRelativePath))
+        {
+            return result;
+        }
+
+        if (false == WriteInitialScriptSource(sourcePath))
+        {
+            std::filesystem::remove(assetPath, errorCode);
+            return result;
+        }
+
+        result.succeeded = true;
+        result.assetPath = assetPath;
+        result.sourcePath = sourcePath;
+        result.scriptAssetId = BuildScriptAssetId(relativeAssetPath);
+        return result;
+    }
+}

--- a/Editor/Source/ScriptAssetService.cpp
+++ b/Editor/Source/ScriptAssetService.cpp
@@ -2,8 +2,10 @@
 
 #include <fstream>
 #include <iomanip>
+#include <optional>
 #include <sstream>
 #include <string>
+#include <string_view>
 #include <system_error>
 
 #include "EditorPathSecurity.h"
@@ -87,6 +89,46 @@ namespace Xelqoria::Editor
         }
 
         /// <summary>
+        /// `key=value` 行から値部分を取得する。
+        /// </summary>
+        /// <param name="line">解析対象行。</param>
+        /// <param name="key">取得対象キー。</param>
+        /// <returns>値。キーが一致しない場合は空。</returns>
+        [[nodiscard]] std::optional<std::string> ReadValue(std::string_view line, std::string_view key)
+        {
+            if (line.size() <= key.size() + 1 || line.substr(0, key.size()) != key || line[key.size()] != '=')
+            {
+                return std::nullopt;
+            }
+
+            return std::string(line.substr(key.size() + 1));
+        }
+
+        /// <summary>
+        /// 引用符付き文字列を復元する。
+        /// </summary>
+        /// <param name="value">復元対象文字列。</param>
+        /// <returns>復元した文字列。失敗時は空。</returns>
+        [[nodiscard]] std::optional<std::string> ParseQuotedString(std::string_view value)
+        {
+            std::istringstream stream{ std::string(value) };
+            std::string parsed{};
+            stream >> std::quoted(parsed);
+            if (false == static_cast<bool>(stream))
+            {
+                return std::nullopt;
+            }
+
+            stream >> std::ws;
+            if (std::char_traits<char>::eof() != stream.peek())
+            {
+                return std::nullopt;
+            }
+
+            return parsed;
+        }
+
+        /// <summary>
         /// Script Asset マニフェストを書き出す。
         /// </summary>
         /// <param name="assetPath">書き出し先 Script Asset ファイル。</param>
@@ -141,6 +183,55 @@ namespace Xelqoria::Editor
     bool ScriptAssetService::IsScriptAssetFile(const std::filesystem::path& path)
     {
         return path.extension() == ScriptAssetExtension;
+    }
+
+    std::optional<std::filesystem::path> ScriptAssetService::ResolveSourcePath(
+        const std::filesystem::path& projectRootDirectory,
+        const std::filesystem::path& assetPath)
+    {
+        if (projectRootDirectory.empty()
+            || assetPath.empty()
+            || false == IsScriptAssetFile(assetPath)
+            || false == EditorPathSecurity::IsPathInsideOrEqual(assetPath, projectRootDirectory))
+        {
+            return std::nullopt;
+        }
+
+        std::ifstream input(assetPath, std::ios::binary);
+        if (false == input.is_open())
+        {
+            return std::nullopt;
+        }
+
+        std::optional<std::string> sourceValue{};
+        std::string line{};
+        while (std::getline(input, line))
+        {
+            if (const auto value = ReadValue(line, "source"))
+            {
+                sourceValue = ParseQuotedString(*value);
+                break;
+            }
+        }
+
+        if (false == sourceValue.has_value())
+        {
+            return std::nullopt;
+        }
+
+        const std::filesystem::path sourceRelativePath = ToWideString(*sourceValue);
+        if (false == EditorPathSecurity::IsSafeRelativePath(sourceRelativePath))
+        {
+            return std::nullopt;
+        }
+
+        const std::filesystem::path sourcePath = projectRootDirectory / sourceRelativePath;
+        if (false == EditorPathSecurity::IsPathInsideOrEqual(sourcePath, projectRootDirectory))
+        {
+            return std::nullopt;
+        }
+
+        return sourcePath;
     }
 
     ScriptAssetCreationResult ScriptAssetService::CreateScriptAsset(

--- a/Editor/Source/ScriptAssetService.h
+++ b/Editor/Source/ScriptAssetService.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <filesystem>
+#include <optional>
 
 #include "AssetId.h"
 
@@ -44,6 +45,16 @@ namespace Xelqoria::Editor
         /// <param name="path">判定対象パス。</param>
         /// <returns>Script Asset ファイルの場合は true。</returns>
         [[nodiscard]] static bool IsScriptAssetFile(const std::filesystem::path& path);
+
+        /// <summary>
+        /// Script Asset マニフェストから Editor 管理下の C++ ソースパスを解決する。
+        /// </summary>
+        /// <param name="projectRootDirectory">プロジェクトルートディレクトリ。</param>
+        /// <param name="assetPath">Script Asset ファイルパス。</param>
+        /// <returns>解決できた C++ ソースパス。失敗時は空。</returns>
+        [[nodiscard]] static std::optional<std::filesystem::path> ResolveSourcePath(
+            const std::filesystem::path& projectRootDirectory,
+            const std::filesystem::path& assetPath);
 
         /// <summary>
         /// Script Asset と初期 C++ コードを作成する。

--- a/Editor/Source/ScriptAssetService.h
+++ b/Editor/Source/ScriptAssetService.h
@@ -1,0 +1,58 @@
+#pragma once
+
+#include <filesystem>
+
+#include "AssetId.h"
+
+namespace Xelqoria::Editor
+{
+    /// <summary>
+    /// Script Asset 生成結果を表す。
+    /// </summary>
+    struct ScriptAssetCreationResult
+    {
+        /// <summary>
+        /// 生成に成功したかを表す。
+        /// </summary>
+        bool succeeded = false;
+
+        /// <summary>
+        /// 作成した Script Asset ファイルを表す。
+        /// </summary>
+        std::filesystem::path assetPath{};
+
+        /// <summary>
+        /// Editor が管理する C++ ソースファイルを表す。
+        /// </summary>
+        std::filesystem::path sourcePath{};
+
+        /// <summary>
+        /// 作成した Script Asset の識別子を表す。
+        /// </summary>
+        Core::AssetId scriptAssetId{};
+    };
+
+    /// <summary>
+    /// Editor プロジェクト内の Script Asset と管理コードファイルを生成する。
+    /// </summary>
+    class ScriptAssetService
+    {
+    public:
+        /// <summary>
+        /// 指定パスが Script Asset ファイルかを判定する。
+        /// </summary>
+        /// <param name="path">判定対象パス。</param>
+        /// <returns>Script Asset ファイルの場合は true。</returns>
+        [[nodiscard]] static bool IsScriptAssetFile(const std::filesystem::path& path);
+
+        /// <summary>
+        /// Script Asset と初期 C++ コードを作成する。
+        /// </summary>
+        /// <param name="projectRootDirectory">プロジェクトルートディレクトリ。</param>
+        /// <param name="targetDirectory">Script Asset 作成先ディレクトリ。</param>
+        /// <returns>作成結果。</returns>
+        [[nodiscard]] static ScriptAssetCreationResult CreateScriptAsset(
+            const std::filesystem::path& projectRootDirectory,
+            const std::filesystem::path& targetDirectory);
+    };
+}

--- a/Editor/Xelqoria.Editor.vcxproj
+++ b/Editor/Xelqoria.Editor.vcxproj
@@ -38,6 +38,7 @@
     <ClCompile Include="Source\SceneViewInputTracker.cpp" />
     <ClCompile Include="Source\SceneViewRenderer.cpp" />
     <ClCompile Include="Source\SceneViewStatusPresenter.cpp" />
+    <ClCompile Include="Source\ScriptAssetService.cpp" />
     <ClCompile Include="Source\StartupScreenController.cpp" />
   </ItemGroup>
   <ItemGroup>
@@ -64,6 +65,7 @@
     <ClInclude Include="Source\SceneViewInteractionTypes.h" />
     <ClInclude Include="Source\SceneViewRenderer.h" />
     <ClInclude Include="Source\SceneViewStatusPresenter.h" />
+    <ClInclude Include="Source\ScriptAssetService.h" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Core\Xelqoria.Core.vcxproj">

--- a/Editor/Xelqoria.Editor.vcxproj.filters
+++ b/Editor/Xelqoria.Editor.vcxproj.filters
@@ -66,6 +66,9 @@
     <ClCompile Include="Source\SceneViewStatusPresenter.cpp">
       <Filter>Source</Filter>
     </ClCompile>
+    <ClCompile Include="Source\ScriptAssetService.cpp">
+      <Filter>Source</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="Source\Application.h">
@@ -135,6 +138,9 @@
       <Filter>Source</Filter>
     </ClInclude>
     <ClInclude Include="Source\SceneViewStatusPresenter.h">
+      <Filter>Source</Filter>
+    </ClInclude>
+    <ClInclude Include="Source\ScriptAssetService.h">
       <Filter>Source</Filter>
     </ClInclude>
   </ItemGroup>

--- a/tests/Editor/Source/ScriptAssetServiceTests.cpp
+++ b/tests/Editor/Source/ScriptAssetServiceTests.cpp
@@ -86,3 +86,41 @@ TEST(ScriptAssetServiceTests, CreateScriptAssetRejectsOutsideTargetDirectory)
     std::filesystem::remove_all(projectRoot);
     std::filesystem::remove_all(outsideRoot);
 }
+
+TEST(ScriptAssetServiceTests, ResolveSourcePathReadsManagedCodePathFromManifest)
+{
+    const std::filesystem::path projectRoot = MakeTempDirectory(L"XelqoriaScriptAssetServiceTests_Resolve");
+    const std::filesystem::path targetDirectory = projectRoot / L"Assets";
+    std::filesystem::create_directories(targetDirectory);
+
+    const Xelqoria::Editor::ScriptAssetCreationResult created =
+        Xelqoria::Editor::ScriptAssetService::CreateScriptAsset(projectRoot, targetDirectory);
+
+    ASSERT_TRUE(created.succeeded);
+    const auto sourcePath =
+        Xelqoria::Editor::ScriptAssetService::ResolveSourcePath(projectRoot, created.assetPath);
+
+    ASSERT_TRUE(sourcePath.has_value());
+    EXPECT_EQ(created.sourcePath, *sourcePath);
+
+    std::filesystem::remove_all(projectRoot);
+}
+
+TEST(ScriptAssetServiceTests, ResolveSourcePathRejectsUnsafeManifestSource)
+{
+    const std::filesystem::path projectRoot = MakeTempDirectory(L"XelqoriaScriptAssetServiceTests_UnsafeSource");
+    const std::filesystem::path assetPath = projectRoot / L"Unsafe.script";
+    {
+        std::ofstream output(assetPath, std::ios::binary | std::ios::trunc);
+        output << "magic=XelqoriaScriptAsset\n";
+        output << "version=1\n";
+        output << "source=\"../Outside.cpp\"\n";
+    }
+
+    const auto sourcePath =
+        Xelqoria::Editor::ScriptAssetService::ResolveSourcePath(projectRoot, assetPath);
+
+    EXPECT_FALSE(sourcePath.has_value());
+
+    std::filesystem::remove_all(projectRoot);
+}

--- a/tests/Editor/Source/ScriptAssetServiceTests.cpp
+++ b/tests/Editor/Source/ScriptAssetServiceTests.cpp
@@ -1,0 +1,88 @@
+#include "ScriptAssetService.h"
+
+#include <filesystem>
+#include <fstream>
+#include <sstream>
+
+#include <gtest/gtest.h>
+
+namespace
+{
+    [[nodiscard]] std::filesystem::path MakeTempDirectory(const std::wstring& name)
+    {
+        const std::filesystem::path directory = std::filesystem::temp_directory_path() / name;
+        std::filesystem::remove_all(directory);
+        std::filesystem::create_directories(directory);
+        return directory;
+    }
+
+    [[nodiscard]] std::string ReadTextFile(const std::filesystem::path& path)
+    {
+        std::ifstream input(path, std::ios::binary);
+        std::ostringstream buffer;
+        buffer << input.rdbuf();
+        return buffer.str();
+    }
+}
+
+TEST(ScriptAssetServiceTests, CreateScriptAssetWritesManifestAndInitialCode)
+{
+    const std::filesystem::path projectRoot = MakeTempDirectory(L"XelqoriaScriptAssetServiceTests_Create");
+    const std::filesystem::path targetDirectory = projectRoot / L"Scripts";
+    std::filesystem::create_directories(targetDirectory);
+
+    const Xelqoria::Editor::ScriptAssetCreationResult result =
+        Xelqoria::Editor::ScriptAssetService::CreateScriptAsset(projectRoot, targetDirectory);
+
+    ASSERT_TRUE(result.succeeded);
+    EXPECT_EQ(targetDirectory / L"NewScript.script", result.assetPath);
+    EXPECT_EQ(projectRoot / L".xelqoria" / L"Scripts" / L"Scripts_NewScript.cpp", result.sourcePath);
+    EXPECT_EQ("scripts/Scripts/NewScript.script", result.scriptAssetId.GetValue());
+
+    const std::string manifest = ReadTextFile(result.assetPath);
+    EXPECT_NE(std::string::npos, manifest.find("magic=XelqoriaScriptAsset\n"));
+    EXPECT_NE(std::string::npos, manifest.find("language=cpp\n"));
+    EXPECT_NE(std::string::npos, manifest.find("name=\"NewScript\"\n"));
+    EXPECT_NE(std::string::npos, manifest.find("source=\".xelqoria/Scripts/Scripts_NewScript.cpp\"\n"));
+
+    const std::string source = ReadTextFile(result.sourcePath);
+    EXPECT_NE(std::string::npos, source.find("void Start()"));
+    EXPECT_NE(std::string::npos, source.find("void Update(float deltaTime)"));
+
+    std::filesystem::remove_all(projectRoot);
+}
+
+TEST(ScriptAssetServiceTests, CreateScriptAssetUsesUniqueNames)
+{
+    const std::filesystem::path projectRoot = MakeTempDirectory(L"XelqoriaScriptAssetServiceTests_Unique");
+    std::filesystem::create_directories(projectRoot);
+
+    const Xelqoria::Editor::ScriptAssetCreationResult first =
+        Xelqoria::Editor::ScriptAssetService::CreateScriptAsset(projectRoot, projectRoot);
+    const Xelqoria::Editor::ScriptAssetCreationResult second =
+        Xelqoria::Editor::ScriptAssetService::CreateScriptAsset(projectRoot, projectRoot);
+
+    ASSERT_TRUE(first.succeeded);
+    ASSERT_TRUE(second.succeeded);
+    EXPECT_EQ(projectRoot / L"NewScript.script", first.assetPath);
+    EXPECT_EQ(projectRoot / L"NewScript1.script", second.assetPath);
+    EXPECT_TRUE(std::filesystem::exists(first.sourcePath));
+    EXPECT_TRUE(std::filesystem::exists(second.sourcePath));
+
+    std::filesystem::remove_all(projectRoot);
+}
+
+TEST(ScriptAssetServiceTests, CreateScriptAssetRejectsOutsideTargetDirectory)
+{
+    const std::filesystem::path projectRoot = MakeTempDirectory(L"XelqoriaScriptAssetServiceTests_Project");
+    const std::filesystem::path outsideRoot = MakeTempDirectory(L"XelqoriaScriptAssetServiceTests_Outside");
+
+    const Xelqoria::Editor::ScriptAssetCreationResult result =
+        Xelqoria::Editor::ScriptAssetService::CreateScriptAsset(projectRoot, outsideRoot);
+
+    EXPECT_FALSE(result.succeeded);
+    EXPECT_FALSE(std::filesystem::exists(outsideRoot / L"NewScript.script"));
+
+    std::filesystem::remove_all(projectRoot);
+    std::filesystem::remove_all(outsideRoot);
+}

--- a/tests/Editor/Xelqoria.Tests.Editor.vcxproj
+++ b/tests/Editor/Xelqoria.Tests.Editor.vcxproj
@@ -24,12 +24,14 @@
     <ClCompile Include="..\..\Editor\Source\RecentProjectsStore.cpp" />
     <ClCompile Include="..\..\Editor\Source\SceneCommandHistory.cpp" />
     <ClCompile Include="..\..\Editor\Source\SceneEditingOperations.cpp" />
+    <ClCompile Include="..\..\Editor\Source\ScriptAssetService.cpp" />
     <ClCompile Include="Source\EditorProjectTests.cpp" />
     <ClCompile Include="Source\HierarchyPanelControllerTests.cpp" />
     <ClCompile Include="Source\InspectorPanelControllerTests.cpp" />
     <ClCompile Include="Source\RecentProjectsStoreTests.cpp" />
     <ClCompile Include="Source\SceneCommandHistoryTests.cpp" />
     <ClCompile Include="Source\SceneEditingOperationsTests.cpp" />
+    <ClCompile Include="Source\ScriptAssetServiceTests.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\third_party\googletest\Xelqoria.GoogleTest.vcxproj">

--- a/tests/Editor/Xelqoria.Tests.Editor.vcxproj.filters
+++ b/tests/Editor/Xelqoria.Tests.Editor.vcxproj.filters
@@ -24,5 +24,11 @@
     <ClCompile Include="Source\RecentProjectsStoreTests.cpp">
       <Filter>Source</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\Editor\Source\ScriptAssetService.cpp">
+      <Filter>Source</Filter>
+    </ClCompile>
+    <ClCompile Include="Source\ScriptAssetServiceTests.cpp">
+      <Filter>Source</Filter>
+    </ClCompile>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
## Summary
- Script Asset マニフェストから Editor 管理下の C++ ソースファイルを解決
- Assets パネルで .script をダブルクリックしたときに関連付けられたエディタを起動
- 管理ソース解決の安全性テストを追加

## Issues
- Parent: #168
- Child: #170

## Dependency
- #169 の Script Asset 作成とマニフェスト形式を前提にしています。

## Verification
- tools/wsl/build.sh tests/Editor/Xelqoria.Tests.Editor.vcxproj
- artifacts/x64/Debug/Xelqoria.Tests.Editor.exe --gtest_filter=ScriptAssetServiceTests.*
- tools/wsl/build.sh Editor/Xelqoria.Editor.vcxproj