### PR TITLE
Editor 再生開始時の Script 自動ビルドとコンパイルエラー表示を実装する

### DIFF
--- a/Editor/Source/Application.cpp
+++ b/Editor/Source/Application.cpp
@@ -18,6 +18,7 @@
 #include "InspectorPanelController.h"
 #include "SceneEditingOperations.h"
 #include "SceneViewInteractionTypes.h"
+#include "ScriptAssetService.h"
 #include <Entity.h>
 #include <cstdint>
 
@@ -49,6 +50,28 @@ namespace Xelqoria::Editor
 
             return {};
         }
+
+        [[nodiscard]] std::filesystem::path SelectScriptAssetFile(
+            HWND ownerWindow,
+            const std::filesystem::path& initialDirectory)
+        {
+            std::array<wchar_t, MAX_PATH> filePath{};
+            OPENFILENAMEW openFileName{};
+            openFileName.lStructSize = sizeof(openFileName);
+            openFileName.hwndOwner = ownerWindow;
+            openFileName.lpstrFilter = L"Xelqoria Script Asset (*.script)\0*.script\0All Files (*.*)\0*.*\0";
+            openFileName.lpstrFile = filePath.data();
+            openFileName.nMaxFile = static_cast<DWORD>(filePath.size());
+            openFileName.lpstrInitialDir = initialDirectory.empty() ? nullptr : initialDirectory.c_str();
+            openFileName.Flags = OFN_FILEMUSTEXIST | OFN_PATHMUSTEXIST;
+            if (GetOpenFileNameW(&openFileName))
+            {
+                return filePath.data();
+            }
+
+            return {};
+        }
+
 
         [[nodiscard]] std::filesystem::path SelectFolder(HWND ownerWindow, const wchar_t* title)
         {
@@ -635,6 +658,32 @@ namespace Xelqoria::Editor
             else
             {
                 SetWindowTextW(m_editorShell.GetSceneViewPlanLabel(), L"Script Asset の作成に失敗しました。");
+            }
+        }
+
+        if (true == m_assetsPanelController.HasAssignScriptRequest())
+        {
+            const std::filesystem::path spriteAssetPath =
+                m_assetsPanelController.GetAssignScriptSpriteAssetPath();
+            m_assetsPanelController.ClearAssignScriptRequest();
+
+            const std::filesystem::path projectRootDirectory =
+                m_sceneDocument.GetProjectInfo().has_value()
+                ? m_sceneDocument.GetProjectInfo()->projectFilePath.parent_path()
+                : std::filesystem::path{};
+            const std::filesystem::path scriptAssetPath =
+                SelectScriptAssetFile(m_window.GetHwnd(), projectRootDirectory);
+            if (false == scriptAssetPath.empty())
+            {
+                if (true == m_sceneDocument.AssignScriptAssetToSpriteAssetFile(spriteAssetPath, scriptAssetPath))
+                {
+                    m_assetsPanelController.Refresh(m_sceneDocument.GetProjectInfo());
+                    SetWindowTextW(m_editorShell.GetSceneViewPlanLabel(), L"Sprite Asset に Script Asset を割り当てました。");
+                }
+                else
+                {
+                    SetWindowTextW(m_editorShell.GetSceneViewPlanLabel(), L"Script Asset の割り当てに失敗しました。");
+                }
             }
         }
 

--- a/Editor/Source/Application.cpp
+++ b/Editor/Source/Application.cpp
@@ -619,6 +619,25 @@ namespace Xelqoria::Editor
             }
         }
 
+        if (true == m_assetsPanelController.HasCreateScriptRequest())
+        {
+            const std::filesystem::path createScriptTargetDirectory =
+                m_assetsPanelController.GetCreateScriptTargetDirectory();
+            m_assetsPanelController.ClearCreateScriptRequest();
+
+            const ScriptAssetCreationResult createScriptResult =
+                m_sceneDocument.CreateScriptAssetFile(createScriptTargetDirectory);
+            if (true == createScriptResult.succeeded)
+            {
+                m_assetsPanelController.Refresh(m_sceneDocument.GetProjectInfo());
+                SetWindowTextW(m_editorShell.GetSceneViewPlanLabel(), L"Script Asset を作成しました。");
+            }
+            else
+            {
+                SetWindowTextW(m_editorShell.GetSceneViewPlanLabel(), L"Script Asset の作成に失敗しました。");
+            }
+        }
+
         if (true == m_hierarchyPanelController.SyncSelection())
         {
             RefreshEditorPanels(canAddSpriteComponent, true);

--- a/Editor/Source/Application.cpp
+++ b/Editor/Source/Application.cpp
@@ -3,6 +3,7 @@
 #include <array>
 #include <chrono>
 #include <commdlg.h>
+#include <cstdlib>
 #include <filesystem>
 #include <functional>
 #include <shlobj.h>
@@ -32,6 +33,7 @@ namespace Xelqoria::Editor
         constexpr unsigned ProjectMenuOpenCommandId = 5104;
         constexpr unsigned ProjectMenuSettingsCommandId = 5105;
         constexpr unsigned ProjectMenuResetLayoutCommandId = 5106;
+        constexpr unsigned ProjectMenuStartPlayCommandId = 5107;
 
         [[nodiscard]] std::filesystem::path SelectProjectFile(HWND ownerWindow)
         {
@@ -106,6 +108,54 @@ namespace Xelqoria::Editor
             }
 
             return projectName;
+        }
+
+        /// <summary>
+        /// Script ビルドに使用する C++ コンパイラを取得する。
+        /// </summary>
+        /// <returns>コンパイラ実行ファイルまたはコマンド。</returns>
+        [[nodiscard]] std::filesystem::path GetScriptCompilerExecutable()
+        {
+            wchar_t* configuredCompiler = nullptr;
+            std::size_t configuredCompilerLength = 0;
+            const errno_t environmentResult =
+                _wdupenv_s(&configuredCompiler, &configuredCompilerLength, L"XELQORIA_SCRIPT_COMPILER");
+            if (0 == environmentResult
+                && nullptr != configuredCompiler
+                && 0 < configuredCompilerLength
+                && L'\0' != configuredCompiler[0])
+            {
+                const std::filesystem::path compilerPath = configuredCompiler;
+                free(configuredCompiler);
+                return compilerPath;
+            }
+
+            free(configuredCompiler);
+            return L"cl.exe";
+        }
+
+        /// <summary>
+        /// Script ビルド結果を SceneView 表示用の短い文面へ変換する。
+        /// </summary>
+        /// <param name="buildResult">Script ビルド結果。</param>
+        /// <returns>表示文面。</returns>
+        [[nodiscard]] std::wstring BuildScriptBuildStatusText(const ScriptBuildResult& buildResult)
+        {
+            if (buildResult.succeeded)
+            {
+                return L"再生開始前 Script ビルドに成功しました。";
+            }
+
+            std::wstring text = L"再生開始前 Script ビルドに失敗しました。詳細: ";
+            text += buildResult.diagnostics;
+            constexpr std::size_t MaxLabelLength = 180;
+            if (MaxLabelLength < text.size())
+            {
+                text.resize(MaxLabelLength - 3);
+                text += L"...";
+            }
+
+            return text;
         }
     }
 
@@ -263,6 +313,8 @@ namespace Xelqoria::Editor
         AppendMenuW(m_projectMenu, MF_STRING, ProjectMenuOpenCommandId, L"プロジェクトを開く");
         AppendMenuW(m_projectMenu, MF_STRING, ProjectMenuSettingsCommandId, L"プロジェクトの設定を開く");
         AppendMenuW(m_projectMenu, MF_SEPARATOR, 0, nullptr);
+        AppendMenuW(m_projectMenu, MF_STRING, ProjectMenuStartPlayCommandId, L"再生を開始する (F5)");
+        AppendMenuW(m_projectMenu, MF_SEPARATOR, 0, nullptr);
         AppendMenuW(m_projectMenu, MF_STRING, ProjectMenuResetLayoutCommandId, L"画面レイアウトを初期状態に戻す");
 
         HMENU menuBar = CreateMenu();
@@ -297,6 +349,12 @@ namespace Xelqoria::Editor
             {
                 m_editorShell.ResetDockLayout();
                 SetWindowTextW(m_editorShell.GetSceneViewPlanLabel(), L"画面レイアウトを初期状態に戻しました。");
+            }
+            break;
+        case ProjectMenuStartPlayCommandId:
+            if (m_editorInitialized)
+            {
+                (void)StartEditorPlay();
             }
             break;
         default:
@@ -541,6 +599,35 @@ namespace Xelqoria::Editor
         m_projectDirty = true;
     }
 
+    bool Application::StartEditorPlay()
+    {
+        if (false == m_sceneDocument.GetProjectInfo().has_value())
+        {
+            SetWindowTextW(m_editorShell.GetSceneViewPlanLabel(), L"再生開始前 Script ビルドにはプロジェクトが必要です。");
+            return false;
+        }
+
+        const std::filesystem::path projectRootDirectory =
+            m_sceneDocument.GetProjectInfo()->projectFilePath.parent_path();
+        const ScriptBuildResult buildResult = ScriptAssetService::BuildProjectScripts(
+            projectRootDirectory,
+            ScriptBuildOptions{ GetScriptCompilerExecutable() });
+        const std::wstring statusText = BuildScriptBuildStatusText(buildResult);
+        SetWindowTextW(m_editorShell.GetSceneViewPlanLabel(), statusText.c_str());
+
+        if (false == buildResult.succeeded)
+        {
+            MessageBoxW(
+                m_window.GetHwnd(),
+                buildResult.diagnostics.c_str(),
+                L"Script ビルドエラー",
+                MB_OK | MB_ICONERROR);
+            return false;
+        }
+
+        return true;
+    }
+
     void Application::ClearProjectDirty()
     {
         m_projectDirty = false;
@@ -600,6 +687,11 @@ namespace Xelqoria::Editor
             m_editorCommandController.Reset(m_sceneDocument, m_hierarchyPanelController.GetSelectedEntityId());
             MarkProjectDirty();
             SetWindowTextW(m_editorShell.GetSceneViewPlanLabel(), L"選択した Scene を読み込みました。");
+        }
+
+        if (inputSnapshot.WasKeyPressed(VK_F5))
+        {
+            (void)StartEditorPlay();
         }
 
         m_assetsPanelController.UpdateDragState(inputSnapshot);

--- a/Editor/Source/Application.h
+++ b/Editor/Source/Application.h
@@ -129,6 +129,12 @@ namespace Xelqoria::Editor
         void MarkProjectDirty();
 
         /// <summary>
+        /// Editor 再生開始前に Script をビルドする。
+        /// </summary>
+        /// <returns>再生開始前ビルドに成功した場合は true。</returns>
+        [[nodiscard]] bool StartEditorPlay();
+
+        /// <summary>
         /// Scene の未保存変更が保存されたことを記録する。
         /// </summary>
         void ClearProjectDirty();

--- a/Editor/Source/AssetsPanelController.cpp
+++ b/Editor/Source/AssetsPanelController.cpp
@@ -15,6 +15,7 @@
 
 #include "EditorAssetPathUtils.h"
 #include "EditorPathSecurity.h"
