### PR TITLE
#187 CPU/GPU Sprite 描画で共通 Sprite 入力 API を整備

### DIFF
--- a/Graphics/Source/Sprite.cpp
+++ b/Graphics/Source/Sprite.cpp
@@ -103,4 +103,19 @@ namespace Xelqoria::Graphics
 	{
 		return m_outlineColor;
 	}
+
+	SpriteDrawInput Sprite::ToDrawInput() const
+	{
+		return SpriteDrawInput{
+			m_texture,
+			m_textureAssetId,
+			m_position,
+			m_scale,
+			m_rotationDegrees,
+			m_color,
+			m_outlineEnabled,
+			m_outlineThickness,
+			m_outlineColor
+		};
+	}
 }

--- a/Graphics/Source/Sprite.h
+++ b/Graphics/Source/Sprite.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "AssetId.h"
+#include "SpriteDrawInput.h"
 #include "Vector2.h"
 
 #include <array>
@@ -143,6 +144,12 @@ namespace Xelqoria::Graphics
 		/// </summary>
 		/// <returns>RGBA 順の外枠色。</returns>
 		const std::array<float, 4>& GetOutlineColor() const;
+
+		/// <summary>
+		/// SpriteRenderer が受け取る共通 Sprite 入力データへ変換する。
+		/// </summary>
+		/// <returns>現在の Sprite 状態から作成した共通描画入力。</returns>
+		[[nodiscard]] SpriteDrawInput ToDrawInput() const;
 
 	private:
 		std::shared_ptr<Texture2D> m_texture;

--- a/Graphics/Source/SpriteDrawInput.h
+++ b/Graphics/Source/SpriteDrawInput.h
@@ -1,0 +1,63 @@
+#pragma once
+
+#include "AssetId.h"
+#include "Vector2.h"
+
+#include <array>
+#include <memory>
+
+namespace Xelqoria::Graphics
+{
+	class Texture2D;
+
+	/// <summary>
+	/// CPU/GPU の Sprite 描画経路へ渡す共通入力データを表す。
+	/// </summary>
+	struct SpriteDrawInput
+	{
+		/// <summary>
+		/// 描画に使用する解決済みテクスチャを表す。
+		/// </summary>
+		std::shared_ptr<Texture2D> texture{};
+
+		/// <summary>
+		/// 描画に使用するテクスチャアセット識別子を表す。
+		/// </summary>
+		Core::AssetId textureAssetId{};
+
+		/// <summary>
+		/// スプライトの描画位置を表す。
+		/// </summary>
+		Xelqoria::Math::Vector2 position{};
+
+		/// <summary>
+		/// スプライトの拡大率を表す。
+		/// </summary>
+		Xelqoria::Math::Vector2 scale{ 1.0f, 1.0f };
+
+		/// <summary>
+		/// 度数法で表したスプライトの回転角度を表す。
+		/// </summary>
+		float rotationDegrees = 0.0f;
+
+		/// <summary>
+		/// RGBA 順の色乗算値を表す。
+		/// </summary>
+		std::array<float, 4> color{ 1.0f, 1.0f, 1.0f, 1.0f };
+
+		/// <summary>
+		/// スプライト外枠描画が有効かを表す。
+		/// </summary>
+		bool outlineEnabled = false;
+
+		/// <summary>
+		/// スプライト外枠の太さを画面ピクセル単位で表す。
+		/// </summary>
+		float outlineThickness = 1.0f;
+
+		/// <summary>
+		/// RGBA 順のスプライト外枠色を表す。
+		/// </summary>
+		std::array<float, 4> outlineColor{ 1.0f, 1.0f, 0.0f, 1.0f };
+	};
+}

--- a/Graphics/Source/SpriteRenderMath.h
+++ b/Graphics/Source/SpriteRenderMath.h
@@ -4,6 +4,7 @@
 #include <cstdint>
 
 #include "Sprite.h"
+#include "SpriteDrawInput.h"
 #include "Texture2D.h"
 #include <Vector2.h>
 
@@ -46,6 +47,38 @@ namespace Xelqoria::Graphics
 	};
 
 	/// <summary>
