### PR TITLE
再生中の Script Start / Update 実行とインスタンス状態分離を実装する

### DIFF
--- a/Editor/Source/Application.cpp
+++ b/Editor/Source/Application.cpp
@@ -7,6 +7,7 @@
 #include <filesystem>
 #include <functional>
 #include <shlobj.h>
+#include <span>
 #include <string>
 
 #include "GraphicsAPI.h"
@@ -148,6 +149,31 @@ namespace Xelqoria::Editor
 
             std::wstring text = L"再生開始前 Script ビルドに失敗しました。詳細: ";
             text += buildResult.diagnostics;
+            constexpr std::size_t MaxLabelLength = 180;
+            if (MaxLabelLength < text.size())
+            {
+                text.resize(MaxLabelLength - 3);
+                text += L"...";
+            }
+
+            return text;
+        }
+
+        /// <summary>
+        /// Script Runtime 診断を短い表示文面へ変換する。
+        /// </summary>
+        /// <param name="diagnostics">Script Runtime 診断一覧。</param>
+        /// <returns>表示文面。</returns>
+        [[nodiscard]] std::wstring BuildScriptRuntimeStatusText(
+            std::span<const ScriptRuntimeDiagnostic> diagnostics)
+        {
+            if (diagnostics.empty())
+            {
+                return L"Script 再生を開始しました。";
+            }
+
+            std::wstring text = L"Script 再生開始時に問題が発生しました。詳細: ";
+            text += diagnostics.front().message;
             constexpr std::size_t MaxLabelLength = 180;
             if (MaxLabelLength < text.size())
             {
@@ -601,7 +627,7 @@ namespace Xelqoria::Editor
 
     bool Application::StartEditorPlay()
     {
-        if (false == m_sceneDocument.GetProjectInfo().has_value())
+        if (false == m_sceneDocument.GetProjectInfo().has_value() || nullptr == m_sceneDocument.GetScene())
         {
             SetWindowTextW(m_editorShell.GetSceneViewPlanLabel(), L"再生開始前 Script ビルドにはプロジェクトが必要です。");
             return false;
@@ -625,7 +651,15 @@ namespace Xelqoria::Editor
             return false;
         }
 
-        return true;
+        const bool runtimeStarted = m_scriptRuntimeSession.Begin(
+            *m_sceneDocument.GetScene(),
+            m_sceneDocument.GetSpriteAssetRegistry(),
+            buildResult,
+            projectRootDirectory);
+        const std::wstring runtimeStatusText =
+            BuildScriptRuntimeStatusText(m_scriptRuntimeSession.GetDiagnostics());
+        SetWindowTextW(m_editorShell.GetSceneViewPlanLabel(), runtimeStatusText.c_str());
+        return runtimeStarted;
     }
 
     void Application::ClearProjectDirty()
@@ -640,8 +674,6 @@ namespace Xelqoria::Editor
 
     void Application::Update(float deltaTime)
     {
-        (void)deltaTime;
-
         m_inputSystem.Update();
         const Core::InputSnapshot& inputSnapshot = m_inputSystem.GetSnapshot();
 
@@ -693,6 +725,8 @@ namespace Xelqoria::Editor
         {
             (void)StartEditorPlay();
         }
+
+        m_scriptRuntimeSession.Update(deltaTime);
 
         m_assetsPanelController.UpdateDragState(inputSnapshot);
         m_inspectorPanelController.UpdateTextureDropHighlight(m_assetsPanelController);

--- a/Editor/Source/Application.h
+++ b/Editor/Source/Application.h
@@ -14,6 +14,7 @@
 #include "ProjectPanelController.h"
 #include "SceneViewController.h"
 #include "SceneViewRenderer.h"
+#include "ScriptRuntimeSession.h"
 #include "StartupScreenController.h"
 #include "RecentProjectsStore.h"
 
@@ -215,6 +216,7 @@ namespace Xelqoria::Editor
         ProjectPanelController m_projectPanelController{};
         SceneViewController m_sceneViewController{};
         SceneViewRenderer m_sceneViewRenderer{};
+        ScriptRuntimeSession m_scriptRuntimeSession{};
         EditorCommandController m_editorCommandController{};
     };
 }

--- a/Editor/Source/ScriptAssetService.cpp
+++ b/Editor/Source/ScriptAssetService.cpp
@@ -181,6 +181,37 @@ namespace Xelqoria::Editor
         }
 
         /// <summary>