+#include "ScriptAssetService.h"
 
 namespace Xelqoria::Editor
 {
@@ -753,7 +754,7 @@ namespace Xelqoria::Editor
         const AssetListEntry entry = m_visibleEntries[entryIndex];
         if (false == entry.isDirectory)
         {
-            return false;
+            return TryOpenScriptAssetSource(entry);
         }
 
         if (entry.isParentLink && m_currentDirectory == m_assetsRootDirectory)
@@ -778,6 +779,46 @@ namespace Xelqoria::Editor
         RebuildVisibleEntries();
         RefreshListView();
         RefreshSummaryLabel();
+        return true;
+    }
+
+    bool AssetsPanelController::TryOpenScriptAssetSource(const AssetListEntry& entry)
+    {
+        if (entry.isDirectory
+            || entry.isParentLink
+            || false == ScriptAssetService::IsScriptAssetFile(entry.path)
+            || false == EditorPathSecurity::IsPathInsideOrEqual(entry.path, m_assetsRootDirectory))
+        {
+            return false;
+        }
+
+        const auto sourcePath = ScriptAssetService::ResolveSourcePath(m_assetsRootDirectory, entry.path);
+        if (false == sourcePath.has_value() || false == std::filesystem::exists(*sourcePath))
+        {
+            MessageBoxW(
+                m_assetsListView,
+                L"Script Asset に対応する C++ コードファイルを開けませんでした。",
+                L"Assets",
+                MB_OK | MB_ICONERROR);
+            return true;
+        }
+
+        const HINSTANCE executeResult = ShellExecuteW(
+            m_assetsListView,
+            L"open",
+            sourcePath->c_str(),
+            nullptr,
+            sourcePath->parent_path().c_str(),
+            SW_SHOWNORMAL);
+        if (reinterpret_cast<INT_PTR>(executeResult) <= 32)
+        {
+            MessageBoxW(
+                m_assetsListView,
+                L"Visual Studio または関連付けられたエディタを起動できませんでした。",
+                L"Assets",
+                MB_OK | MB_ICONERROR);
+        }
+
         return true;
     }
 

--- a/Editor/Source/AssetsPanelController.cpp
+++ b/Editor/Source/AssetsPanelController.cpp
@@ -241,6 +241,11 @@ namespace Xelqoria::Editor
         constexpr UINT_PTR CreateSpriteMenuCommandId = 1;
 
         /// <summary>
+        /// Assets の右クリックメニューから Script Asset を作成するコマンド ID を表す。
+        /// </summary>
+        constexpr UINT_PTR CreateScriptMenuCommandId = 3;
+
+        /// <summary>
         /// Assets 項目の削除メニューから実行されたコマンド ID を表す。
         /// </summary>
         constexpr UINT_PTR DeleteEntryMenuCommandId = 2;
@@ -268,6 +273,8 @@ namespace Xelqoria::Editor
             m_canPlaceDraggingAssetInScene = false;
             m_createSpriteRequested = false;
             m_createSpriteTargetDirectory.clear();
+            m_createScriptRequested = false;
+            m_createScriptTargetDirectory.clear();
             EndDragImage();
             RefreshListView();
             RefreshSummaryLabel();
@@ -354,7 +361,7 @@ namespace Xelqoria::Editor
                 return false;
             }
 
-            return ShowCreateSpriteContextMenu(createSpriteTargetDirectory, menuPoint);
+            return ShowCreateAssetContextMenu(createSpriteTargetDirectory, menuPoint);
         }
 
         if (notifyHeader->code == LVN_KEYDOWN)
@@ -537,9 +544,25 @@ namespace Xelqoria::Editor
         m_createSpriteTargetDirectory.clear();
     }
 
+    bool AssetsPanelController::HasCreateScriptRequest() const
+    {
+        return m_createScriptRequested;
+    }
+
+    void AssetsPanelController::ClearCreateScriptRequest()
+    {
+        m_createScriptRequested = false;
+        m_createScriptTargetDirectory.clear();
+    }
+
     const std::filesystem::path& AssetsPanelController::GetCreateSpriteTargetDirectory() const
     {
         return m_createSpriteTargetDirectory;
+    }
+
+    const std::filesystem::path& AssetsPanelController::GetCreateScriptTargetDirectory() const
+    {
+        return m_createScriptTargetDirectory;
     }
 
     void AssetsPanelController::InitializeListView()
@@ -874,7 +897,7 @@ namespace Xelqoria::Editor
         return DeleteEntry(entryIndex);
     }
 
-    bool AssetsPanelController::ShowCreateSpriteContextMenu(
+    bool AssetsPanelController::ShowCreateAssetContextMenu(
         const std::filesystem::path& targetDirectory,
         POINT screenPoint)
     {
@@ -895,6 +918,7 @@ namespace Xelqoria::Editor
         }
 
         AppendMenuW(popupMenu, MF_STRING, CreateSpriteMenuCommandId, L"Spriteを作成");
+        AppendMenuW(popupMenu, MF_STRING, CreateScriptMenuCommandId, L"Scriptを作成");
 
         const UINT command = TrackPopupMenu(
             popupMenu,
@@ -906,14 +930,26 @@ namespace Xelqoria::Editor
             nullptr);
         DestroyMenu(popupMenu);
 
-        if (CreateSpriteMenuCommandId != command)
+        if (CreateSpriteMenuCommandId == command)
+        {
+            m_createSpriteRequested = true;
+            m_createSpriteTargetDirectory = targetDirectory;
+            return true;
+        }
+
+        if (CreateScriptMenuCommandId == command)
+        {
+            m_createScriptRequested = true;
+            m_createScriptTargetDirectory = targetDirectory;
+            return true;
+        }
+
+        if (0 != command)
         {
             return false;
         }
 
-        m_createSpriteRequested = true;
-        m_createSpriteTargetDirectory = targetDirectory;
-        return true;
+        return false;
     }
 
     bool AssetsPanelController::DeleteEntry(std::size_t entryIndex)

--- a/Editor/Source/AssetsPanelController.cpp
+++ b/Editor/Source/AssetsPanelController.cpp
@@ -247,6 +247,11 @@ namespace Xelqoria::Editor
         constexpr UINT_PTR CreateScriptMenuCommandId = 3;
 
         /// <summary>
+        /// Sprite Asset へ Script Asset を割り当てるコマンド ID を表す。
+        /// </summary>
+        constexpr UINT_PTR AssignScriptMenuCommandId = 4;
+
+        /// <summary>
         /// Assets 項目の削除メニューから実行されたコマンド ID を表す。
         /// </summary>
         constexpr UINT_PTR DeleteEntryMenuCommandId = 2;
@@ -276,6 +281,8 @@ namespace Xelqoria::Editor
             m_createSpriteTargetDirectory.clear();
             m_createScriptRequested = false;
             m_createScriptTargetDirectory.clear();
+            m_assignScriptRequested = false;
+            m_assignScriptSpriteAssetPath.clear();
             EndDragImage();
             RefreshListView();
             RefreshSummaryLabel();
@@ -556,6 +563,17 @@ namespace Xelqoria::Editor
         m_createScriptTargetDirectory.clear();
     }
 
+    bool AssetsPanelController::HasAssignScriptRequest() const
+    {
+        return m_assignScriptRequested;
+    }
+
+    void AssetsPanelController::ClearAssignScriptRequest()
+    {
+        m_assignScriptRequested = false;
+        m_assignScriptSpriteAssetPath.clear();
+    }
+
     const std::filesystem::path& AssetsPanelController::GetCreateSpriteTargetDirectory() const
     {
         return m_createSpriteTargetDirectory;
@@ -564,6 +582,11 @@ namespace Xelqoria::Editor
     const std::filesystem::path& AssetsPanelController::GetCreateScriptTargetDirectory() const
     {
         return m_createScriptTargetDirectory;
+    }
+
+    const std::filesystem::path& AssetsPanelController::GetAssignScriptSpriteAssetPath() const
+    {
+        return m_assignScriptSpriteAssetPath;
     }
 
     void AssetsPanelController::InitializeListView()
@@ -919,6 +942,11 @@ namespace Xelqoria::Editor
             MF_STRING,
             DeleteEntryMenuCommandId,
             entry.isDirectory ? L"フォルダを削除する" : L"ファイルを削除する");
+        if (false == entry.isDirectory && EditorAssetPathUtils::IsSpriteAssetFile(entry.path))
+        {
+            AppendMenuW(popupMenu, MF_SEPARATOR, 0, nullptr);
+            AppendMenuW(popupMenu, MF_STRING, AssignScriptMenuCommandId, L"Scriptを割り当て");
+        }
 
         const UINT command = TrackPopupMenu(
             popupMenu,
@@ -929,6 +957,13 @@ namespace Xelqoria::Editor
             m_assetsListView,
             nullptr);
         DestroyMenu(popupMenu);