+	/// 共通 Sprite 入力データの位置と拡大率からクアッド描画用の正規化変換を計算する。
+	/// </summary>
+	/// <param name="input">変換対象の共通 Sprite 入力データ。</param>
+	/// <param name="viewportWidth">描画先ビューポート幅。</param>
+	/// <param name="viewportHeight">描画先ビューポート高さ。</param>
+	/// <returns>単位クアッドに適用する変換値。</returns>
+	inline SpriteQuadTransform ComputeSpriteQuadTransform(const SpriteDrawInput& input, std::uint32_t viewportWidth, std::uint32_t viewportHeight)
+	{
+		SpriteQuadTransform transform{};
+		if (viewportWidth == 0 || viewportHeight == 0) {
+			return transform;
+		}
+
+		const auto texture = input.texture;
+		if (!texture) {
+			return transform;
+		}
+
+		const Xelqoria::Math::Vector2 position = input.position;
+		const Xelqoria::Math::Vector2 scale = input.scale;
+
+		transform.scaleX = (2.0f * static_cast<float>(texture->GetWidth()) * scale.x) / static_cast<float>(viewportWidth);
+		transform.scaleY = (2.0f * static_cast<float>(texture->GetHeight()) * scale.y) / static_cast<float>(viewportHeight);
+		transform.translateX = (2.0f * position.x) / static_cast<float>(viewportWidth);
+		transform.translateY = (-2.0f * position.y) / static_cast<float>(viewportHeight);
+		const float rotationRadians = input.rotationDegrees * (3.14159265358979323846f / 180.0f);
+		transform.rotationCos = std::cos(rotationRadians);
+		transform.rotationSin = std::sin(rotationRadians);
+		return transform;
+	}
+
+	/// <summary>
 	/// Sprite の位置と拡大率からクアッド描画用の正規化変換を計算する。
 	/// </summary>
 	/// <param name="sprite">変換対象の Sprite。</param>
@@ -54,26 +87,6 @@ namespace Xelqoria::Graphics
 	/// <returns>単位クアッドに適用する変換値。</returns>
 	inline SpriteQuadTransform ComputeSpriteQuadTransform(const Sprite& sprite, std::uint32_t viewportWidth, std::uint32_t viewportHeight)
 	{
-		SpriteQuadTransform transform{};
-		if (viewportWidth == 0 || viewportHeight == 0) {
-			return transform;
-		}
-
-		const auto texture = sprite.GetTexture();
-		if (!texture) {
-			return transform;
-		}
-
-		const Xelqoria::Math::Vector2 position = sprite.GetPosition();
-		const Xelqoria::Math::Vector2 scale = sprite.GetScale();
-
-		transform.scaleX = (2.0f * static_cast<float>(texture->GetWidth()) * scale.x) / static_cast<float>(viewportWidth);
-		transform.scaleY = (2.0f * static_cast<float>(texture->GetHeight()) * scale.y) / static_cast<float>(viewportHeight);
-		transform.translateX = (2.0f * position.x) / static_cast<float>(viewportWidth);
-		transform.translateY = (-2.0f * position.y) / static_cast<float>(viewportHeight);
-		const float rotationRadians = sprite.GetRotationDegrees() * (3.14159265358979323846f / 180.0f);
-		transform.rotationCos = std::cos(rotationRadians);
-		transform.rotationSin = std::sin(rotationRadians);
-		return transform;
+		return ComputeSpriteQuadTransform(sprite.ToDrawInput(), viewportWidth, viewportHeight);
 	}
 }

--- a/Graphics/Source/SpriteRenderer.cpp
+++ b/Graphics/Source/SpriteRenderer.cpp
@@ -3,6 +3,7 @@
 #include "SpriteRenderMath.h"
 #include "QuadTransformFactory.h"
 #include "Sprite.h"
+#include "SpriteDrawInput.h"
 #include "Texture2D.h"
 #include "IGraphicsContext.h"
 