+        /// Script 実行モジュールの出力先パスを作成する。
+        /// </summary>
+        /// <param name="projectRootDirectory">プロジェクトルートディレクトリ。</param>
+        /// <param name="sourcePath">コンパイル対象ソース。</param>
+        /// <param name="index">同名回避用インデックス。</param>
+        /// <returns>実行モジュールファイルパス。</returns>
+        [[nodiscard]] std::filesystem::path BuildModulePath(
+            const std::filesystem::path& projectRootDirectory,
+            const std::filesystem::path& sourcePath,
+            std::size_t index)
+        {
+            std::error_code errorCode;
+            std::filesystem::path relativeSourcePath =
+                std::filesystem::relative(sourcePath, projectRootDirectory, errorCode);
+            if (errorCode || relativeSourcePath.empty())
+            {
+                relativeSourcePath = sourcePath.filename();
+            }
+
+            std::wstring moduleStem = SanitizeManagedCodeStem(relativeSourcePath.generic_wstring());
+            if (moduleStem.empty())
+            {
+                moduleStem = L"Script";
+            }
+
+            return projectRootDirectory
+                / ScriptBuildDirectory
+                / (std::to_wstring(index) + L"_" + moduleStem + L".dll");
+        }
+
+        /// <summary>
         /// Script Asset への相対パスから管理 C++ ソースの相対パスを構築する。
         /// </summary>
         /// <param name="relativeAssetPath">プロジェクトルート基準の Script Asset パス。</param>
@@ -285,10 +316,12 @@ namespace Xelqoria::Editor
             }
 
             output
+                << "extern \"C\" __declspec(dllexport) "
                 << "void Start()\n"
                 << "{\n"
                 << "}\n"
                 << "\n"
+                << "extern \"C\" __declspec(dllexport) "
                 << "void Update(float deltaTime)\n"
                 << "{\n"
                 << "    (void)deltaTime;\n"
@@ -475,6 +508,15 @@ namespace Xelqoria::Editor
         std::size_t compiledCount = 0;
         for (const std::filesystem::path& scriptAssetPath : scriptAssetPaths)
         {
+            const Core::AssetId scriptAssetId = BuildScriptAssetId(projectRootDirectory, scriptAssetPath);
+            if (scriptAssetId.IsEmpty())
+            {
+                allSucceeded = false;
+                diagnostics << L"[Script] " << scriptAssetPath.wstring()
+                    << L": Script AssetId を生成できません。\n";
+                continue;
+            }
+
             const std::optional<std::filesystem::path> sourcePath =
                 ResolveSourcePath(projectRootDirectory, scriptAssetPath);
             if (false == sourcePath.has_value())
@@ -496,15 +538,19 @@ namespace Xelqoria::Editor
             result.sourcePaths.push_back(*sourcePath);
             const std::filesystem::path objectPath =
                 BuildObjectPath(projectRootDirectory, *sourcePath, compiledCount);
+            const std::filesystem::path modulePath =
+                BuildModulePath(projectRootDirectory, *sourcePath, compiledCount);
             ++compiledCount;
 
             const std::wstring commandLine =
                 L"call "
                 + QuoteCommandArgument(options.compilerExecutable)
-                + L" /nologo /EHsc /std:c++20 /c "
+                + L" /nologo /EHsc /std:c++20 /LD "
                 + QuoteCommandArgument(*sourcePath)
                 + L" /Fo"
                 + QuoteCommandArgument(objectPath)
+                + L" /Fe"
+                + QuoteCommandArgument(modulePath)
                 + L" 2>&1";
 
             std::wstring compilerOutput{};
@@ -523,6 +569,14 @@ namespace Xelqoria::Editor
             {
                 allSucceeded = false;
                 diagnostics << L"終了コード: " << exitCode << L"\n";
+            }
+            else
+            {
+                result.artifacts.push_back(ScriptBuildArtifact{
+                    scriptAssetId,
+                    *sourcePath,
+                    modulePath
+                });
             }
         }
 

--- a/Editor/Source/ScriptAssetService.h
+++ b/Editor/Source/ScriptAssetService.h
@@ -47,6 +47,27 @@ namespace Xelqoria::Editor
     };
 
     /// <summary>