+
+        if (AssignScriptMenuCommandId == command)
+        {
+            m_assignScriptRequested = true;
+            m_assignScriptSpriteAssetPath = entry.path;
+            return true;
+        }
 
         if (DeleteEntryMenuCommandId != command)
         {

--- a/Editor/Source/AssetsPanelController.h
+++ b/Editor/Source/AssetsPanelController.h
@@ -161,10 +161,27 @@ namespace Xelqoria::Editor
         void ClearCreateSpriteRequest();
 
         /// <summary>
+        /// Assets 空白右クリックから Script 作成が要求されたかを取得する。
+        /// </summary>
+        /// <returns>Script 作成要求がある場合は true。</returns>
+        [[nodiscard]] bool HasCreateScriptRequest() const;
+
+        /// <summary>
+        /// Script 作成要求を消費する。
+        /// </summary>
+        void ClearCreateScriptRequest();
+
+        /// <summary>
         /// Sprite アセットファイルの作成先フォルダを取得する。
         /// </summary>
         /// <returns>作成先フォルダ。未指定時は空。</returns>
         [[nodiscard]] const std::filesystem::path& GetCreateSpriteTargetDirectory() const;
+
+        /// <summary>
+        /// Script Asset ファイルの作成先フォルダを取得する。
+        /// </summary>
+        /// <returns>作成先フォルダ。未指定時は空。</returns>
+        [[nodiscard]] const std::filesystem::path& GetCreateScriptTargetDirectory() const;
 
     private:
         /// <summary>
@@ -241,10 +258,10 @@ namespace Xelqoria::Editor
         /// <summary>
         /// Assets 空白またはフォルダ用の作成メニューを表示する。
         /// </summary>
-        /// <param name="targetDirectory">Sprite 作成先フォルダ。</param>
+        /// <param name="targetDirectory">作成先フォルダ。</param>
         /// <param name="screenPoint">メニュー表示位置のスクリーン座標。</param>
         /// <returns>操作を処理した場合は true。</returns>
-        [[nodiscard]] bool ShowCreateSpriteContextMenu(
+        [[nodiscard]] bool ShowCreateAssetContextMenu(
             const std::filesystem::path& targetDirectory,
             POINT screenPoint);
 
@@ -335,6 +352,8 @@ namespace Xelqoria::Editor
         bool m_assetDragReleasedThisFrame = false;
         bool m_createSpriteRequested = false;
         std::filesystem::path m_createSpriteTargetDirectory{};
+        bool m_createScriptRequested = false;
+        std::filesystem::path m_createScriptTargetDirectory{};
         bool m_listViewInitialized = false;
         HIMAGELIST m_dragImageList = nullptr;
         bool m_isDragImageVisible = false;

--- a/Editor/Source/AssetsPanelController.h
+++ b/Editor/Source/AssetsPanelController.h
@@ -222,6 +222,13 @@ namespace Xelqoria::Editor
         [[nodiscard]] bool TryOpenEntry(std::size_t entryIndex);
 
         /// <summary>
+        /// Script Asset の管理 C++ ソースを関連付けられたアプリケーションで開く。
+        /// </summary>
+        /// <param name="entry">対象 Script Asset 項目。</param>
+        /// <returns>処理対象の Script Asset だった場合は true。</returns>
+        [[nodiscard]] bool TryOpenScriptAssetSource(const AssetListEntry& entry);
+
+        /// <summary>
         /// 現在選択しているフォルダ項目を開く。
         /// </summary>
         /// <returns>フォルダ移動した場合は true。</returns>

--- a/Editor/Source/AssetsPanelController.h
+++ b/Editor/Source/AssetsPanelController.h
@@ -172,6 +172,17 @@ namespace Xelqoria::Editor
         void ClearCreateScriptRequest();
 
         /// <summary>
+        /// Sprite Asset への Script 割り当て要求があるかを取得する。
+        /// </summary>
+        /// <returns>割り当て要求がある場合は true。</returns>
+        [[nodiscard]] bool HasAssignScriptRequest() const;
+
+        /// <summary>
+        /// Script 割り当て要求を消費する。
+        /// </summary>
+        void ClearAssignScriptRequest();
+
+        /// <summary>
         /// Sprite アセットファイルの作成先フォルダを取得する。
         /// </summary>
         /// <returns>作成先フォルダ。未指定時は空。</returns>
@@ -182,6 +193,12 @@ namespace Xelqoria::Editor
         /// </summary>
         /// <returns>作成先フォルダ。未指定時は空。</returns>
         [[nodiscard]] const std::filesystem::path& GetCreateScriptTargetDirectory() const;
+
+        /// <summary>
+        /// Script を割り当てる Sprite Asset ファイルパスを取得する。
+        /// </summary>
+        /// <returns>割り当て先 Sprite Asset ファイルパス。</returns>
+        [[nodiscard]] const std::filesystem::path& GetAssignScriptSpriteAssetPath() const;
 
     private:
         /// <summary>
@@ -361,6 +378,8 @@ namespace Xelqoria::Editor
         std::filesystem::path m_createSpriteTargetDirectory{};
         bool m_createScriptRequested = false;
         std::filesystem::path m_createScriptTargetDirectory{};
+        bool m_assignScriptRequested = false;
+        std::filesystem::path m_assignScriptSpriteAssetPath{};
         bool m_listViewInitialized = false;
         HIMAGELIST m_dragImageList = nullptr;
         bool m_isDragImageVisible = false;

--- a/Editor/Source/EditorAssetPathUtils.cpp
+++ b/Editor/Source/EditorAssetPathUtils.cpp
@@ -47,6 +47,11 @@ namespace Xelqoria::Editor::EditorAssetPathUtils
             || extension == L".bmp";
     }
 
+    bool IsSpriteAssetFile(const std::filesystem::path& path)
+    {
+        return path.extension() == L".sprite";
+    }
+
     Core::AssetId BuildTextureAssetId(
         const std::filesystem::path& path,
         const std::filesystem::path& assetsRootDirectory)

--- a/Editor/Source/EditorAssetPathUtils.h
+++ b/Editor/Source/EditorAssetPathUtils.h
@@ -14,6 +14,13 @@ namespace Xelqoria::Editor::EditorAssetPathUtils
     [[nodiscard]] bool IsTextureImageFile(const std::filesystem::path& path);
 
     /// <summary>
+    /// 指定パスが Sprite Asset ファイルかを判定する。
+    /// </summary>
+    /// <param name="path">判定対象パス。</param>
+    /// <returns>Sprite Asset ファイルの場合は true。</returns>
+    [[nodiscard]] bool IsSpriteAssetFile(const std::filesystem::path& path);
+
+    /// <summary>
     /// プロジェクトルート基準の画像ファイルパスから TextureAssetId を生成する。
     /// </summary>
     /// <param name="path">画像ファイルパス。</param>
@@ -24,7 +31,7 @@ namespace Xelqoria::Editor::EditorAssetPathUtils
         const std::filesystem::path& assetsRootDirectory);
 
     /// <summary>
-    /// プロジェクトルート基準の画像ファイルパスから SpriteAssetId を生成する。
+    /// プロジェクトルート基準のアセットファイルパスから SpriteAssetId を生成する。
     /// </summary>
     /// <param name="path">画像ファイルパス。</param>
     /// <param name="assetsRootDirectory">AssetId の基準になるプロジェクトルート。</param>

--- a/Editor/Source/EditorSceneDocument.cpp
+++ b/Editor/Source/EditorSceneDocument.cpp
@@ -7,9 +7,12 @@
 #include <iomanip>
 #include <memory>
 #include <sstream>
+#include <string>
+#include <string_view>
 #include <system_error>
 
 #include "Assets/SpriteAsset.h"
+#include "Assets/SpriteAssetLoader.h"
 #include "SceneSerializer.h"
 #include "SpriteComponent.h"
 #include "Texture2D.h"
@@ -41,6 +44,67 @@ namespace Xelqoria::Editor
         void AppendVector3(std::ostringstream& stream, const Math::Vector3& value)
         {
             stream << value.x << "," << value.y << "," << value.z;
+        }
+
+        /// <summary>
+        /// `key=value` 形式の行かを判定する。
+        /// </summary>
+        /// <param name="line">判定対象行。</param>
+        /// <param name="key">確認するキー。</param>
+        /// <returns>対象キーの行の場合は true。</returns>
+        [[nodiscard]] bool IsFieldLine(std::string_view line, std::string_view key)
+        {
+            return line.size() > key.size()
+                && line.substr(0, key.size()) == key
+                && line[key.size()] == '=';
+        }
+
+        /// <summary>
+        /// Sprite Asset テキストの scriptAssetId フィールドを書き換える。
+        /// </summary>
+        /// <param name="source">元の Sprite Asset テキスト。</param>
+        /// <param name="scriptAssetId">保存する Script AssetId。</param>
+        /// <returns>書き換え後の Sprite Asset テキスト。</returns>
+        [[nodiscard]] std::string ReplaceSpriteAssetScriptAssetId(
+            std::string_view source,
+            const Core::AssetId& scriptAssetId)
+        {
+            std::ostringstream output;
+            bool wroteScriptAssetId = false;
+            std::size_t cursor = 0;
+            while (cursor <= source.size())
+            {
+                const std::size_t lineEnd = source.find('\n', cursor);
+                const std::size_t lineLength = lineEnd == std::string_view::npos
+                    ? source.size() - cursor
+                    : lineEnd - cursor;
+                const std::string_view line = source.substr(cursor, lineLength);
+
+                if (IsFieldLine(line, "scriptAssetId"))
+                {
+                    output << "scriptAssetId=" << scriptAssetId.GetValue();
+                    wroteScriptAssetId = true;
+                }
+                else
+                {
+                    output << line;
+                }
+
+                output << "\n";
+                if (lineEnd == std::string_view::npos)
+                {
+                    break;
+                }
+
+                cursor = lineEnd + 1;
+            }
+
+            if (false == wroteScriptAssetId)
+            {
+                output << "scriptAssetId=" << scriptAssetId.GetValue() << "\n";
+            }
+
+            return output.str();
         }
     }
 
@@ -221,10 +285,16 @@ namespace Xelqoria::Editor
 
             if (entry.is_regular_file(errorCode)
                 && false == static_cast<bool>(errorCode)
-                && EditorPathSecurity::IsPathInsideOrEqual(entry.path(), rootDirectory)
-                && EditorAssetPathUtils::IsTextureImageFile(entry.path()))
+                && EditorPathSecurity::IsPathInsideOrEqual(entry.path(), rootDirectory))
             {
-                (void)RegisterImageAsset(entry.path());
+                if (EditorAssetPathUtils::IsTextureImageFile(entry.path()))
+                {
+                    (void)RegisterImageAsset(entry.path());
+                }
+                else if (EditorAssetPathUtils::IsSpriteAssetFile(entry.path()))
+                {
+                    (void)RegisterSpriteAssetFile(entry.path());
+                }
             }
         }
     }
@@ -279,6 +349,54 @@ namespace Xelqoria::Editor
         return true;
     }
 
+    bool EditorSceneDocument::RegisterSpriteAssetFile(const std::filesystem::path& spriteAssetPath)
+    {
+        if (false == m_project.GetInfo().has_value()
+            || false == EditorAssetPathUtils::IsSpriteAssetFile(spriteAssetPath))
+        {
+            return false;
+        }
+
+        const std::filesystem::path rootDirectory = m_project.GetInfo()->projectFilePath.parent_path();
+        if (false == EditorPathSecurity::IsPathInsideOrEqual(spriteAssetPath, rootDirectory))
+        {
+            return false;
+        }
+
+        std::ifstream input(spriteAssetPath, std::ios::binary);
+        if (false == input.is_open())
+        {
+            return false;
+        }
+
+        std::ostringstream buffer;
+        buffer << input.rdbuf();
+        const auto loadResult = Game::Assets::SpriteAssetLoader::LoadFromText(buffer.str());
+        if (false == loadResult.IsSuccess() || false == loadResult.asset.has_value())
+        {
+            return false;
+        }
+
+        const Core::AssetId spriteAssetId =
+            EditorAssetPathUtils::BuildSpriteAssetId(spriteAssetPath, rootDirectory);
+        if (spriteAssetId.IsEmpty())
+        {
+            return false;
+        }
+
+        m_spriteAssetRegistry.RegisterSpriteAsset(spriteAssetId, *loadResult.asset);
+        const auto alreadyRegistered = std::find(
+            m_registeredSpriteAssetIds.begin(),
+            m_registeredSpriteAssetIds.end(),
+            spriteAssetId);
+        if (alreadyRegistered == m_registeredSpriteAssetIds.end())
+        {
+            m_registeredSpriteAssetIds.push_back(spriteAssetId);
+        }
+
+        return true;
+    }
+
     bool EditorSceneDocument::CreateSpriteAssetFile(
         const Game::Entity& entity,
         const std::filesystem::path& targetDirectory)
@@ -318,16 +436,11 @@ namespace Xelqoria::Editor
         }
 
         const std::filesystem::path spriteAssetPath = outputDirectory / (ToWideString(entity.GetName()) + L".sprite");
-        std::ofstream output(spriteAssetPath, std::ios::binary | std::ios::trunc);
-        if (false == output.is_open())
-        {
-            return false;
-        }
-
         const Game::Transform& transform = entity.GetTransform();
         const auto spriteComponent = entity.GetSpriteComponent();
         Core::AssetId spriteAssetRef{};
         Core::AssetId textureAssetId{};
+        Core::AssetId scriptAssetId{};
         std::uint32_t textureWidth = 0;
         std::uint32_t textureHeight = 0;
         Game::SpriteRenderSettings renderSettings{};
@@ -341,6 +454,7 @@ namespace Xelqoria::Editor
             if (spriteAsset.has_value())
             {
                 textureAssetId = spriteAsset->textureAssetId;
+                scriptAssetId = spriteAsset->scriptAssetId;
                 const auto texture = m_textureAssetRegistry.ResolveTexture(textureAssetId);
                 if (static_cast<bool>(texture))
                 {
@@ -348,6 +462,27 @@ namespace Xelqoria::Editor
                     textureHeight = texture->GetHeight();
                 }
             }
+        }
+
+        if (scriptAssetId.IsEmpty() && std::filesystem::exists(spriteAssetPath))
+        {
+            std::ifstream existingInput(spriteAssetPath, std::ios::binary);
+            if (existingInput.is_open())
+            {
+                std::ostringstream buffer;
+                buffer << existingInput.rdbuf();
+                const auto loadResult = Game::Assets::SpriteAssetLoader::LoadFromText(buffer.str());
+                if (loadResult.IsSuccess() && loadResult.asset.has_value())
+                {
+                    scriptAssetId = loadResult.asset->scriptAssetId;
+                }
+            }
+        }
+
+        std::ofstream output(spriteAssetPath, std::ios::binary | std::ios::trunc);
+        if (false == output.is_open())
+        {
+            return false;
         }
 
         std::ostringstream text;
