### PR TITLE
Add 2D physics collision foundation

### DIFF
--- a/Game/Source/Physics2D.cpp
+++ b/Game/Source/Physics2D.cpp
@@ -1,0 +1,70 @@
+#include "Physics2D.h"
+
+#include <algorithm>
+#include <cmath>
+
+namespace
+{
+	float Dot(const Xelqoria::Math::Vector2& lhs, const Xelqoria::Math::Vector2& rhs)
+	{
+		return (lhs.x * rhs.x) + (lhs.y * rhs.y);
+	}
+}
+
+namespace Xelqoria::Game
+{
+	CollisionResult2D Physics2D::TestAabbOverlap(
+		const AabbCollider2D& movingCollider,
+		const AabbCollider2D& staticCollider)
+	{
+		const Xelqoria::Math::Vector2 delta = movingCollider.center - staticCollider.center;
+		const float overlapX = (movingCollider.halfSize.x + staticCollider.halfSize.x) - std::fabs(delta.x);
+		if (overlapX <= 0.0f) {
+			return {};
+		}
+
+		const float overlapY = (movingCollider.halfSize.y + staticCollider.halfSize.y) - std::fabs(delta.y);
+		if (overlapY <= 0.0f) {
+			return {};
+		}
+
+		CollisionResult2D result{};
+		result.hit = true;
+		if (overlapX < overlapY) {
+			result.normal = { delta.x < 0.0f ? -1.0f : 1.0f, 0.0f };
+			result.penetrationDepth = overlapX;
+			return result;
+		}
+
+		result.normal = { 0.0f, delta.y < 0.0f ? -1.0f : 1.0f };
+		result.penetrationDepth = overlapY;
+		return result;
+	}
+
+	Xelqoria::Math::Vector2 Physics2D::ComputeSeparationVector(const CollisionResult2D& collisionResult)
+	{
+		if (false == collisionResult.hit) {
+			return {};
+		}
+
+		return collisionResult.normal * collisionResult.penetrationDepth;
+	}
+
+	Xelqoria::Math::Vector2 Physics2D::ResolveRestitution(
+		const Xelqoria::Math::Vector2& velocity,
+		const CollisionResult2D& collisionResult,
+		float restitution)
+	{
+		if (false == collisionResult.hit) {
+			return velocity;
+		}
+
+		const float velocityAlongNormal = Dot(velocity, collisionResult.normal);
+		if (velocityAlongNormal >= 0.0f) {
+			return velocity;
+		}
+
+		const float clampedRestitution = std::clamp(restitution, 0.0f, 1.0f);
+		return velocity - (collisionResult.normal * ((1.0f + clampedRestitution) * velocityAlongNormal));
+	}
+}

--- a/Game/Source/Physics2D.h
+++ b/Game/Source/Physics2D.h
@@ -1,0 +1,79 @@
+#pragma once
+#include "Vector2.h"
+
+namespace Xelqoria::Game
+{
+	/// <summary>
+	/// 2D の軸平行矩形コライダーを表す。
+	/// </summary>
+	struct AabbCollider2D
+	{
+		/// <summary>
+		/// コライダー中心座標。
+		/// </summary>
+		Xelqoria::Math::Vector2 center{};
+
+		/// <summary>
+		/// コライダーの半分の幅と高さ。
+		/// </summary>
+		Xelqoria::Math::Vector2 halfSize{};
+	};
+
+	/// <summary>
+	/// 2D 当たり判定の結果を表す。
+	/// </summary>
+	struct CollisionResult2D
+	{
+		/// <summary>
+		/// 当たり判定が成立したかどうか。
+		/// </summary>
+		bool hit = false;
+
+		/// <summary>
+		/// 対象を押し戻す方向を表す単位法線。
+		/// </summary>
+		Xelqoria::Math::Vector2 normal{};
+
+		/// <summary>
+		/// 法線方向へ押し戻す必要がある距離。
+		/// </summary>
+		float penetrationDepth = 0.0f;
+	};
+
+	/// <summary>
+	/// 2D 当たり判定と反発に必要な最小 API を提供する。
+	/// </summary>
+	class Physics2D
+	{
+	public:
+		/// <summary>
+		/// 2つの AABB コライダーの重なりを判定する。
+		/// </summary>
+		/// <param name="movingCollider">反発対象となるコライダー。</param>
+		/// <param name="staticCollider">衝突相手となるコライダー。</param>
+		/// <returns>当たり判定結果。hit が true の場合は法線とめり込み量を含む。</returns>
+		[[nodiscard]] static CollisionResult2D TestAabbOverlap(
+			const AabbCollider2D& movingCollider,
+			const AabbCollider2D& staticCollider);
+
+		/// <summary>
+		/// 衝突結果から、めり込みを解消する移動量を計算する。
+		/// </summary>
+		/// <param name="collisionResult">当たり判定結果。</param>
+		/// <returns>hit が true の場合は押し戻しベクトル、それ以外はゼロベクトル。</returns>
+		[[nodiscard]] static Xelqoria::Math::Vector2 ComputeSeparationVector(
+			const CollisionResult2D& collisionResult);
+
+		/// <summary>
+		/// 衝突法線に基づいて速度を反発方向へ変換する。
+		/// </summary>
+		/// <param name="velocity">現在の速度。</param>
+		/// <param name="collisionResult">当たり判定結果。</param>
+		/// <param name="restitution">反発係数。0 から 1 の範囲に補正して扱う。</param>
+		/// <returns>反発後の速度。衝突していない場合や離れる向きの場合は元の速度。</returns>
+		[[nodiscard]] static Xelqoria::Math::Vector2 ResolveRestitution(
+			const Xelqoria::Math::Vector2& velocity,
+			const CollisionResult2D& collisionResult,
+			float restitution);
+	};
+}