+    /// Script ビルドで生成された実行用モジュールを表す。
+    /// </summary>
+    struct ScriptBuildArtifact
+    {
+        /// <summary>
+        /// 対応する Script Asset 識別子を表す。
+        /// </summary>
+        Core::AssetId scriptAssetId{};
+
+        /// <summary>
+        /// ビルド対象になった C++ ソースファイルを表す。
+        /// </summary>
+        std::filesystem::path sourcePath{};
+
+        /// <summary>
+        /// 実行時にロードするモジュールファイルを表す。
+        /// </summary>
+        std::filesystem::path modulePath{};
+    };
+
+    /// <summary>
     /// Script 管理 C++ ソースのビルド結果を表す。
     /// </summary>
     struct ScriptBuildResult
@@ -60,6 +81,11 @@ namespace Xelqoria::Editor
         /// ビルド対象になった C++ ソースファイル一覧を表す。
         /// </summary>
         std::vector<std::filesystem::path> sourcePaths{};
+
+        /// <summary>
+        /// ビルドにより生成された Script 実行モジュール一覧を表す。
+        /// </summary>
+        std::vector<ScriptBuildArtifact> artifacts{};
 
         /// <summary>
         /// Editor に表示するビルド診断メッセージを表す。

--- a/Editor/Source/ScriptRuntimeSession.cpp
+++ b/Editor/Source/ScriptRuntimeSession.cpp
@@ -1,0 +1,248 @@
+#include "ScriptRuntimeSession.h"
+
+#include <algorithm>
+#include <filesystem>
+#include <string>
+#include <system_error>
+#include <utility>
+
+#include "Assets/SpriteAsset.h"
+#include "EditorStringUtils.h"
+#include "SpriteComponent.h"
+
+namespace Xelqoria::Editor
+{
+    namespace
+    {
+        constexpr const wchar_t* ScriptInstanceDirectory = L".xelqoria/ScriptInstances";
+
+        /// <summary>
+        /// Entity ごとの Script モジュールコピー先を構築する。
+        /// </summary>
+        /// <param name="projectRootDirectory">プロジェクトルートディレクトリ。</param>
+        /// <param name="entityId">対象 Entity ID。</param>
+        /// <param name="index">同名回避用インデックス。</param>
+        /// <param name="sourceModulePath">元のモジュールファイル。</param>
+        /// <returns>コピー先モジュールファイル。</returns>
+        [[nodiscard]] std::filesystem::path BuildInstanceModulePath(
+            const std::filesystem::path& projectRootDirectory,
+            Game::EntityId entityId,
+            std::size_t index,
+            const std::filesystem::path& sourceModulePath)
+        {
+            const std::wstring extension = sourceModulePath.extension().empty()
+                ? std::wstring(L".dll")
+                : sourceModulePath.extension().wstring();
+            return projectRootDirectory
+                / ScriptInstanceDirectory
+                / (L"entity_"
+                    + std::to_wstring(static_cast<unsigned>(entityId))
+                    + L"_"
+                    + std::to_wstring(index)
+                    + extension);
+        }
+
+        /// <summary>
+        /// Script AssetId に対応するビルド成果物を取得する。
+        /// </summary>
+        /// <param name="buildResult">Script ビルド結果。</param>
+        /// <param name="scriptAssetId">検索する Script AssetId。</param>
+        /// <returns>見つかった成果物。未検出時は nullptr。</returns>
+        [[nodiscard]] const ScriptBuildArtifact* FindArtifact(
+            const ScriptBuildResult& buildResult,
+            const Core::AssetId& scriptAssetId)
+        {
+            const auto found = std::find_if(
+                buildResult.artifacts.begin(),
+                buildResult.artifacts.end(),
+                [&scriptAssetId](const ScriptBuildArtifact& artifact)
+                {
+                    return artifact.scriptAssetId == scriptAssetId;
+                });
+            return found == buildResult.artifacts.end() ? nullptr : &(*found);
+        }
+    }
+
+    ScriptRuntimeSession::~ScriptRuntimeSession()
+    {
+        End();
+    }
+
+    std::vector<ScriptRuntimeInstancePlan> ScriptRuntimeSession::BuildInstancePlans(
+        const Game::Scene& scene,
+        const Game::Assets::ISpriteAssetResolver& spriteAssetResolver,
+        const ScriptBuildResult& buildResult,
+        const std::filesystem::path& projectRootDirectory)
+    {
+        std::vector<ScriptRuntimeInstancePlan> plans{};
+        std::size_t index = 0;
+        for (const Game::Entity& entity : scene.GetEntities())
+        {
+            const auto spriteComponent = entity.GetSpriteComponent();
+            if (false == spriteComponent.has_value())
+            {
+                continue;
+            }
+
+            const auto spriteAsset = spriteAssetResolver.ResolveSpriteAsset(spriteComponent->get().spriteAssetRef);
+            if (false == spriteAsset.has_value() || spriteAsset->scriptAssetId.IsEmpty())
+            {
+                continue;
+            }
+
+            const ScriptBuildArtifact* artifact = FindArtifact(buildResult, spriteAsset->scriptAssetId);
+            if (nullptr == artifact)
+            {
+                continue;
+            }
+
+            plans.push_back(ScriptRuntimeInstancePlan{
+                entity.GetId(),
+                spriteAsset->scriptAssetId,
+                artifact->modulePath,
+                BuildInstanceModulePath(projectRootDirectory, entity.GetId(), index, artifact->modulePath)
+            });
+            ++index;
+        }
+
+        return plans;
+    }
+
+    bool ScriptRuntimeSession::Begin(
+        const Game::Scene& scene,
+        const Game::Assets::ISpriteAssetResolver& spriteAssetResolver,
+        const ScriptBuildResult& buildResult,
+        const std::filesystem::path& projectRootDirectory)
+    {
+        End();
+        const std::vector<ScriptRuntimeInstancePlan> plans =
+            BuildInstancePlans(scene, spriteAssetResolver, buildResult, projectRootDirectory);
+
+        std::error_code errorCode;
+        std::filesystem::create_directories(projectRootDirectory / ScriptInstanceDirectory, errorCode);
+        if (errorCode)
+        {
+            AddDiagnostic(0, {}, L"Script インスタンス用フォルダを作成できません。");
+            return false;
+        }
+
+        for (const ScriptRuntimeInstancePlan& plan : plans)
+        {
+            if (false == std::filesystem::exists(plan.sourceModulePath, errorCode) || errorCode)
+            {
+                AddDiagnostic(
+                    plan.entityId,
+                    plan.scriptAssetId,
+                    L"Script 実行モジュールが見つかりません: " + plan.sourceModulePath.wstring());
+                continue;
+            }
+
+            errorCode.clear();
+            std::filesystem::copy_file(
+                plan.sourceModulePath,
+                plan.instanceModulePath,
+                std::filesystem::copy_options::overwrite_existing,
+                errorCode);
+            if (errorCode)
+            {
+                AddDiagnostic(
+                    plan.entityId,
+                    plan.scriptAssetId,
+                    L"Script 実行モジュールをインスタンス用にコピーできません。");
+                continue;
+            }
+
+            HMODULE moduleHandle = LoadLibraryW(plan.instanceModulePath.c_str());
+            if (nullptr == moduleHandle)
+            {
+                AddDiagnostic(
+                    plan.entityId,
+                    plan.scriptAssetId,
+                    L"Script 実行モジュールをロードできません: " + plan.instanceModulePath.wstring());
+                continue;
+            }
+
+            auto start = reinterpret_cast<StartFunction>(GetProcAddress(moduleHandle, "Start"));
+            auto update = reinterpret_cast<UpdateFunction>(GetProcAddress(moduleHandle, "Update"));
+            if (nullptr == start || nullptr == update)
+            {
+                FreeLibrary(moduleHandle);
+                AddDiagnostic(
+                    plan.entityId,
+                    plan.scriptAssetId,
+                    L"Script 実行モジュールに Start / Update が見つかりません。");
+                continue;
+            }
+
+            m_instances.push_back(ScriptRuntimeInstance{
+                plan.entityId,
+                plan.scriptAssetId,
+                plan.instanceModulePath,
+                moduleHandle,
+                start,
+                update,
+                false
+            });
+        }
+
+        m_playing = true;
+        return m_diagnostics.empty();
+    }
+
+    void ScriptRuntimeSession::Update(float deltaTime)
+    {
+        if (false == m_playing)
+        {
+            return;
+        }
+
+        for (ScriptRuntimeInstance& instance : m_instances)
+        {
+            if (false == instance.startCalled)
+            {
+                instance.start();
+                instance.startCalled = true;
+            }
+
+            instance.update(deltaTime);
+        }
+    }
+
+    void ScriptRuntimeSession::End()
+    {
+        for (ScriptRuntimeInstance& instance : m_instances)
+        {
+            if (nullptr != instance.moduleHandle)
+            {
+                FreeLibrary(instance.moduleHandle);
+                instance.moduleHandle = nullptr;
+            }
+        }
+
+        m_instances.clear();
+        m_diagnostics.clear();
+        m_playing = false;
+    }
+
+    bool ScriptRuntimeSession::IsPlaying() const
+    {
+        return m_playing;
+    }
+
+    std::span<const ScriptRuntimeDiagnostic> ScriptRuntimeSession::GetDiagnostics() const
+    {
+        return m_diagnostics;
+    }
+
+    void ScriptRuntimeSession::AddDiagnostic(
+        Game::EntityId entityId,
+        Core::AssetId scriptAssetId,
+        std::wstring message)
+    {
+        m_diagnostics.push_back(ScriptRuntimeDiagnostic{
+            entityId,
+            std::move(scriptAssetId),
+            std::move(message)
+        });
+    }
+}