@@ -367,6 +502,7 @@ namespace Xelqoria::Editor
         text << "hasSpriteComponent=" << (spriteComponent.has_value() ? "true" : "false") << "\n";
         text << "spriteAssetRef=" << spriteAssetRef.GetValue() << "\n";
         text << "textureAssetId=" << textureAssetId.GetValue() << "\n";
+        text << "scriptAssetId=" << scriptAssetId.GetValue() << "\n";
         text << "texture.size=" << textureWidth << "," << textureHeight << "\n";
         text << "render.visible=" << (renderSettings.visible ? "true" : "false") << "\n";
         text << "render.sortOrder=" << renderSettings.sortOrder << "\n";
@@ -374,6 +510,61 @@ namespace Xelqoria::Editor
 
         output << text.str();
         return static_cast<bool>(output);
+    }
+
+    bool EditorSceneDocument::AssignScriptAssetToSpriteAssetFile(
+        const std::filesystem::path& spriteAssetPath,
+        const std::filesystem::path& scriptAssetPath)
+    {
+        if (false == m_project.GetInfo().has_value()
+            || false == EditorAssetPathUtils::IsSpriteAssetFile(spriteAssetPath)
+            || false == ScriptAssetService::IsScriptAssetFile(scriptAssetPath))
+        {
+            return false;
+        }
+
+        const std::filesystem::path rootDirectory = m_project.GetInfo()->projectFilePath.parent_path();
+        if (false == EditorPathSecurity::IsPathInsideOrEqual(spriteAssetPath, rootDirectory)
+            || false == EditorPathSecurity::IsPathInsideOrEqual(scriptAssetPath, rootDirectory))
+        {
+            return false;
+        }
+
+        const Core::AssetId scriptAssetId =
+            ScriptAssetService::BuildScriptAssetId(rootDirectory, scriptAssetPath);
+        if (scriptAssetId.IsEmpty())
+        {
+            return false;
+        }
+
+        std::ifstream input(spriteAssetPath, std::ios::binary);
+        if (false == input.is_open())
+        {
+            return false;
+        }
+
+        std::ostringstream buffer;
+        buffer << input.rdbuf();
+        const std::string source = buffer.str();
+        const auto loadResult = Game::Assets::SpriteAssetLoader::LoadFromText(source);
+        if (false == loadResult.IsSuccess() || false == loadResult.asset.has_value())
+        {
+            return false;
+        }
+
+        std::ofstream output(spriteAssetPath, std::ios::binary | std::ios::trunc);
+        if (false == output.is_open())
+        {
+            return false;
+        }
+
+        output << ReplaceSpriteAssetScriptAssetId(source, scriptAssetId);
+        if (false == static_cast<bool>(output))
+        {
+            return false;
+        }
+
+        return RegisterSpriteAssetFile(spriteAssetPath);
     }
 
     ScriptAssetCreationResult EditorSceneDocument::CreateScriptAssetFile(

--- a/Editor/Source/EditorSceneDocument.cpp
+++ b/Editor/Source/EditorSceneDocument.cpp
@@ -25,6 +25,7 @@
 #include "EditorAssetPathUtils.h"
 #include "EditorPathSecurity.h"
 #include "EditorStringUtils.h"
+#include "ScriptAssetService.h"
 
 namespace Xelqoria::Editor
 {
@@ -373,6 +374,19 @@ namespace Xelqoria::Editor
 
         output << text.str();
         return static_cast<bool>(output);
+    }
+
+    ScriptAssetCreationResult EditorSceneDocument::CreateScriptAssetFile(
+        const std::filesystem::path& targetDirectory)
+    {
+        if (false == m_project.GetInfo().has_value())
+        {
+            return {};
+        }
+
+        return ScriptAssetService::CreateScriptAsset(
+            m_project.GetInfo()->projectFilePath.parent_path(),
+            targetDirectory);
     }
 
     const std::optional<EditorProjectInfo>& EditorSceneDocument::GetProjectInfo() const

--- a/Editor/Source/EditorSceneDocument.h
+++ b/Editor/Source/EditorSceneDocument.h
@@ -101,6 +101,13 @@ namespace Xelqoria::Editor
         [[nodiscard]] bool RegisterImageAsset(const std::filesystem::path& imagePath);
 
         /// <summary>
+        /// 指定 Sprite Asset ファイルを SpriteAsset として登録する。
+        /// </summary>
+        /// <param name="spriteAssetPath">登録対象の Sprite Asset ファイルパス。</param>
+        /// <returns>登録に成功した場合は true。</returns>
+        [[nodiscard]] bool RegisterSpriteAssetFile(const std::filesystem::path& spriteAssetPath);
+
+        /// <summary>
         /// Entity の Sprite 情報に対応する Sprite アセットファイルをプロジェクト配下へ作成する。
         /// </summary>
         /// <param name="entity">保存元の Sprite Entity。</param>
@@ -109,6 +116,16 @@ namespace Xelqoria::Editor
         [[nodiscard]] bool CreateSpriteAssetFile(
             const Game::Entity& entity,
             const std::filesystem::path& targetDirectory);
+
+        /// <summary>
+        /// Sprite Asset ファイルへ Script Asset の割り当てを保存する。
+        /// </summary>
+        /// <param name="spriteAssetPath">割り当て先 Sprite Asset ファイルパス。</param>
+        /// <param name="scriptAssetPath">割り当てる Script Asset ファイルパス。</param>
+        /// <returns>保存に成功した場合は true。</returns>
+        [[nodiscard]] bool AssignScriptAssetToSpriteAssetFile(
+            const std::filesystem::path& spriteAssetPath,
+            const std::filesystem::path& scriptAssetPath);
 
         /// <summary>
         /// 現在のプロジェクト配下へ Script Asset と初期 C++ コードを作成する。

--- a/Editor/Source/EditorSceneDocument.h
+++ b/Editor/Source/EditorSceneDocument.h
@@ -12,6 +12,7 @@
 #include "EditorProject.h"
 #include "IGraphicsContext.h"
 #include "Scene.h"
+#include "ScriptAssetService.h"
 #include "TextureAssetRegistry.h"
 
 namespace Xelqoria::Editor
@@ -107,6 +108,14 @@ namespace Xelqoria::Editor
         /// <returns>作成または既存ファイル確認に成功した場合は true。</returns>
         [[nodiscard]] bool CreateSpriteAssetFile(
             const Game::Entity& entity,
+            const std::filesystem::path& targetDirectory);
+
+        /// <summary>
+        /// 現在のプロジェクト配下へ Script Asset と初期 C++ コードを作成する。
+        /// </summary>
+        /// <param name="targetDirectory">Script Asset 作成先フォルダ。空またはプロジェクト外の場合は作成しない。</param>
+        /// <returns>Script Asset 作成結果。</returns>
+        [[nodiscard]] ScriptAssetCreationResult CreateScriptAssetFile(
             const std::filesystem::path& targetDirectory);
 
         /// <summary>

--- a/Editor/Source/ScriptAssetService.cpp
+++ b/Editor/Source/ScriptAssetService.cpp
@@ -185,6 +185,29 @@ namespace Xelqoria::Editor
         return path.extension() == ScriptAssetExtension;
     }
 
+    Core::AssetId ScriptAssetService::BuildScriptAssetId(
+        const std::filesystem::path& projectRootDirectory,
+        const std::filesystem::path& assetPath)
+    {
+        if (projectRootDirectory.empty()
+            || assetPath.empty()
+            || false == IsScriptAssetFile(assetPath)
+            || false == EditorPathSecurity::IsPathInsideOrEqual(assetPath, projectRootDirectory))
+        {
+            return {};
+        }
+
+        std::error_code errorCode;
+        const std::filesystem::path relativeAssetPath =
+            std::filesystem::relative(assetPath, projectRootDirectory, errorCode);
+        if (errorCode || false == EditorPathSecurity::IsSafeRelativePath(relativeAssetPath))
+        {
+            return {};
+        }
+
+        return Xelqoria::Editor::BuildScriptAssetId(relativeAssetPath);
+    }
+
     std::optional<std::filesystem::path> ScriptAssetService::ResolveSourcePath(
         const std::filesystem::path& projectRootDirectory,
         const std::filesystem::path& assetPath)
@@ -291,7 +314,8 @@ namespace Xelqoria::Editor
         result.succeeded = true;
         result.assetPath = assetPath;
         result.sourcePath = sourcePath;
-        result.scriptAssetId = BuildScriptAssetId(relativeAssetPath);
+        result.scriptAssetId = Xelqoria::Editor::BuildScriptAssetId(relativeAssetPath);
         return result;
     }
+
 }

--- a/Editor/Source/ScriptAssetService.cpp
+++ b/Editor/Source/ScriptAssetService.cpp
@@ -1,5 +1,8 @@
 #include "ScriptAssetService.h"
 
+#include <algorithm>
+#include <array>
+#include <cstdio>
 #include <fstream>
 #include <iomanip>
 #include <optional>
@@ -18,6 +21,7 @@ namespace Xelqoria::Editor
         constexpr const wchar_t* DefaultScriptName = L"NewScript";
         constexpr const wchar_t* ScriptAssetExtension = L".script";
         constexpr const wchar_t* ManagedScriptsDirectory = L".xelqoria/Scripts";
+        constexpr const wchar_t* ScriptBuildDirectory = L".xelqoria/ScriptBuild";
 
         /// <summary>
         /// Script Asset の既定名から未使用ファイルパスを取得する。
@@ -61,6 +65,119 @@ namespace Xelqoria::Editor
             }
 
             return value;