@@ -20,12 +21,17 @@ namespace Xelqoria::Graphics
 
     void SpriteRenderer::Draw(const Sprite& sprite)
     {
+        Draw(sprite.ToDrawInput());
+    }
+
+    void SpriteRenderer::Draw(const SpriteDrawInput& input)
+    {
         if (!m_isDrawing || !m_context)
         {
             return;
         }
 
-        const auto texture = sprite.GetTexture();
+        const auto texture = input.texture;
         if (!texture)
         {
             return;
@@ -39,15 +45,15 @@ namespace Xelqoria::Graphics
 
         m_context->BindTexture(0, rhiTexture.get());
         const SpriteQuadTransform quadTransform = ComputeSpriteQuadTransform(
-            sprite,
+            input,
             m_context->GetViewportWidth(),
             m_context->GetViewportHeight());
         const QuadRenderConstants quadRenderConstants = MakeTexturedQuadTransform(
             quadTransform,
-            sprite.IsOutlineEnabled(),
-            sprite.GetOutlineThickness(),
-            sprite.GetOutlineColor(),
-            sprite.GetColor());
+            input.outlineEnabled,
+            input.outlineThickness,
+            input.outlineColor,
+            input.color);
         ApplyQuadRenderConstants(*m_context, quadRenderConstants);
 
         // 1スプライトを2三角形(6頂点)で描画する前提。

--- a/Graphics/Source/SpriteRenderer.h
+++ b/Graphics/Source/SpriteRenderer.h
@@ -8,6 +8,7 @@ namespace Xelqoria::RHI
 namespace Xelqoria::Graphics
 {
     class Sprite;
+    struct SpriteDrawInput;
 
     /// <summary>
     /// Sprite を描画するレンダラー。
@@ -33,6 +34,12 @@ namespace Xelqoria::Graphics
         void Draw(const Sprite& sprite);
 
         /// <summary>
+        /// 共通 Sprite 入力データを描画キューへ追加する。
+        /// </summary>
+        /// <param name="input">描画対象の共通 Sprite 入力データ。</param>
+        void Draw(const SpriteDrawInput& input);
+
+        /// <summary>
         /// 描画バッチを終了して送信する。
         /// </summary>
         void End();
@@ -41,4 +48,14 @@ namespace Xelqoria::Graphics
         RHI::IGraphicsContext* m_context = nullptr;
         bool m_isDrawing = false;
     };
+
+    /// <summary>
+    /// CPU SpriteBatch として利用する Sprite 描画 API を表す。
+    /// </summary>
+    using SpriteBatch = SpriteRenderer;
+
+    /// <summary>
+    /// GPU InstancedSpriteRenderer として利用する Sprite 描画 API を表す。
+    /// </summary>
+    using InstancedSpriteRenderer = SpriteRenderer;
 }

--- a/Graphics/Xelqoria.Graphics.vcxproj
+++ b/Graphics/Xelqoria.Graphics.vcxproj
@@ -28,6 +28,7 @@
     <ClInclude Include="Source\ITextureAssetResolver.h" />
     <ClInclude Include="Source\QuadTransformFactory.h" />
     <ClInclude Include="Source\Sprite.h" />
+    <ClInclude Include="Source\SpriteDrawInput.h" />
     <ClInclude Include="Source\SpriteRenderMath.h" />
     <ClInclude Include="Source\SpriteRenderer.h" />
     <ClInclude Include="Source\TextureAssetRegistry.h" />

--- a/Graphics/Xelqoria.Graphics.vcxproj.filters
+++ b/Graphics/Xelqoria.Graphics.vcxproj.filters
@@ -29,6 +29,9 @@
     <ClInclude Include="Source\Sprite.h">
       <Filter>Source</Filter>
     </ClInclude>
+    <ClInclude Include="Source\SpriteDrawInput.h">
+      <Filter>Source</Filter>
+    </ClInclude>
     <ClInclude Include="Source\SpriteRenderMath.h">
       <Filter>Source</Filter>
     </ClInclude>

--- a/tests/Graphics/Source/SpriteRenderMathTests.cpp
+++ b/tests/Graphics/Source/SpriteRenderMathTests.cpp
@@ -1,13 +1,17 @@
 #include <cmath>
 #include <memory>