--- a/Editor/Source/ScriptRuntimeSession.h
+++ b/Editor/Source/ScriptRuntimeSession.h
@@ -1,0 +1,157 @@
+#pragma once
+
+#include <filesystem>
+#include <optional>
+#include <span>
+#include <string>
+#include <vector>
+#include <Windows.h>
+
+#include "AssetId.h"
+#include "Assets/ISpriteAssetResolver.h"
+#include "Entity.h"
+#include "Scene.h"
+#include "ScriptAssetService.h"
+
+namespace Xelqoria::Editor
+{
+    /// <summary>
+    /// Script Runtime の診断メッセージを表す。
+    /// </summary>
+    struct ScriptRuntimeDiagnostic
+    {
+        /// <summary>
+        /// 対象 Entity ID を表す。
+        /// </summary>
+        Game::EntityId entityId = 0;
+
+        /// <summary>
+        /// 対象 Script Asset 識別子を表す。
+        /// </summary>
+        Core::AssetId scriptAssetId{};
+
+        /// <summary>
+        /// Editor に表示する診断メッセージを表す。
+        /// </summary>
+        std::wstring message{};
+    };
+
+    /// <summary>
+    /// Script 実行インスタンスの作成計画を表す。
+    /// </summary>
+    struct ScriptRuntimeInstancePlan
+    {
+        /// <summary>
+        /// 対象 Entity ID を表す。
+        /// </summary>
+        Game::EntityId entityId = 0;
+
+        /// <summary>
+        /// 対象 Script Asset 識別子を表す。
+        /// </summary>
+        Core::AssetId scriptAssetId{};
+
+        /// <summary>
+        /// ビルド済み Script モジュールを表す。
+        /// </summary>
+        std::filesystem::path sourceModulePath{};
+
+        /// <summary>
+        /// Entity インスタンスごとのロード用コピーを表す。
+        /// </summary>
+        std::filesystem::path instanceModulePath{};
+    };
+
+    /// <summary>
+    /// Editor 再生中の Script Start / Update 実行状態を管理する。
+    /// </summary>
+    class ScriptRuntimeSession
+    {
+    public:
+        /// <summary>
+        /// Script Runtime Session を破棄する。
+        /// </summary>
+        ~ScriptRuntimeSession();
+
+        /// <summary>
+        /// Scene 内の Script 付き Sprite から実行計画を構築する。
+        /// </summary>
+        /// <param name="scene">対象 Scene。</param>
+        /// <param name="spriteAssetResolver">SpriteAsset 解決器。</param>
+        /// <param name="buildResult">Script ビルド結果。</param>
+        /// <param name="projectRootDirectory">プロジェクトルートディレクトリ。</param>
+        /// <returns>Script 実行計画。</returns>
+        [[nodiscard]] static std::vector<ScriptRuntimeInstancePlan> BuildInstancePlans(
+            const Game::Scene& scene,
+            const Game::Assets::ISpriteAssetResolver& spriteAssetResolver,
+            const ScriptBuildResult& buildResult,
+            const std::filesystem::path& projectRootDirectory);
+
+        /// <summary>
+        /// Editor 再生用 Script 実行セッションを開始する。
+        /// </summary>
+        /// <param name="scene">対象 Scene。</param>
+        /// <param name="spriteAssetResolver">SpriteAsset 解決器。</param>
+        /// <param name="buildResult">Script ビルド結果。</param>
+        /// <param name="projectRootDirectory">プロジェクトルートディレクトリ。</param>
+        /// <returns>開始に成功した場合は true。</returns>
+        [[nodiscard]] bool Begin(
+            const Game::Scene& scene,
+            const Game::Assets::ISpriteAssetResolver& spriteAssetResolver,
+            const ScriptBuildResult& buildResult,
+            const std::filesystem::path& projectRootDirectory);
+
+        /// <summary>
+        /// Script の Start と Update を実行する。
+        /// </summary>
+        /// <param name="deltaTime">前フレームからの経過時間（秒）。</param>
+        void Update(float deltaTime);
+
+        /// <summary>
+        /// Script 実行セッションを終了する。
+        /// </summary>
+        void End();
+
+        /// <summary>
+        /// 再生中かを取得する。
+        /// </summary>
+        /// <returns>再生中の場合は true。</returns>
+        [[nodiscard]] bool IsPlaying() const;
+
+        /// <summary>
+        /// Script Runtime 診断メッセージを取得する。
+        /// </summary>
+        /// <returns>診断メッセージ一覧。</returns>
+        [[nodiscard]] std::span<const ScriptRuntimeDiagnostic> GetDiagnostics() const;
+
+    private:
+        using StartFunction = void (*)();
+        using UpdateFunction = void (*)(float);
+
+        struct ScriptRuntimeInstance
+        {
+            Game::EntityId entityId = 0;
+            Core::AssetId scriptAssetId{};
+            std::filesystem::path instanceModulePath{};
+            HMODULE moduleHandle = nullptr;
+            StartFunction start = nullptr;
+            UpdateFunction update = nullptr;
+            bool startCalled = false;
+        };
+
+        /// <summary>
+        /// Script Runtime 診断メッセージを追加する。
+        /// </summary>
+        /// <param name="entityId">対象 Entity ID。</param>
+        /// <param name="scriptAssetId">対象 Script Asset 識別子。</param>
+        /// <param name="message">診断メッセージ。</param>
+        void AddDiagnostic(
+            Game::EntityId entityId,
+            Core::AssetId scriptAssetId,
+            std::wstring message);
+
+        std::vector<ScriptRuntimeInstance> m_instances{};
+        std::vector<ScriptRuntimeDiagnostic> m_diagnostics{};
+        bool m_playing = false;
+    };
+}