+        }
+
+        /// <summary>
+        /// コマンドライン引数として渡す文字列を引用符で囲む。
+        /// </summary>
+        /// <param name="value">引用符で囲む値。</param>
+        /// <returns>コマンドライン向け文字列。</returns>
+        [[nodiscard]] std::wstring QuoteCommandArgument(const std::filesystem::path& value)
+        {
+            std::wstring quoted = L"\"";
+            for (const wchar_t character : value.wstring())
+            {
+                if (L'"' == character)
+                {
+                    quoted += L'\\';
+                }
+
+                quoted += character;
+            }
+
+            quoted += L"\"";
+            return quoted;
+        }
+
+        /// <summary>
+        /// 外部コマンドを実行して標準出力と標準エラーを取得する。
+        /// </summary>
+        /// <param name="commandLine">実行するコマンドライン。</param>
+        /// <param name="output">取得した出力。</param>
+        /// <returns>プロセス終了コード。起動失敗時は -1。</returns>
+        [[nodiscard]] int RunCommandAndCaptureOutput(const std::wstring& commandLine, std::wstring& output)
+        {
+#if defined(_WIN32)
+            FILE* pipe = _popen(ToNarrowString(commandLine).c_str(), "r");
+            if (nullptr == pipe)
+            {
+                output += L"コンパイラ プロセスを開始できませんでした。\n";
+                return -1;
+            }
+
+            std::array<char, 512> buffer{};
+            while (nullptr != fgets(buffer.data(), static_cast<int>(buffer.size()), pipe))
+            {
+                output += ToWideString(buffer.data());
+            }
+
+            return _pclose(pipe);
+#else
+            (void)commandLine;
+            output += L"Script ビルドは Windows Editor でのみ実行できます。\n";
+            return -1;
+#endif
+        }
+
+        /// <summary>
+        /// Script Asset ファイルをプロジェクト配下から列挙する。
+        /// </summary>
+        /// <param name="projectRootDirectory">プロジェクトルートディレクトリ。</param>
+        /// <returns>Script Asset ファイル一覧。</returns>
+        [[nodiscard]] std::vector<std::filesystem::path> EnumerateScriptAssetFiles(
+            const std::filesystem::path& projectRootDirectory)
+        {
+            std::vector<std::filesystem::path> assetPaths{};
+            std::error_code errorCode;
+            for (const std::filesystem::directory_entry& entry :
+                std::filesystem::recursive_directory_iterator(projectRootDirectory, errorCode))
+            {
+                if (errorCode)
+                {
+                    break;
+                }
+
+                if (entry.is_regular_file(errorCode)
+                    && false == static_cast<bool>(errorCode)
+                    && entry.path().extension() == ScriptAssetExtension)
+                {
+                    assetPaths.push_back(entry.path());
+                }
+            }
+
+            std::sort(assetPaths.begin(), assetPaths.end());
+            return assetPaths;
+        }
+
+        /// <summary>
+        /// コンパイル出力先 object ファイルパスを作成する。
+        /// </summary>
+        /// <param name="projectRootDirectory">プロジェクトルートディレクトリ。</param>
+        /// <param name="sourcePath">コンパイル対象ソース。</param>
+        /// <param name="index">同名回避用インデックス。</param>
+        /// <returns>object ファイルパス。</returns>
+        [[nodiscard]] std::filesystem::path BuildObjectPath(
+            const std::filesystem::path& projectRootDirectory,
+            const std::filesystem::path& sourcePath,
+            std::size_t index)
+        {
+            std::error_code errorCode;
+            std::filesystem::path relativeSourcePath =
+                std::filesystem::relative(sourcePath, projectRootDirectory, errorCode);
+            if (errorCode || relativeSourcePath.empty())
+            {
+                relativeSourcePath = sourcePath.filename();
+            }
+
+            std::wstring objectStem = SanitizeManagedCodeStem(relativeSourcePath.generic_wstring());
+            if (objectStem.empty())
+            {
+                objectStem = L"Script";
+            }
+
+            return projectRootDirectory
+                / ScriptBuildDirectory
+                / (std::to_wstring(index) + L"_" + objectStem + L".obj");
         }
 
         /// <summary>
@@ -315,6 +432,108 @@ namespace Xelqoria::Editor
         result.assetPath = assetPath;
         result.sourcePath = sourcePath;
         result.scriptAssetId = Xelqoria::Editor::BuildScriptAssetId(relativeAssetPath);
+        return result;
+    }
+
+    ScriptBuildResult ScriptAssetService::BuildProjectScripts(
+        const std::filesystem::path& projectRootDirectory,
+        const ScriptBuildOptions& options)
+    {
+        ScriptBuildResult result{};
+        if (projectRootDirectory.empty())
+        {
+            result.diagnostics = L"Script ビルド対象のプロジェクトが開かれていません。";
+            return result;
+        }
+
+        std::error_code errorCode;
+        if (false == std::filesystem::is_directory(projectRootDirectory, errorCode) || errorCode)
+        {
+            result.diagnostics = L"Script ビルド対象のプロジェクトルートを確認できません。";
+            return result;
+        }
+
+        const std::vector<std::filesystem::path> scriptAssetPaths =
+            EnumerateScriptAssetFiles(projectRootDirectory);
+        if (scriptAssetPaths.empty())
+        {
+            result.succeeded = true;
+            result.diagnostics = L"Script Asset はありません。";
+            return result;
+        }
+
+        const std::filesystem::path buildDirectory = projectRootDirectory / ScriptBuildDirectory;
+        std::filesystem::create_directories(buildDirectory, errorCode);
+        if (errorCode)
+        {
+            result.diagnostics = L"Script ビルド出力フォルダを作成できません。";
+            return result;
+        }
+
+        std::wostringstream diagnostics{};
+        bool allSucceeded = true;
+        std::size_t compiledCount = 0;
+        for (const std::filesystem::path& scriptAssetPath : scriptAssetPaths)
+        {
+            const std::optional<std::filesystem::path> sourcePath =
+                ResolveSourcePath(projectRootDirectory, scriptAssetPath);
+            if (false == sourcePath.has_value())
+            {
+                allSucceeded = false;
+                diagnostics << L"[Script] " << scriptAssetPath.wstring()
+                    << L": 管理 C++ ソースの参照を解決できません。\n";
+                continue;
+            }
+
+            if (false == std::filesystem::exists(*sourcePath, errorCode) || errorCode)
+            {
+                allSucceeded = false;
+                diagnostics << L"[Script] " << scriptAssetPath.wstring()
+                    << L": 管理 C++ ソースが見つかりません: " << sourcePath->wstring() << L"\n";
+                continue;
+            }
+
+            result.sourcePaths.push_back(*sourcePath);
+            const std::filesystem::path objectPath =
+                BuildObjectPath(projectRootDirectory, *sourcePath, compiledCount);
+            ++compiledCount;
+
+            const std::wstring commandLine =
+                L"call "
+                + QuoteCommandArgument(options.compilerExecutable)
+                + L" /nologo /EHsc /std:c++20 /c "
+                + QuoteCommandArgument(*sourcePath)
+                + L" /Fo"
+                + QuoteCommandArgument(objectPath)
+                + L" 2>&1";
+
+            std::wstring compilerOutput{};
+            const int exitCode = RunCommandAndCaptureOutput(commandLine, compilerOutput);
+            diagnostics << L"[Script] " << sourcePath->wstring() << L"\n";
+            if (false == compilerOutput.empty())
+            {
+                diagnostics << compilerOutput;
+                if (compilerOutput.back() != L'\n')
+                {
+                    diagnostics << L"\n";
+                }
+            }
+
+            if (0 != exitCode)
+            {
+                allSucceeded = false;
+                diagnostics << L"終了コード: " << exitCode << L"\n";
+            }
+        }
+
+        result.succeeded = allSucceeded;
+        if (allSucceeded)
+        {
+            diagnostics << L"Script ビルドに成功しました。対象: "
+                << result.sourcePaths.size() << L" 件";
+        }
+
+        result.diagnostics = diagnostics.str();
         return result;
     }
 

--- a/Editor/Source/ScriptAssetService.cpp
+++ b/Editor/Source/ScriptAssetService.cpp
@@ -1,0 +1,206 @@
+#include "ScriptAssetService.h"
+
+#include <fstream>
+#include <iomanip>
+#include <sstream>
+#include <string>
+#include <system_error>
+
+#include "EditorPathSecurity.h"
+#include "EditorStringUtils.h"
+
+namespace Xelqoria::Editor
+{
+    namespace
+    {
+        constexpr const wchar_t* DefaultScriptName = L"NewScript";
+        constexpr const wchar_t* ScriptAssetExtension = L".script";
+        constexpr const wchar_t* ManagedScriptsDirectory = L".xelqoria/Scripts";
+
+        /// <summary>
+        /// Script Asset の既定名から未使用ファイルパスを取得する。
+        /// </summary>
+        /// <param name="targetDirectory">作成先ディレクトリ。</param>
+        /// <returns>未使用の Script Asset ファイルパス。</returns>
+        [[nodiscard]] std::filesystem::path FindAvailableScriptAssetPath(
+            const std::filesystem::path& targetDirectory)
+        {
+            std::filesystem::path candidate = targetDirectory / (std::wstring(DefaultScriptName) + ScriptAssetExtension);
+            for (int index = 1; std::filesystem::exists(candidate); ++index)
+            {
+                candidate = targetDirectory
+                    / (std::wstring(DefaultScriptName) + std::to_wstring(index) + ScriptAssetExtension);
+            }
+
+            return candidate;
+        }
+
+        /// <summary>
+        /// 管理コードファイル名に使えない文字を置換する。
+        /// </summary>
+        /// <param name="value">変換対象文字列。</param>
+        /// <returns>安全なファイル名要素。</returns>
+        [[nodiscard]] std::wstring SanitizeManagedCodeStem(std::wstring value)
+        {
+            for (wchar_t& character : value)
+            {
+                if (character == L'/'
+                    || character == L'\\'
+                    || character == L':'
+                    || character == L'*'
+                    || character == L'?'
+                    || character == L'"'
+                    || character == L'<'
+                    || character == L'>'
+                    || character == L'|')
+                {
+                    character = L'_';
+                }
+            }
+
+            return value;
+        }
+
+        /// <summary>
+        /// Script Asset への相対パスから管理 C++ ソースの相対パスを構築する。
+        /// </summary>
+        /// <param name="relativeAssetPath">プロジェクトルート基準の Script Asset パス。</param>
+        /// <returns>プロジェクトルート基準の C++ ソースパス。</returns>
+        [[nodiscard]] std::filesystem::path BuildManagedSourceRelativePath(
+            const std::filesystem::path& relativeAssetPath)
+        {
+            std::filesystem::path sourceStem = relativeAssetPath;
+            sourceStem.replace_extension();
+            const std::wstring sourceFileName =
+                SanitizeManagedCodeStem(sourceStem.generic_wstring()) + L".cpp";
+            return std::filesystem::path(ManagedScriptsDirectory) / sourceFileName;
+        }
+
+        /// <summary>
+        /// Script AssetId を構築する。
+        /// </summary>
+        /// <param name="relativeAssetPath">プロジェクトルート基準の Script Asset パス。</param>
+        /// <returns>Script AssetId。</returns>
+        [[nodiscard]] Core::AssetId BuildScriptAssetId(const std::filesystem::path& relativeAssetPath)
+        {
+            return Core::AssetId("scripts/" + ToNarrowString(relativeAssetPath.generic_wstring()));
+        }
+
+        /// <summary>
+        /// Script Asset マニフェストを書き出す。
+        /// </summary>
+        /// <param name="assetPath">書き出し先 Script Asset ファイル。</param>
+        /// <param name="scriptName">Script 表示名。</param>
+        /// <param name="sourceRelativePath">管理 C++ ソースの相対パス。</param>
+        /// <returns>書き出しに成功した場合は true。</returns>
+        [[nodiscard]] bool WriteScriptAssetManifest(
+            const std::filesystem::path& assetPath,
+            const std::wstring& scriptName,
+            const std::filesystem::path& sourceRelativePath)
+        {
+            std::ofstream output(assetPath, std::ios::binary | std::ios::trunc);
+            if (false == output.is_open())
+            {
+                return false;
+            }
+
+            output << "magic=XelqoriaScriptAsset\n";
+            output << "version=1\n";
+            output << "language=cpp\n";
+            output << "name=" << std::quoted(ToNarrowString(scriptName)) << "\n";
+            output << "source=" << std::quoted(ToNarrowString(sourceRelativePath.generic_wstring())) << "\n";
+            return output.good();
+        }
+
+        /// <summary>
+        /// Start / Update を含む初期 C++ コードを書き出す。
+        /// </summary>
+        /// <param name="sourcePath">書き出し先 C++ ソースファイル。</param>
+        /// <returns>書き出しに成功した場合は true。</returns>
+        [[nodiscard]] bool WriteInitialScriptSource(const std::filesystem::path& sourcePath)
+        {
+            std::ofstream output(sourcePath, std::ios::binary | std::ios::trunc);
+            if (false == output.is_open())
+            {
+                return false;
+            }
+
+            output
+                << "void Start()\n"
+                << "{\n"
+                << "}\n"
+                << "\n"
+                << "void Update(float deltaTime)\n"
+                << "{\n"
+                << "    (void)deltaTime;\n"
+                << "}\n";
+            return output.good();
+        }
+    }
+
+    bool ScriptAssetService::IsScriptAssetFile(const std::filesystem::path& path)
+    {
+        return path.extension() == ScriptAssetExtension;
+    }
+
+    ScriptAssetCreationResult ScriptAssetService::CreateScriptAsset(
+        const std::filesystem::path& projectRootDirectory,
+        const std::filesystem::path& targetDirectory)
+    {
+        ScriptAssetCreationResult result{};
+        if (projectRootDirectory.empty() || targetDirectory.empty())
+        {
+            return result;
+        }
+
+        if (false == EditorPathSecurity::IsPathInsideOrEqual(targetDirectory, projectRootDirectory))
+        {
+            return result;
+        }
+
+        std::error_code errorCode;
+        if (false == std::filesystem::is_directory(targetDirectory, errorCode) || errorCode)
+        {
+            return result;
+        }
+
+        const std::filesystem::path assetPath = FindAvailableScriptAssetPath(targetDirectory);
+        const std::filesystem::path relativeAssetPath =
+            std::filesystem::relative(assetPath, projectRootDirectory, errorCode);
+        if (errorCode || false == EditorPathSecurity::IsSafeRelativePath(relativeAssetPath))
+        {
+            return result;
+        }
+
+        const std::filesystem::path sourceRelativePath = BuildManagedSourceRelativePath(relativeAssetPath);
+        if (false == EditorPathSecurity::IsSafeRelativePath(sourceRelativePath))
+        {
+            return result;
+        }
+
+        const std::filesystem::path sourcePath = projectRootDirectory / sourceRelativePath;
+        std::filesystem::create_directories(sourcePath.parent_path(), errorCode);
+        if (errorCode)
+        {
+            return result;
+        }
+
+        const std::wstring scriptName = assetPath.stem().wstring();
+        if (false == WriteScriptAssetManifest(assetPath, scriptName, sourceRelativePath))
+        {
+            return result;
+        }
+
+        if (false == WriteInitialScriptSource(sourcePath))
+        {
+            std::filesystem::remove(assetPath, errorCode);
+            return result;
+        }
+
+        result.succeeded = true;
+        result.assetPath = assetPath;
+        result.sourcePath = sourcePath;
+        result.scriptAssetId = BuildScriptAssetId(relativeAssetPath);
+        return result;
+    }
+}