+#include <vector>
 
 #include <gtest/gtest.h>
 
 #include "AssetId.h"
+#include "IGraphicsContext.h"
 #include "ITexture.h"
 #include "QuadTransformFactory.h"
 #include "Sprite.h"
+#include "SpriteDrawInput.h"
 #include "SpriteRenderMath.h"
+#include "SpriteRenderer.h"
 #include "TextureAssetRegistry.h"
 #include "Texture2D.h"
 
@@ -40,6 +44,83 @@ namespace
     private:
         std::uint32_t m_width = 0;
         std::uint32_t m_height = 0;
+    };
+
+    class FakeGraphicsContext final : public Xelqoria::RHI::IGraphicsContext
+    {
+    public:
+        bool Initialize(
+            Xelqoria::RHI::NativeWindowHandle,
+            Xelqoria::RHI::NativeInstanceHandle,
+            std::uint32_t,
+            std::uint32_t) override
+        {
+            return true;
+        }
+
+        void Shutdown() override
+        {
+        }
+
+        void BeginFrame() override
+        {
+        }
+
+        void EndFrame() override
+        {
+        }
+
+        std::shared_ptr<Xelqoria::RHI::ITexture> CreateTextureFromFile(const std::wstring&) override
+        {
+            return nullptr;
+        }
+
+        void BindTexture(std::uint32_t slot, Xelqoria::RHI::ITexture* texture) override
+        {
+            lastBoundSlot = slot;
+            lastBoundTexture = texture;
+        }
+
+        void SetShaderConstants(std::span<const float> constants) override
+        {
+            lastConstants.assign(constants.begin(), constants.end());
+        }
+
+        void Draw(std::uint32_t vertexCount, std::uint32_t startVertexLocation) override
+        {
+            ++drawCount;
+            lastVertexCount = vertexCount;
+            lastStartVertexLocation = startVertexLocation;
+        }
+
+        void DrawIndexed(std::uint32_t, std::uint32_t, std::int32_t) override
+        {
+        }
+
+        void Resize(std::uint32_t width, std::uint32_t height) override
+        {
+            viewportWidth = width;
+            viewportHeight = height;
+        }
+
+        std::uint32_t GetViewportWidth() const override
+        {
+            return viewportWidth;
+        }
+
+        std::uint32_t GetViewportHeight() const override
+        {
+            return viewportHeight;
+        }
+
+        std::uint32_t viewportWidth = 1280;
+        std::uint32_t viewportHeight = 720;
+        std::uint32_t drawCount = 0;
+        std::uint32_t lastBoundSlot = 0;
+        Xelqoria::RHI::ITexture* lastBoundTexture = nullptr;
+        std::uint32_t lastVertexCount = 0;
+        std::uint32_t lastStartVertexLocation = 0;
+        std::vector<float> lastConstants{};
     };
 }
 
@@ -81,6 +162,72 @@ TEST(SpriteRenderMathTests, SpriteStoresRenderStateAndComputesQuadTransform)
     EXPECT_TRUE(IsEqual(emptyTransform.translateY, 0.0f));
     EXPECT_TRUE(IsEqual(emptyTransform.rotationCos, 1.0f));
     EXPECT_TRUE(IsEqual(emptyTransform.rotationSin, 0.0f));