--- a/Editor/Xelqoria.Editor.vcxproj
+++ b/Editor/Xelqoria.Editor.vcxproj
@@ -39,6 +39,7 @@
     <ClCompile Include="Source\SceneViewRenderer.cpp" />
     <ClCompile Include="Source\SceneViewStatusPresenter.cpp" />
     <ClCompile Include="Source\ScriptAssetService.cpp" />
+    <ClCompile Include="Source\ScriptRuntimeSession.cpp" />
     <ClCompile Include="Source\StartupScreenController.cpp" />
   </ItemGroup>
   <ItemGroup>
@@ -66,6 +67,7 @@
     <ClInclude Include="Source\SceneViewRenderer.h" />
     <ClInclude Include="Source\SceneViewStatusPresenter.h" />
     <ClInclude Include="Source\ScriptAssetService.h" />
+    <ClInclude Include="Source\ScriptRuntimeSession.h" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Core\Xelqoria.Core.vcxproj">

--- a/Editor/Xelqoria.Editor.vcxproj.filters
+++ b/Editor/Xelqoria.Editor.vcxproj.filters
@@ -69,6 +69,9 @@
     <ClCompile Include="Source\ScriptAssetService.cpp">
       <Filter>Source</Filter>
     </ClCompile>
+    <ClCompile Include="Source\ScriptRuntimeSession.cpp">
+      <Filter>Source</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="Source\Application.h">
@@ -141,6 +144,9 @@
       <Filter>Source</Filter>
     </ClInclude>
     <ClInclude Include="Source\ScriptAssetService.h">