--- a/Editor/Source/ScriptAssetService.cpp
+++ b/Editor/Source/ScriptAssetService.cpp
@@ -2,8 +2,10 @@
 
 #include <fstream>
 #include <iomanip>
+#include <optional>
 #include <sstream>
 #include <string>
+#include <string_view>
 #include <system_error>
 
 #include "EditorPathSecurity.h"
@@ -87,6 +89,46 @@ namespace Xelqoria::Editor
         }
 
         /// <summary>
+        /// `key=value` 行から値部分を取得する。
+        /// </summary>
+        /// <param name="line">解析対象行。</param>
+        /// <param name="key">取得対象キー。</param>
+        /// <returns>値。キーが一致しない場合は空。</returns>
+        [[nodiscard]] std::optional<std::string> ReadValue(std::string_view line, std::string_view key)
+        {
+            if (line.size() <= key.size() + 1 || line.substr(0, key.size()) != key || line[key.size()] != '=')
+            {
+                return std::nullopt;
+            }
+
+            return std::string(line.substr(key.size() + 1));
+        }
+
+        /// <summary>
+        /// 引用符付き文字列を復元する。
+        /// </summary>
+        /// <param name="value">復元対象文字列。</param>
+        /// <returns>復元した文字列。失敗時は空。</returns>
+        [[nodiscard]] std::optional<std::string> ParseQuotedString(std::string_view value)
+        {
+            std::istringstream stream{ std::string(value) };
+            std::string parsed{};
+            stream >> std::quoted(parsed);
+            if (false == static_cast<bool>(stream))
+            {
+                return std::nullopt;
+            }
+
+            stream >> std::ws;
+            if (std::char_traits<char>::eof() != stream.peek())
+            {
+                return std::nullopt;
+            }
+
+            return parsed;
+        }
+
+        /// <summary>
         /// Script Asset マニフェストを書き出す。
         /// </summary>
         /// <param name="assetPath">書き出し先 Script Asset ファイル。</param>
@@ -141,6 +183,55 @@ namespace Xelqoria::Editor
     bool ScriptAssetService::IsScriptAssetFile(const std::filesystem::path& path)
     {
         return path.extension() == ScriptAssetExtension;
+    }
+
+    std::optional<std::filesystem::path> ScriptAssetService::ResolveSourcePath(
+        const std::filesystem::path& projectRootDirectory,
+        const std::filesystem::path& assetPath)
+    {
+        if (projectRootDirectory.empty()
+            || assetPath.empty()
+            || false == IsScriptAssetFile(assetPath)
+            || false == EditorPathSecurity::IsPathInsideOrEqual(assetPath, projectRootDirectory))
+        {
+            return std::nullopt;
+        }
+
+        std::ifstream input(assetPath, std::ios::binary);
+        if (false == input.is_open())
+        {
+            return std::nullopt;
+        }
+
+        std::optional<std::string> sourceValue{};
+        std::string line{};
+        while (std::getline(input, line))
+        {
+            if (const auto value = ReadValue(line, "source"))
+            {
+                sourceValue = ParseQuotedString(*value);
+                break;
+            }
+        }
+
+        if (false == sourceValue.has_value())
+        {
+            return std::nullopt;
+        }
+
+        const std::filesystem::path sourceRelativePath = ToWideString(*sourceValue);
+        if (false == EditorPathSecurity::IsSafeRelativePath(sourceRelativePath))
+        {
+            return std::nullopt;
+        }
+
+        const std::filesystem::path sourcePath = projectRootDirectory / sourceRelativePath;
+        if (false == EditorPathSecurity::IsPathInsideOrEqual(sourcePath, projectRootDirectory))
+        {
+            return std::nullopt;
+        }
+
+        return sourcePath;
     }
 
     ScriptAssetCreationResult ScriptAssetService::CreateScriptAsset(

--- a/Editor/Source/ScriptAssetService.h
+++ b/Editor/Source/ScriptAssetService.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <filesystem>
+#include <optional>
 
 #include "AssetId.h"
 
@@ -44,6 +45,16 @@ namespace Xelqoria::Editor
         /// <param name="path">判定対象パス。</param>
         /// <returns>Script Asset ファイルの場合は true。</returns>
         [[nodiscard]] static bool IsScriptAssetFile(const std::filesystem::path& path);
+
+        /// <summary>
+        /// Script Asset マニフェストから Editor 管理下の C++ ソースパスを解決する。
+        /// </summary>
+        /// <param name="projectRootDirectory">プロジェクトルートディレクトリ。</param>
+        /// <param name="assetPath">Script Asset ファイルパス。</param>
+        /// <returns>解決できた C++ ソースパス。失敗時は空。</returns>
+        [[nodiscard]] static std::optional<std::filesystem::path> ResolveSourcePath(
+            const std::filesystem::path& projectRootDirectory,
+            const std::filesystem::path& assetPath);
 
         /// <summary>
         /// Script Asset と初期 C++ コードを作成する。

--- a/Editor/Source/ScriptAssetService.h
+++ b/Editor/Source/ScriptAssetService.h
@@ -2,6 +2,8 @@
 
 #include <filesystem>
 #include <optional>
+#include <string>
+#include <vector>
 
 #include "AssetId.h"
 
@@ -31,6 +33,38 @@ namespace Xelqoria::Editor
         /// 作成した Script Asset の識別子を表す。
         /// </summary>
         Core::AssetId scriptAssetId{};
+    };
+
+    /// <summary>
+    /// Script 管理 C++ ソースのビルド設定を表す。
+    /// </summary>
+    struct ScriptBuildOptions
+    {
+        /// <summary>
+        /// C++ コンパイラ実行ファイルまたはコマンドを表す。
+        /// </summary>
+        std::filesystem::path compilerExecutable = L"cl.exe";
+    };
+
+    /// <summary>
+    /// Script 管理 C++ ソースのビルド結果を表す。
+    /// </summary>
+    struct ScriptBuildResult
+    {
+        /// <summary>
+        /// ビルドに成功したかを表す。
+        /// </summary>
+        bool succeeded = false;
+
+        /// <summary>
+        /// ビルド対象になった C++ ソースファイル一覧を表す。
+        /// </summary>
+        std::vector<std::filesystem::path> sourcePaths{};
+
+        /// <summary>
+        /// Editor に表示するビルド診断メッセージを表す。
+        /// </summary>
+        std::wstring diagnostics{};
     };
 
     /// <summary>
@@ -75,6 +109,16 @@ namespace Xelqoria::Editor
         [[nodiscard]] static ScriptAssetCreationResult CreateScriptAsset(
             const std::filesystem::path& projectRootDirectory,
             const std::filesystem::path& targetDirectory);
+
+        /// <summary>
+        /// プロジェクト配下の Script Asset が参照する管理 C++ ソースをビルドする。
+        /// </summary>
+        /// <param name="projectRootDirectory">プロジェクトルートディレクトリ。</param>
+        /// <param name="options">ビルド設定。</param>
+        /// <returns>ビルド結果。診断にはコンパイル出力を含む。</returns>
+        [[nodiscard]] static ScriptBuildResult BuildProjectScripts(
+            const std::filesystem::path& projectRootDirectory,
+            const ScriptBuildOptions& options = {});
 
     };
 }

--- a/Editor/Source/ScriptAssetService.h
+++ b/Editor/Source/ScriptAssetService.h
@@ -1,0 +1,58 @@
+#pragma once
+
+#include <filesystem>
+
+#include "AssetId.h"
+
+namespace Xelqoria::Editor
+{
+    /// <summary>
+    /// Script Asset 生成結果を表す。
+    /// </summary>
+    struct ScriptAssetCreationResult
+    {
+        /// <summary>
+        /// 生成に成功したかを表す。
+        /// </summary>
+        bool succeeded = false;
+
+        /// <summary>
+        /// 作成した Script Asset ファイルを表す。
+        /// </summary>
+        std::filesystem::path assetPath{};
+
+        /// <summary>
+        /// Editor が管理する C++ ソースファイルを表す。
+        /// </summary>
+        std::filesystem::path sourcePath{};
+
+        /// <summary>
+        /// 作成した Script Asset の識別子を表す。
+        /// </summary>
+        Core::AssetId scriptAssetId{};
+    };
+
+    /// <summary>
+    /// Editor プロジェクト内の Script Asset と管理コードファイルを生成する。
+    /// </summary>
+    class ScriptAssetService
+    {
+    public:
+        /// <summary>
+        /// 指定パスが Script Asset ファイルかを判定する。
+        /// </summary>
+        /// <param name="path">判定対象パス。</param>
+        /// <returns>Script Asset ファイルの場合は true。</returns>
+        [[nodiscard]] static bool IsScriptAssetFile(const std::filesystem::path& path);
+
+        /// <summary>
+        /// Script Asset と初期 C++ コードを作成する。
+        /// </summary>
+        /// <param name="projectRootDirectory">プロジェクトルートディレクトリ。</param>
+        /// <param name="targetDirectory">Script Asset 作成先ディレクトリ。</param>
+        /// <returns>作成結果。</returns>
+        [[nodiscard]] static ScriptAssetCreationResult CreateScriptAsset(
+            const std::filesystem::path& projectRootDirectory,
+            const std::filesystem::path& targetDirectory);
+    };
+}