+}
+
+TEST(SpriteRenderMathTests, SpriteCreatesCommonDrawInput)
+{
+    Xelqoria::Graphics::Sprite sprite;
+    sprite.SetTextureAssetId("textures/player-idle");
+    sprite.SetPosition(32.0f, 48.0f);
+    sprite.SetScale(1.5f, 2.0f);
+    sprite.SetRotationDegrees(45.0f);
+    sprite.SetColor(0.2f, 0.4f, 0.6f, 0.8f);
+    sprite.SetOutlineEnabled(true);
+    sprite.SetOutlineThickness(3.0f);
+    sprite.SetOutlineColor(0.9f, 0.7f, 0.5f, 0.3f);
+
+    auto renderTexture = std::make_shared<Xelqoria::Graphics::Texture2D>();
+    renderTexture->SetRHITexture(std::make_shared<FakeTexture>(16, 24));
+    sprite.SetTexture(renderTexture);
+
+    const Xelqoria::Graphics::SpriteDrawInput input = sprite.ToDrawInput();
+
+    EXPECT_EQ(input.texture, renderTexture);
+    EXPECT_EQ(input.textureAssetId, Xelqoria::Core::AssetId("textures/player-idle"));
+    EXPECT_TRUE(IsEqual(input.position.x, 32.0f));
+    EXPECT_TRUE(IsEqual(input.scale.y, 2.0f));
+    EXPECT_TRUE(IsEqual(input.rotationDegrees, 45.0f));
+    EXPECT_TRUE(IsEqual(input.color[2], 0.6f));
+    EXPECT_TRUE(input.outlineEnabled);
+    EXPECT_TRUE(IsEqual(input.outlineThickness, 3.0f));
+    EXPECT_TRUE(IsEqual(input.outlineColor[3], 0.3f));
+}
+
+TEST(SpriteRenderMathTests, SpriteRendererDrawsCommonDrawInput)
+{
+    auto rhiTexture = std::make_shared<FakeTexture>(64, 32);
+    auto renderTexture = std::make_shared<Xelqoria::Graphics::Texture2D>();
+    renderTexture->SetRHITexture(rhiTexture);
+
+    Xelqoria::Graphics::SpriteDrawInput input{};
+    input.texture = renderTexture;
+    input.position = { 160.0f, -90.0f };
+    input.scale = { 2.0f, 0.5f };
+    input.rotationDegrees = 90.0f;
+    input.color = { 0.25f, 0.5f, 0.75f, 0.8f };
+    input.outlineEnabled = true;
+    input.outlineThickness = 4.0f;
+    input.outlineColor = { 0.1f, 0.2f, 0.3f, 0.4f };
+
+    FakeGraphicsContext context{};
+    Xelqoria::Graphics::SpriteBatch spriteBatch(context);
+    Xelqoria::Graphics::InstancedSpriteRenderer& instancedSpriteRenderer = spriteBatch;
+
+    spriteBatch.Begin();
+    instancedSpriteRenderer.Draw(input);
+    spriteBatch.End();
+
+    EXPECT_EQ(context.drawCount, 1u);
+    EXPECT_EQ(context.lastVertexCount, 6u);
+    EXPECT_EQ(context.lastStartVertexLocation, 0u);
+    EXPECT_EQ(context.lastBoundSlot, 0u);
+    EXPECT_EQ(context.lastBoundTexture, nullptr);
+    EXPECT_EQ(context.lastConstants.size(), Xelqoria::Graphics::QuadRenderConstantFloatCount);
+    EXPECT_TRUE(IsEqual(context.lastConstants[0], 0.2f));
+    EXPECT_TRUE(IsEqual(context.lastConstants[6], 1.0f));
+    EXPECT_TRUE(IsEqual(context.lastConstants[7], 4.0f));
+    EXPECT_TRUE(IsEqual(context.lastConstants[12], 0.25f));
+    EXPECT_TRUE(IsEqual(context.lastConstants[15], 0.8f));
 }
 
 TEST(SpriteRenderMathTests, TextureRegistryAndTexture2DHandleResolvedAndMissingTextures)


### PR DESCRIPTION
## Summary
- Add Graphics::SpriteDrawInput as the common Sprite input data for CPU/GPU sprite drawing APIs.
- Allow SpriteRenderer, SpriteBatch, and InstancedSpriteRenderer API surfaces to draw SpriteDrawInput.
- Keep existing Sprite drawing path by converting Sprite to SpriteDrawInput.

## Issues
- Parent: #186
- Child: #187

## Verification
- dotnet build tools/LayerDependencyChecker/LayerDependencyChecker.csproj -c Debug
- MSBuild tests/Graphics/Xelqoria.Tests.Graphics.vcxproj /p:Configuration=Debug /p:Platform=x64
- ./artifacts/x64/Debug/Xelqoria.Tests.Graphics.exe