+      <Filter>Source</Filter>
+    </ClInclude>
+    <ClInclude Include="Source\ScriptRuntimeSession.h">
       <Filter>Source</Filter>
     </ClInclude>
   </ItemGroup>

--- a/tests/Editor/Source/ScriptAssetServiceTests.cpp
+++ b/tests/Editor/Source/ScriptAssetServiceTests.cpp
@@ -177,7 +177,11 @@ TEST(ScriptAssetServiceTests, BuildProjectScriptsCompilesResolvedManagedSources)
 
     EXPECT_TRUE(buildResult.succeeded);
     ASSERT_EQ(static_cast<std::size_t>(1), buildResult.sourcePaths.size());
+    ASSERT_EQ(static_cast<std::size_t>(1), buildResult.artifacts.size());
     EXPECT_EQ(created.sourcePath, buildResult.sourcePaths[0]);
+    EXPECT_EQ(created.scriptAssetId, buildResult.artifacts[0].scriptAssetId);
+    EXPECT_EQ(created.sourcePath, buildResult.artifacts[0].sourcePath);
+    EXPECT_EQ(L".dll", buildResult.artifacts[0].modulePath.extension().wstring());
     EXPECT_NE(std::wstring::npos, buildResult.diagnostics.find(L"fake compile ok"));
 
     std::filesystem::remove_all(projectRoot);