--- a/Editor/Source/ScriptAssetService.h
+++ b/Editor/Source/ScriptAssetService.h
@@ -47,6 +47,16 @@ namespace Xelqoria::Editor
         [[nodiscard]] static bool IsScriptAssetFile(const std::filesystem::path& path);
 
         /// <summary>
+        /// プロジェクト配下の Script Asset ファイルパスから Script AssetId を生成する。
+        /// </summary>
+        /// <param name="projectRootDirectory">プロジェクトルートディレクトリ。</param>
+        /// <param name="assetPath">Script Asset ファイルパス。</param>
+        /// <returns>Script AssetId。生成できない場合は空。</returns>
+        [[nodiscard]] static Core::AssetId BuildScriptAssetId(
+            const std::filesystem::path& projectRootDirectory,
+            const std::filesystem::path& assetPath);
+
+        /// <summary>
         /// Script Asset マニフェストから Editor 管理下の C++ ソースパスを解決する。
         /// </summary>
         /// <param name="projectRootDirectory">プロジェクトルートディレクトリ。</param>
@@ -65,5 +75,6 @@ namespace Xelqoria::Editor
         [[nodiscard]] static ScriptAssetCreationResult CreateScriptAsset(
             const std::filesystem::path& projectRootDirectory,
             const std::filesystem::path& targetDirectory);
+
     };
 }

--- a/Editor/Xelqoria.Editor.vcxproj
+++ b/Editor/Xelqoria.Editor.vcxproj
@@ -38,6 +38,7 @@
     <ClCompile Include="Source\SceneViewInputTracker.cpp" />
     <ClCompile Include="Source\SceneViewRenderer.cpp" />
     <ClCompile Include="Source\SceneViewStatusPresenter.cpp" />
+    <ClCompile Include="Source\ScriptAssetService.cpp" />
     <ClCompile Include="Source\StartupScreenController.cpp" />
   </ItemGroup>
   <ItemGroup>
@@ -64,6 +65,7 @@
     <ClInclude Include="Source\SceneViewInteractionTypes.h" />
     <ClInclude Include="Source\SceneViewRenderer.h" />
     <ClInclude Include="Source\SceneViewStatusPresenter.h" />
+    <ClInclude Include="Source\ScriptAssetService.h" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Core\Xelqoria.Core.vcxproj">

--- a/Editor/Xelqoria.Editor.vcxproj.filters
+++ b/Editor/Xelqoria.Editor.vcxproj.filters
@@ -66,6 +66,9 @@
     <ClCompile Include="Source\SceneViewStatusPresenter.cpp">
       <Filter>Source</Filter>
     </ClCompile>
+    <ClCompile Include="Source\ScriptAssetService.cpp">
+      <Filter>Source</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="Source\Application.h">
@@ -135,6 +138,9 @@
       <Filter>Source</Filter>
     </ClInclude>
     <ClInclude Include="Source\SceneViewStatusPresenter.h">
+      <Filter>Source</Filter>
+    </ClInclude>
+    <ClInclude Include="Source\ScriptAssetService.h">
       <Filter>Source</Filter>
     </ClInclude>
   </ItemGroup>

--- a/Game/Source/Assets/SpriteAsset.h
+++ b/Game/Source/Assets/SpriteAsset.h
@@ -13,5 +13,10 @@ namespace Xelqoria::Game::Assets
 		/// スプライトに関連付けるテクスチャアセット識別子を表す。
 		/// </summary>
 		Core::AssetId textureAssetId{};
+
+		/// <summary>
+		/// スプライトに関連付ける Script Asset 識別子を表す。
+		/// </summary>
+		Core::AssetId scriptAssetId{};
 	};
 }

--- a/Game/Source/Assets/SpriteAssetLoader.cpp
+++ b/Game/Source/Assets/SpriteAssetLoader.cpp
@@ -58,6 +58,7 @@ namespace Xelqoria::Game::Assets
 		SpriteAsset asset{};
 		bool hasEditorSpriteAssetMagic = false;
 		bool hasTextureAssetId = false;
+		bool hasScriptAssetId = false;
 		std::size_t lineNumber = 0;
 		std::size_t cursor = 0;
 
@@ -122,6 +123,18 @@ namespace Xelqoria::Game::Assets
 
 					asset.textureAssetId = Core::AssetId(value);
 					hasTextureAssetId = true;
+				}
+				else if (key == "scriptAssetId") {
+					if (hasScriptAssetId) {
+						return MakeError(
+							SpriteAssetLoadErrorCode::DuplicateField,
+							lineNumber,
+							key,
+							"scriptAssetId が重複しています。");
+					}
+
+					asset.scriptAssetId = Core::AssetId(value);
+					hasScriptAssetId = true;
 				}
 				else if (hasEditorSpriteAssetMagic
 					&& (key == "version"

--- a/tests/Editor/Source/ScriptAssetServiceTests.cpp
+++ b/tests/Editor/Source/ScriptAssetServiceTests.cpp
@@ -86,3 +86,41 @@ TEST(ScriptAssetServiceTests, CreateScriptAssetRejectsOutsideTargetDirectory)
     std::filesystem::remove_all(projectRoot);
     std::filesystem::remove_all(outsideRoot);
 }
+
+TEST(ScriptAssetServiceTests, ResolveSourcePathReadsManagedCodePathFromManifest)
+{
+    const std::filesystem::path projectRoot = MakeTempDirectory(L"XelqoriaScriptAssetServiceTests_Resolve");
+    const std::filesystem::path targetDirectory = projectRoot / L"Assets";
+    std::filesystem::create_directories(targetDirectory);
+
+    const Xelqoria::Editor::ScriptAssetCreationResult created =
+        Xelqoria::Editor::ScriptAssetService::CreateScriptAsset(projectRoot, targetDirectory);
+
+    ASSERT_TRUE(created.succeeded);
+    const auto sourcePath =
+        Xelqoria::Editor::ScriptAssetService::ResolveSourcePath(projectRoot, created.assetPath);
+
+    ASSERT_TRUE(sourcePath.has_value());
+    EXPECT_EQ(created.sourcePath, *sourcePath);
+
+    std::filesystem::remove_all(projectRoot);
+}
+
+TEST(ScriptAssetServiceTests, ResolveSourcePathRejectsUnsafeManifestSource)
+{
+    const std::filesystem::path projectRoot = MakeTempDirectory(L"XelqoriaScriptAssetServiceTests_UnsafeSource");
+    const std::filesystem::path assetPath = projectRoot / L"Unsafe.script";
+    {
+        std::ofstream output(assetPath, std::ios::binary | std::ios::trunc);
+        output << "magic=XelqoriaScriptAsset\n";
+        output << "version=1\n";
+        output << "source=\"../Outside.cpp\"\n";
+    }
+
+    const auto sourcePath =
+        Xelqoria::Editor::ScriptAssetService::ResolveSourcePath(projectRoot, assetPath);
+
+    EXPECT_FALSE(sourcePath.has_value());
+
+    std::filesystem::remove_all(projectRoot);
+}

--- a/tests/Editor/Source/ScriptAssetServiceTests.cpp
+++ b/tests/Editor/Source/ScriptAssetServiceTests.cpp
@@ -1,0 +1,88 @@
+#include "ScriptAssetService.h"
+
+#include <filesystem>
+#include <fstream>
+#include <sstream>
+
+#include <gtest/gtest.h>
+
+namespace
+{
+    [[nodiscard]] std::filesystem::path MakeTempDirectory(const std::wstring& name)
+    {
+        const std::filesystem::path directory = std::filesystem::temp_directory_path() / name;
+        std::filesystem::remove_all(directory);
+        std::filesystem::create_directories(directory);
+        return directory;
+    }
+
+    [[nodiscard]] std::string ReadTextFile(const std::filesystem::path& path)
+    {
+        std::ifstream input(path, std::ios::binary);
+        std::ostringstream buffer;
+        buffer << input.rdbuf();
+        return buffer.str();
+    }
+}
+
+TEST(ScriptAssetServiceTests, CreateScriptAssetWritesManifestAndInitialCode)
+{
+    const std::filesystem::path projectRoot = MakeTempDirectory(L"XelqoriaScriptAssetServiceTests_Create");
+    const std::filesystem::path targetDirectory = projectRoot / L"Scripts";
+    std::filesystem::create_directories(targetDirectory);
+
+    const Xelqoria::Editor::ScriptAssetCreationResult result =
+        Xelqoria::Editor::ScriptAssetService::CreateScriptAsset(projectRoot, targetDirectory);
+
+    ASSERT_TRUE(result.succeeded);
+    EXPECT_EQ(targetDirectory / L"NewScript.script", result.assetPath);
+    EXPECT_EQ(projectRoot / L".xelqoria" / L"Scripts" / L"Scripts_NewScript.cpp", result.sourcePath);
+    EXPECT_EQ("scripts/Scripts/NewScript.script", result.scriptAssetId.GetValue());
+
+    const std::string manifest = ReadTextFile(result.assetPath);
+    EXPECT_NE(std::string::npos, manifest.find("magic=XelqoriaScriptAsset\n"));
+    EXPECT_NE(std::string::npos, manifest.find("language=cpp\n"));
+    EXPECT_NE(std::string::npos, manifest.find("name=\"NewScript\"\n"));
+    EXPECT_NE(std::string::npos, manifest.find("source=\".xelqoria/Scripts/Scripts_NewScript.cpp\"\n"));
+
+    const std::string source = ReadTextFile(result.sourcePath);
+    EXPECT_NE(std::string::npos, source.find("void Start()"));
+    EXPECT_NE(std::string::npos, source.find("void Update(float deltaTime)"));
+
+    std::filesystem::remove_all(projectRoot);
+}
+
+TEST(ScriptAssetServiceTests, CreateScriptAssetUsesUniqueNames)
+{
+    const std::filesystem::path projectRoot = MakeTempDirectory(L"XelqoriaScriptAssetServiceTests_Unique");
+    std::filesystem::create_directories(projectRoot);
+
+    const Xelqoria::Editor::ScriptAssetCreationResult first =
+        Xelqoria::Editor::ScriptAssetService::CreateScriptAsset(projectRoot, projectRoot);
+    const Xelqoria::Editor::ScriptAssetCreationResult second =
+        Xelqoria::Editor::ScriptAssetService::CreateScriptAsset(projectRoot, projectRoot);
+
+    ASSERT_TRUE(first.succeeded);
+    ASSERT_TRUE(second.succeeded);
+    EXPECT_EQ(projectRoot / L"NewScript.script", first.assetPath);
+    EXPECT_EQ(projectRoot / L"NewScript1.script", second.assetPath);
+    EXPECT_TRUE(std::filesystem::exists(first.sourcePath));
+    EXPECT_TRUE(std::filesystem::exists(second.sourcePath));
+
+    std::filesystem::remove_all(projectRoot);
+}
+
+TEST(ScriptAssetServiceTests, CreateScriptAssetRejectsOutsideTargetDirectory)
+{
+    const std::filesystem::path projectRoot = MakeTempDirectory(L"XelqoriaScriptAssetServiceTests_Project");
+    const std::filesystem::path outsideRoot = MakeTempDirectory(L"XelqoriaScriptAssetServiceTests_Outside");
+
+    const Xelqoria::Editor::ScriptAssetCreationResult result =
+        Xelqoria::Editor::ScriptAssetService::CreateScriptAsset(projectRoot, outsideRoot);
+
+    EXPECT_FALSE(result.succeeded);
+    EXPECT_FALSE(std::filesystem::exists(outsideRoot / L"NewScript.script"));
+
+    std::filesystem::remove_all(projectRoot);
+    std::filesystem::remove_all(outsideRoot);
+}

--- a/tests/Editor/Source/ScriptAssetServiceTests.cpp
+++ b/tests/Editor/Source/ScriptAssetServiceTests.cpp
@@ -3,6 +3,7 @@
 #include <filesystem>
 #include <fstream>
 #include <sstream>
+#include <string>
 
 #include <gtest/gtest.h>
 
@@ -24,6 +25,17 @@ namespace
         return buffer.str();
     }
 