--- a/Game/Xelqoria.Game.vcxproj
+++ b/Game/Xelqoria.Game.vcxproj
@@ -33,6 +33,7 @@
     <ClCompile Include="Source\Assets\SpriteAssetRegistry.cpp" />
     <ClCompile Include="Source\Assets\SpriteAssetLoader.cpp" />
     <ClCompile Include="Source\Entity.cpp" />
+    <ClCompile Include="Source\Physics2D.cpp" />
     <ClCompile Include="Source\Scene.cpp" />
     <ClCompile Include="Source\SceneTextReader.cpp" />
     <ClCompile Include="Source\SceneTextWriter.cpp" />
@@ -45,6 +46,7 @@
     <ClInclude Include="Source\Assets\SpriteAssetLoader.h" />
     <ClInclude Include="Source\Assets\SpriteAssetRegistry.h" />
     <ClInclude Include="Source\Entity.h" />
+    <ClInclude Include="Source\Physics2D.h" />
     <ClInclude Include="Source\Scene.h" />
     <ClInclude Include="Source\SceneSaveFormat.h" />
     <ClInclude Include="Source\SceneSerializer.h" />

--- a/Game/Xelqoria.Game.vcxproj.filters
+++ b/Game/Xelqoria.Game.vcxproj.filters
@@ -20,6 +20,9 @@
     <ClCompile Include="Source\Entity.cpp">
       <Filter>Source</Filter>
     </ClCompile>
+    <ClCompile Include="Source\Physics2D.cpp">
+      <Filter>Source</Filter>
+    </ClCompile>
     <ClCompile Include="Source\Scene.cpp">
       <Filter>Source</Filter>
     </ClCompile>
@@ -50,6 +53,9 @@
       <Filter>Source\Assets</Filter>
     </ClInclude>
     <ClInclude Include="Source\Entity.h">
+      <Filter>Source</Filter>
+    </ClInclude>
+    <ClInclude Include="Source\Physics2D.h">
       <Filter>Source</Filter>
     </ClInclude>
     <ClInclude Include="Source\Scene.h">