--- a/tests/Editor/Source/ScriptRuntimeSessionTests.cpp
+++ b/tests/Editor/Source/ScriptRuntimeSessionTests.cpp
@@ -1,0 +1,86 @@
+#include "ScriptRuntimeSession.h"
+
+#include <filesystem>
+
+#include <gtest/gtest.h>
+
+#include "Assets/SpriteAssetRegistry.h"
+#include "Scene.h"
+
+TEST(ScriptRuntimeSessionTests, BuildInstancePlansCreatesSeparateModuleCopiesPerSpriteInstance)
+{
+    Xelqoria::Game::Scene scene{};
+    Xelqoria::Game::Entity& firstEntity = scene.CreateEntity();
+    firstEntity.SetSpriteComponent(Xelqoria::Game::SpriteComponent{
+        Xelqoria::Core::AssetId("sprites/player"),
+        {}
+    });
+    const Xelqoria::Game::EntityId firstEntityId = firstEntity.GetId();
+    Xelqoria::Game::Entity& secondEntity = scene.CreateEntity();
+    secondEntity.SetSpriteComponent(Xelqoria::Game::SpriteComponent{
+        Xelqoria::Core::AssetId("sprites/player"),
+        {}
+    });
+    const Xelqoria::Game::EntityId secondEntityId = secondEntity.GetId();
+
+    Xelqoria::Game::Assets::SpriteAssetRegistry spriteAssetRegistry{};
+    spriteAssetRegistry.RegisterSpriteAsset(
+        Xelqoria::Core::AssetId("sprites/player"),
+        Xelqoria::Game::Assets::SpriteAsset{
+            Xelqoria::Core::AssetId("textures/player"),
+            Xelqoria::Core::AssetId("scripts/Player.script")
+        });
+
+    const std::filesystem::path projectRoot = std::filesystem::temp_directory_path() / L"XelqoriaScriptRuntimeSessionTests";
+    const Xelqoria::Editor::ScriptBuildResult buildResult{
+        true,
+        { projectRoot / L".xelqoria" / L"Scripts" / L"Player.cpp" },
+        {
+            Xelqoria::Editor::ScriptBuildArtifact{
+                Xelqoria::Core::AssetId("scripts/Player.script"),
+                projectRoot / L".xelqoria" / L"Scripts" / L"Player.cpp",
+                projectRoot / L".xelqoria" / L"ScriptBuild" / L"Player.dll"
+            }
+        },
+        L""
+    };
+
+    const std::vector<Xelqoria::Editor::ScriptRuntimeInstancePlan> plans =
+        Xelqoria::Editor::ScriptRuntimeSession::BuildInstancePlans(
+            scene,
+            spriteAssetRegistry,
+            buildResult,
+            projectRoot);
+
+    ASSERT_EQ(static_cast<std::size_t>(2), plans.size());
+    EXPECT_EQ(firstEntityId, plans[0].entityId);
+    EXPECT_EQ(secondEntityId, plans[1].entityId);
+    EXPECT_EQ(plans[0].scriptAssetId, plans[1].scriptAssetId);
+    EXPECT_EQ(plans[0].sourceModulePath, plans[1].sourceModulePath);
+    EXPECT_NE(plans[0].instanceModulePath, plans[1].instanceModulePath);
+}
+
+TEST(ScriptRuntimeSessionTests, BuildInstancePlansSkipsSpritesWithoutScriptAsset)
+{
+    Xelqoria::Game::Scene scene{};
+    Xelqoria::Game::Entity& entity = scene.CreateEntity();
+    entity.SetSpriteComponent(Xelqoria::Game::SpriteComponent{
+        Xelqoria::Core::AssetId("sprites/no-script"),
+        {}
+    });
+
+    Xelqoria::Game::Assets::SpriteAssetRegistry spriteAssetRegistry{};
+    spriteAssetRegistry.RegisterSpriteAsset(
+        Xelqoria::Core::AssetId("sprites/no-script"),
+        Xelqoria::Game::Assets::SpriteAsset{ Xelqoria::Core::AssetId("textures/player") });
+
+    const Xelqoria::Editor::ScriptBuildResult buildResult{};
+    const std::vector<Xelqoria::Editor::ScriptRuntimeInstancePlan> plans =
+        Xelqoria::Editor::ScriptRuntimeSession::BuildInstancePlans(
+            scene,
+            spriteAssetRegistry,
+            buildResult,
+            std::filesystem::temp_directory_path());
+
+    EXPECT_TRUE(plans.empty());
+}