+    void WriteFakeCompiler(
+        const std::filesystem::path& path,
+        const std::string& outputText,
+        int exitCode)
+    {
+        std::ofstream output(path, std::ios::binary | std::ios::trunc);
+        output
+            << "@echo off\r\n"
+            << "echo " << outputText << "\r\n"
+            << "exit /B " << exitCode << "\r\n";
+    }
 }
 
 TEST(ScriptAssetServiceTests, CreateScriptAssetWritesManifestAndInitialCode)
@@ -141,6 +153,59 @@ TEST(ScriptAssetServiceTests, ResolveSourcePathRejectsUnsafeManifestSource)
         Xelqoria::Editor::ScriptAssetService::ResolveSourcePath(projectRoot, assetPath);
 
     EXPECT_FALSE(sourcePath.has_value());
+
+    std::filesystem::remove_all(projectRoot);
+}
+
+TEST(ScriptAssetServiceTests, BuildProjectScriptsCompilesResolvedManagedSources)
+{
+    const std::filesystem::path projectRoot = MakeTempDirectory(L"XelqoriaScriptAssetServiceTests_BuildSuccess");
+    const std::filesystem::path targetDirectory = projectRoot / L"Assets";
+    std::filesystem::create_directories(targetDirectory);
+
+    const Xelqoria::Editor::ScriptAssetCreationResult created =
+        Xelqoria::Editor::ScriptAssetService::CreateScriptAsset(projectRoot, targetDirectory);
+    ASSERT_TRUE(created.succeeded);
+
+    const std::filesystem::path fakeCompilerPath = projectRoot / L"FakeCompiler.cmd";
+    WriteFakeCompiler(fakeCompilerPath, "fake compile ok", 0);
+
+    const Xelqoria::Editor::ScriptBuildResult buildResult =
+        Xelqoria::Editor::ScriptAssetService::BuildProjectScripts(
+            projectRoot,
+            Xelqoria::Editor::ScriptBuildOptions{ fakeCompilerPath });
+
+    EXPECT_TRUE(buildResult.succeeded);
+    ASSERT_EQ(static_cast<std::size_t>(1), buildResult.sourcePaths.size());
+    EXPECT_EQ(created.sourcePath, buildResult.sourcePaths[0]);
+    EXPECT_NE(std::wstring::npos, buildResult.diagnostics.find(L"fake compile ok"));
+
+    std::filesystem::remove_all(projectRoot);
+}
+
+TEST(ScriptAssetServiceTests, BuildProjectScriptsReportsCompilerOutputOnFailure)
+{
+    const std::filesystem::path projectRoot = MakeTempDirectory(L"XelqoriaScriptAssetServiceTests_BuildFailure");
+    const std::filesystem::path targetDirectory = projectRoot / L"Assets";
+    std::filesystem::create_directories(targetDirectory);
+
+    const Xelqoria::Editor::ScriptAssetCreationResult created =
+        Xelqoria::Editor::ScriptAssetService::CreateScriptAsset(projectRoot, targetDirectory);
+    ASSERT_TRUE(created.succeeded);
+
+    const std::filesystem::path fakeCompilerPath = projectRoot / L"FakeCompiler.cmd";
+    WriteFakeCompiler(fakeCompilerPath, "script compile failed", 2);
+
+    const Xelqoria::Editor::ScriptBuildResult buildResult =
+        Xelqoria::Editor::ScriptAssetService::BuildProjectScripts(
+            projectRoot,
+            Xelqoria::Editor::ScriptBuildOptions{ fakeCompilerPath });
+
+    EXPECT_FALSE(buildResult.succeeded);
+    ASSERT_EQ(static_cast<std::size_t>(1), buildResult.sourcePaths.size());
+    EXPECT_EQ(created.sourcePath, buildResult.sourcePaths[0]);
+    EXPECT_NE(std::wstring::npos, buildResult.diagnostics.find(L"script compile failed"));
+    EXPECT_NE(std::wstring::npos, buildResult.diagnostics.find(L"終了コード"));
 
     std::filesystem::remove_all(projectRoot);
 }

--- a/tests/Editor/Source/ScriptAssetServiceTests.cpp
+++ b/tests/Editor/Source/ScriptAssetServiceTests.cpp
@@ -23,6 +23,7 @@ namespace
         buffer << input.rdbuf();
         return buffer.str();
     }
+
 }
 
 TEST(ScriptAssetServiceTests, CreateScriptAssetWritesManifestAndInitialCode)
@@ -48,6 +49,25 @@ TEST(ScriptAssetServiceTests, CreateScriptAssetWritesManifestAndInitialCode)
     const std::string source = ReadTextFile(result.sourcePath);
     EXPECT_NE(std::string::npos, source.find("void Start()"));
     EXPECT_NE(std::string::npos, source.find("void Update(float deltaTime)"));
+
+    std::filesystem::remove_all(projectRoot);
+}
+
+TEST(ScriptAssetServiceTests, BuildScriptAssetIdUsesProjectRelativeScriptPath)
+{
+    const std::filesystem::path projectRoot = MakeTempDirectory(L"XelqoriaScriptAssetServiceTests_AssetId");
+    const std::filesystem::path scriptDirectory = projectRoot / L"Scripts";
+    std::filesystem::create_directories(scriptDirectory);
+    const std::filesystem::path scriptPath = scriptDirectory / L"Player.script";
+    {
+        std::ofstream output(scriptPath, std::ios::binary | std::ios::trunc);
+        output << "magic=XelqoriaScriptAsset\n";
+    }
+
+    const Xelqoria::Core::AssetId scriptAssetId =
+        Xelqoria::Editor::ScriptAssetService::BuildScriptAssetId(projectRoot, scriptPath);
+
+    EXPECT_EQ("scripts/Scripts/Player.script", scriptAssetId.GetValue());
 
     std::filesystem::remove_all(projectRoot);
 }

--- a/tests/Editor/Xelqoria.Tests.Editor.vcxproj
+++ b/tests/Editor/Xelqoria.Tests.Editor.vcxproj
@@ -24,12 +24,14 @@
     <ClCompile Include="..\..\Editor\Source\RecentProjectsStore.cpp" />
     <ClCompile Include="..\..\Editor\Source\SceneCommandHistory.cpp" />
     <ClCompile Include="..\..\Editor\Source\SceneEditingOperations.cpp" />
+    <ClCompile Include="..\..\Editor\Source\ScriptAssetService.cpp" />
     <ClCompile Include="Source\EditorProjectTests.cpp" />
     <ClCompile Include="Source\HierarchyPanelControllerTests.cpp" />
     <ClCompile Include="Source\InspectorPanelControllerTests.cpp" />
     <ClCompile Include="Source\RecentProjectsStoreTests.cpp" />
     <ClCompile Include="Source\SceneCommandHistoryTests.cpp" />
     <ClCompile Include="Source\SceneEditingOperationsTests.cpp" />
+    <ClCompile Include="Source\ScriptAssetServiceTests.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\third_party\googletest\Xelqoria.GoogleTest.vcxproj">

--- a/tests/Editor/Xelqoria.Tests.Editor.vcxproj.filters
+++ b/tests/Editor/Xelqoria.Tests.Editor.vcxproj.filters
@@ -24,5 +24,11 @@
     <ClCompile Include="Source\RecentProjectsStoreTests.cpp">
       <Filter>Source</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\Editor\Source\ScriptAssetService.cpp">
+      <Filter>Source</Filter>
+    </ClCompile>
+    <ClCompile Include="Source\ScriptAssetServiceTests.cpp">
+      <Filter>Source</Filter>
+    </ClCompile>
   </ItemGroup>
 </Project>

--- a/tests/Game/Source/TransformTests.cpp
+++ b/tests/Game/Source/TransformTests.cpp
@@ -332,11 +332,13 @@ TEST(TransformTests, TransformAndSceneRuntimeApiWorks)
 
 		const auto spriteAssetLoadResult = Xelqoria::Game::Assets::SpriteAssetLoader::LoadFromText(
 		"# SpriteAsset\n"
-		"textureAssetId = textures/player-idle\n");
+		"textureAssetId = textures/player-idle\n"
+		"scriptAssetId = scripts/Scripts/Player.script\n");
 		EXPECT_TRUE(spriteAssetLoadResult.IsSuccess());
 		ASSERT_TRUE(spriteAssetLoadResult.asset.has_value());
 
 		EXPECT_EQ(spriteAssetLoadResult.asset->textureAssetId, Xelqoria::Core::AssetId("textures/player-idle"));
+		EXPECT_EQ(spriteAssetLoadResult.asset->scriptAssetId, Xelqoria::Core::AssetId("scripts/Scripts/Player.script"));
 
 		const auto editorSpriteAssetLoadResult = Xelqoria::Game::Assets::SpriteAssetLoader::LoadFromText(
 		"magic=XelqoriaSpriteAsset\n"
@@ -348,6 +350,7 @@ TEST(TransformTests, TransformAndSceneRuntimeApiWorks)
 		"hasSpriteComponent=true\n"
 		"spriteAssetRef=sprites/player-idle\n"
 		"textureAssetId=textures/player-idle\n"
+		"scriptAssetId=scripts/Scripts/Player.script\n"
 		"texture.size=64,32\n"
 		"render.visible=true\n"
 		"render.sortOrder=0\n"
@@ -355,6 +358,7 @@ TEST(TransformTests, TransformAndSceneRuntimeApiWorks)
 		EXPECT_TRUE(editorSpriteAssetLoadResult.IsSuccess());
 		ASSERT_TRUE(editorSpriteAssetLoadResult.asset.has_value());
 		EXPECT_EQ(editorSpriteAssetLoadResult.asset->textureAssetId, Xelqoria::Core::AssetId("textures/player-idle"));
+		EXPECT_EQ(editorSpriteAssetLoadResult.asset->scriptAssetId, Xelqoria::Core::AssetId("scripts/Scripts/Player.script"));
 
 		Xelqoria::Game::Assets::SpriteAssetRegistry spriteAssetRegistry;
 		spriteAssetRegistry.RegisterSpriteAsset(


### PR DESCRIPTION
## Summary
- Project メニューと F5 から Editor 再生開始前 Script ビルドを実行
- プロジェクト配下の .script が参照する管理 C++ ソースをコンパイル
- ビルド失敗時の診断を SceneView ラベルとダイアログに表示
- Script ビルドサービスの成功/失敗テストを追加

## Issues
- Parent: #168
- Child: #172

## Dependency
- #169 の Script Asset マニフェストと管理 C++ ソース配置を前提にしています。

## Verification
- tools/wsl/build.sh tests/Editor/Xelqoria.Tests.Editor.vcxproj
- artifacts/x64/Debug/Xelqoria.Tests.Editor.exe --gtest_filter=ScriptAssetServiceTests.*
- tools/wsl/build.sh Editor/Xelqoria.Editor.vcxproj