--- a/tests/Game/Source/Physics2DTests.cpp
+++ b/tests/Game/Source/Physics2DTests.cpp
@@ -1,0 +1,90 @@
+#include <cmath>
+
+#include <gtest/gtest.h>
+
+#include "Physics2D.h"
+
+namespace
+{
+	bool IsEqual(float lhs, float rhs)
+	{
+		return std::fabs(lhs - rhs) < 0.0001f;
+	}
+}
+
+TEST(Physics2DTests, AabbOverlapReportsCollisionNormalAndSeparation)
+{
+	const Xelqoria::Game::AabbCollider2D movingCollider{
+		{ 0.5f, 0.0f },
+		{ 1.0f, 1.0f }
+	};
+	const Xelqoria::Game::AabbCollider2D staticCollider{
+		{ 1.25f, 0.0f },
+		{ 1.0f, 1.0f }
+	};
+
+	const Xelqoria::Game::CollisionResult2D result =
+		Xelqoria::Game::Physics2D::TestAabbOverlap(movingCollider, staticCollider);
+
+	EXPECT_TRUE(result.hit);
+	EXPECT_TRUE(IsEqual(result.normal.x, -1.0f));
+	EXPECT_TRUE(IsEqual(result.normal.y, 0.0f));
+	EXPECT_TRUE(IsEqual(result.penetrationDepth, 1.25f));
+
+	const Xelqoria::Math::Vector2 separation =
+		Xelqoria::Game::Physics2D::ComputeSeparationVector(result);
+	EXPECT_TRUE(IsEqual(separation.x, -1.25f));
+	EXPECT_TRUE(IsEqual(separation.y, 0.0f));
+}
+
+TEST(Physics2DTests, AabbOverlapReturnsMissWhenSeparated)
+{
+	const Xelqoria::Game::AabbCollider2D movingCollider{
+		{ -3.0f, 0.0f },
+		{ 1.0f, 1.0f }
+	};
+	const Xelqoria::Game::AabbCollider2D staticCollider{
+		{ 3.0f, 0.0f },
+		{ 1.0f, 1.0f }
+	};
+
+	const Xelqoria::Game::CollisionResult2D result =
+		Xelqoria::Game::Physics2D::TestAabbOverlap(movingCollider, staticCollider);
+
+	EXPECT_FALSE(result.hit);
+	EXPECT_TRUE(IsEqual(result.normal.x, 0.0f));
+	EXPECT_TRUE(IsEqual(result.normal.y, 0.0f));
+	EXPECT_TRUE(IsEqual(result.penetrationDepth, 0.0f));
+}
+
+TEST(Physics2DTests, RestitutionReflectsVelocityAlongCollisionNormal)
+{
+	const Xelqoria::Game::CollisionResult2D result{
+		true,
+		{ -1.0f, 0.0f },
+		1.0f
+	};
+	const Xelqoria::Math::Vector2 velocity{ 10.0f, 2.0f };
+
+	const Xelqoria::Math::Vector2 reflectedVelocity =
+		Xelqoria::Game::Physics2D::ResolveRestitution(velocity, result, 0.5f);
+
+	EXPECT_TRUE(IsEqual(reflectedVelocity.x, -5.0f));
+	EXPECT_TRUE(IsEqual(reflectedVelocity.y, 2.0f));
+}
+
+TEST(Physics2DTests, RestitutionDoesNotApplyWhenAlreadyMovingAway)
+{
+	const Xelqoria::Game::CollisionResult2D result{
+		true,
+		{ -1.0f, 0.0f },
+		1.0f
+	};
+	const Xelqoria::Math::Vector2 velocity{ -3.0f, 4.0f };
+
+	const Xelqoria::Math::Vector2 resolvedVelocity =
+		Xelqoria::Game::Physics2D::ResolveRestitution(velocity, result, 1.0f);
+
+	EXPECT_TRUE(IsEqual(resolvedVelocity.x, -3.0f));
+	EXPECT_TRUE(IsEqual(resolvedVelocity.y, 4.0f));
+}

--- a/tests/Game/Xelqoria.Tests.Game.vcxproj
+++ b/tests/Game/Xelqoria.Tests.Game.vcxproj
@@ -19,6 +19,7 @@
     </ProjectConfiguration>
   </ItemGroup>
   <ItemGroup>
+    <ClCompile Include="Source\Physics2DTests.cpp" />
     <ClCompile Include="Source\TransformTests.cpp" />
   </ItemGroup>
   <ItemGroup>

--- a/tests/Game/Xelqoria.Tests.Game.vcxproj.filters
+++ b/tests/Game/Xelqoria.Tests.Game.vcxproj.filters
@@ -6,6 +6,9 @@
     </Filter>
   </ItemGroup>
   <ItemGroup>
+    <ClCompile Include="Source\Physics2DTests.cpp">
+      <Filter>Source</Filter>
+    </ClCompile>
     <ClCompile Include="Source\TransformTests.cpp">
       <Filter>Source</Filter>
     </ClCompile>


### PR DESCRIPTION
Parent issue: #186
Child issue: #189

## Summary
- Add a minimal Game-layer Physics2D foundation for AABB collision detection.
- Add collision-result separation and restitution velocity resolution without gravity or rigid-body simulation.
- Add Game tests for hit, miss, separation, and restitution behavior.

## Verification
- BuildTools MSBuild: tests/Game/Xelqoria.Tests.Game.vcxproj Debug x64
- artifacts/x64/Debug/Xelqoria.Tests.Game.exe --gtest_color=no

## Notes
- tools/wsl/test.sh -c Debug -p x64 could not complete because Windows dotnet failed to resolve Microsoft.NET.Sdk for tools/LayerDependencyChecker/LayerDependencyChecker.csproj in this environment.