--- a/tests/Editor/Xelqoria.Tests.Editor.vcxproj
+++ b/tests/Editor/Xelqoria.Tests.Editor.vcxproj
@@ -25,6 +25,7 @@
     <ClCompile Include="..\..\Editor\Source\SceneCommandHistory.cpp" />
     <ClCompile Include="..\..\Editor\Source\SceneEditingOperations.cpp" />
     <ClCompile Include="..\..\Editor\Source\ScriptAssetService.cpp" />
+    <ClCompile Include="..\..\Editor\Source\ScriptRuntimeSession.cpp" />
     <ClCompile Include="Source\EditorProjectTests.cpp" />
     <ClCompile Include="Source\HierarchyPanelControllerTests.cpp" />
     <ClCompile Include="Source\InspectorPanelControllerTests.cpp" />
@@ -32,6 +33,7 @@
     <ClCompile Include="Source\SceneCommandHistoryTests.cpp" />
     <ClCompile Include="Source\SceneEditingOperationsTests.cpp" />
     <ClCompile Include="Source\ScriptAssetServiceTests.cpp" />
+    <ClCompile Include="Source\ScriptRuntimeSessionTests.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\third_party\googletest\Xelqoria.GoogleTest.vcxproj">

--- a/tests/Editor/Xelqoria.Tests.Editor.vcxproj.filters
+++ b/tests/Editor/Xelqoria.Tests.Editor.vcxproj.filters
@@ -27,7 +27,13 @@
     <ClCompile Include="..\..\Editor\Source\ScriptAssetService.cpp">
       <Filter>Source</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\Editor\Source\ScriptRuntimeSession.cpp">
+      <Filter>Source</Filter>
+    </ClCompile>
     <ClCompile Include="Source\ScriptAssetServiceTests.cpp">
+      <Filter>Source</Filter>
+    </ClCompile>
+    <ClCompile Include="Source\ScriptRuntimeSessionTests.cpp">
       <Filter>Source</Filter>
     </ClCompile>
   </ItemGroup>


### PR DESCRIPTION
Parent: #168
Child: #173

## Summary
- Script ビルド成果物として実行用 DLL を生成し、Script AssetId と対応付けます。
- Editor 再生開始時に ScriptRuntimeSession を開始し、Start を一度、Update を毎フレーム実行します。
- 同一 Script 付き Sprite を複数配置した場合に Entity ごとの DLL コピーをロードし、静的状態が分離されるようにします。

## Verification
- tools/wsl/build.sh tests/Editor/Xelqoria.Tests.Editor.vcxproj
- artifacts/x64/Debug/Xelqoria.Tests.Editor.exe --gtest_filter=ScriptRuntimeSessionTests.*:ScriptAssetServiceTests.*
- tools/wsl/build.sh Editor/Xelqoria.Editor.vcxproj
- tools/wsl/test.sh --no-build