### PR TITLE
Add platform abstraction projects

### DIFF
--- a/Platform.Mac/Source/MacPlatformAnchor.cpp
+++ b/Platform.Mac/Source/MacPlatformAnchor.cpp
@@ -1,0 +1,11 @@
+#include "IApplication.h"
+
+namespace Xelqoria::Platform::Mac
+{
+    /// <summary>
+    /// Mac プラットフォーム実装プロジェクトのリンク対象翻訳単位を用意する。
+    /// </summary>
+    void MacPlatformAnchor()
+    {
+    }
+}

--- a/Platform.Mac/Xelqoria.Platform.Mac.vcxproj
+++ b/Platform.Mac/Xelqoria.Platform.Mac.vcxproj
@@ -1,0 +1,140 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <ItemGroup Condition="'$(OS)'!='Windows_NT'">
+    <ClCompile Include="Source\MacPlatformAnchor.cpp" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Platform\Xelqoria.Platform.vcxproj">
+      <Project>{FBC1E45E-2F7B-4E99-B813-916509583283}</Project>
+    </ProjectReference>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <VCProjectVersion>18.0</VCProjectVersion>
+    <Keyword>Win32Proj</Keyword>
+    <ProjectGuid>{2BBDB336-AF96-404D-AAB6-42C1F36CA1A3}</ProjectGuid>
+    <RootNamespace>XelqoriaPlatformMac</RootNamespace>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType Condition="'$(OS)'=='Windows_NT'">Utility</ConfigurationType>
+    <ConfigurationType Condition="'$(OS)'!='Windows_NT'">StaticLibrary</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v145</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType Condition="'$(OS)'=='Windows_NT'">Utility</ConfigurationType>
+    <ConfigurationType Condition="'$(OS)'!='Windows_NT'">StaticLibrary</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v145</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType Condition="'$(OS)'=='Windows_NT'">Utility</ConfigurationType>
+    <ConfigurationType Condition="'$(OS)'!='Windows_NT'">StaticLibrary</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v145</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType Condition="'$(OS)'=='Windows_NT'">Utility</ConfigurationType>
+    <ConfigurationType Condition="'$(OS)'!='Windows_NT'">StaticLibrary</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v145</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings" />
+  <ImportGroup Label="Shared" />
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup>
+    <OutDir>$(SolutionDir)artifacts\$(Platform)\$(Configuration)\</OutDir>
+    <IntDir>$(SolutionDir)build\$(ProjectName)\$(Platform)\$(Configuration)\</IntDir>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>WIN32;_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+      <LanguageStandard>stdcpp20</LanguageStandard>
+      <AdditionalIncludeDirectories>$(ProjectDir)Source;$(RepoRootDir)Platform\Source;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalOptions>/utf-8 %(AdditionalOptions)</AdditionalOptions>
+    </ClCompile>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>WIN32;NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+      <LanguageStandard>stdcpp20</LanguageStandard>
+      <AdditionalIncludeDirectories>$(ProjectDir)Source;$(RepoRootDir)Platform\Source;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalOptions>/utf-8 %(AdditionalOptions)</AdditionalOptions>
+    </ClCompile>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+      <LanguageStandard>stdcpp20</LanguageStandard>
+      <AdditionalIncludeDirectories>$(ProjectDir)Source;$(RepoRootDir)Platform\Source;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalOptions>/utf-8 %(AdditionalOptions)</AdditionalOptions>
+    </ClCompile>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+      <LanguageStandard>stdcpp20</LanguageStandard>
+      <AdditionalIncludeDirectories>$(ProjectDir)Source;$(RepoRootDir)Platform\Source;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalOptions>/utf-8 %(AdditionalOptions)</AdditionalOptions>
+    </ClCompile>
+  </ItemDefinitionGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <PropertyGroup>
+    <RepoRootDir>$(MSBuildProjectDirectory)\..\</RepoRootDir>
+  </PropertyGroup>
+  <ImportGroup Label="ExtensionTargets" />
+</Project>

--- a/Platform.Mac/Xelqoria.Platform.Mac.vcxproj.filters
+++ b/Platform.Mac/Xelqoria.Platform.Mac.vcxproj.filters
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Filter Include="Source">
+      <UniqueIdentifier>{E6C5B3DE-DFAE-409C-B160-32F2CE84CC18}</UniqueIdentifier>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="Source\MacPlatformAnchor.cpp">
+      <Filter>Source</Filter>
+    </ClCompile>
+  </ItemGroup>
+</Project>

--- a/Platform.Win32/Source/Win32PlatformAnchor.cpp
+++ b/Platform.Win32/Source/Win32PlatformAnchor.cpp
@@ -1,0 +1,11 @@
+#include "IApplication.h"
+
+namespace Xelqoria::Platform::Win32
+{
+    /// <summary>
+    /// Win32 プラットフォーム実装プロジェクトのリンク対象翻訳単位を用意する。
+    /// </summary>
+    void Win32PlatformAnchor()
+    {
+    }
+}

--- a/Platform.Win32/Xelqoria.Platform.Win32.vcxproj
+++ b/Platform.Win32/Xelqoria.Platform.Win32.vcxproj
@@ -1,0 +1,136 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="Source\Win32PlatformAnchor.cpp" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Platform\Xelqoria.Platform.vcxproj">
+      <Project>{FBC1E45E-2F7B-4E99-B813-916509583283}</Project>
+    </ProjectReference>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <VCProjectVersion>18.0</VCProjectVersion>
+    <Keyword>Win32Proj</Keyword>
+    <ProjectGuid>{E121A6F2-EFFE-44E6-8123-02CCED1196FC}</ProjectGuid>
+    <RootNamespace>XelqoriaPlatformWin32</RootNamespace>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v145</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v145</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v145</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v145</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings" />
+  <ImportGroup Label="Shared" />
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup>
+    <OutDir>$(SolutionDir)artifacts\$(Platform)\$(Configuration)\</OutDir>
+    <IntDir>$(SolutionDir)build\$(ProjectName)\$(Platform)\$(Configuration)\</IntDir>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>WIN32;_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+      <LanguageStandard>stdcpp20</LanguageStandard>
+      <AdditionalIncludeDirectories>$(ProjectDir)Source;$(RepoRootDir)Platform\Source;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalOptions>/utf-8 %(AdditionalOptions)</AdditionalOptions>
+    </ClCompile>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>WIN32;NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+      <LanguageStandard>stdcpp20</LanguageStandard>
+      <AdditionalIncludeDirectories>$(ProjectDir)Source;$(RepoRootDir)Platform\Source;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalOptions>/utf-8 %(AdditionalOptions)</AdditionalOptions>
+    </ClCompile>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+      <LanguageStandard>stdcpp20</LanguageStandard>
+      <AdditionalIncludeDirectories>$(ProjectDir)Source;$(RepoRootDir)Platform\Source;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalOptions>/utf-8 %(AdditionalOptions)</AdditionalOptions>
+    </ClCompile>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+      <LanguageStandard>stdcpp20</LanguageStandard>
+      <AdditionalIncludeDirectories>$(ProjectDir)Source;$(RepoRootDir)Platform\Source;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalOptions>/utf-8 %(AdditionalOptions)</AdditionalOptions>
+    </ClCompile>
+  </ItemDefinitionGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <PropertyGroup>
+    <RepoRootDir>$(MSBuildProjectDirectory)\..\</RepoRootDir>
+  </PropertyGroup>
+  <ImportGroup Label="ExtensionTargets" />
+</Project>

--- a/Platform.Win32/Xelqoria.Platform.Win32.vcxproj.filters
+++ b/Platform.Win32/Xelqoria.Platform.Win32.vcxproj.filters
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Filter Include="Source">
+      <UniqueIdentifier>{F7998D79-1082-4AC6-8F25-8857C5589D21}</UniqueIdentifier>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="Source\Win32PlatformAnchor.cpp">
+      <Filter>Source</Filter>
+    </ClCompile>
+  </ItemGroup>
+</Project>

--- a/Platform/Source/IApplication.h
+++ b/Platform/Source/IApplication.h
@@ -1,0 +1,24 @@
+#pragma once
+
+namespace Xelqoria::Platform
+{
+    /// <summary>
+    /// OS 固有のアプリケーション初期化と終了処理を抽象化する。
+    /// </summary>
+    class IApplication
+    {
+    public:
+        virtual ~IApplication() = default;
+
+        /// <summary>
+        /// アプリケーション基盤を初期化する。
+        /// </summary>
+        /// <returns>初期化に成功した場合は true。</returns>
+        virtual bool Initialize() = 0;
+
+        /// <summary>
+        /// アプリケーション基盤を終了し、保持している OS リソースを解放する。
+        /// </summary>
+        virtual void Shutdown() = 0;
+    };
+}

--- a/Platform/Source/IClipboard.h
+++ b/Platform/Source/IClipboard.h
@@ -1,0 +1,28 @@
+#pragma once
+
+#include <string>
+
+namespace Xelqoria::Platform
+{
+    /// <summary>
+    /// OS のクリップボード操作を抽象化する。
+    /// </summary>
+    class IClipboard
+    {
+    public:
+        virtual ~IClipboard() = default;
+
+        /// <summary>
+        /// クリップボードにテキストを設定する。
+        /// </summary>
+        /// <param name="text">設定する Unicode テキスト。</param>
+        /// <returns>設定に成功した場合は true。</returns>
+        virtual bool SetText(const std::wstring& text) = 0;
+
+        /// <summary>
+        /// クリップボードからテキストを取得する。
+        /// </summary>
+        /// <returns>取得した Unicode テキスト。取得できない場合は空文字列。</returns>
+        [[nodiscard]] virtual std::wstring GetText() const = 0;
+    };
+}

--- a/Platform/Source/ICursor.h
+++ b/Platform/Source/ICursor.h
@@ -1,0 +1,37 @@
+#pragma once
+
+#include "PlatformTypes.h"
+
+namespace Xelqoria::Platform
+{
+    /// <summary>
+    /// OS のカーソル表示と座標操作を抽象化する。
+    /// </summary>
+    class ICursor
+    {
+    public:
+        virtual ~ICursor() = default;
+
+        /// <summary>
+        /// カーソルを表示する。
+        /// </summary>
+        virtual void Show() = 0;
+
+        /// <summary>
+        /// カーソルを非表示にする。
+        /// </summary>
+        virtual void Hide() = 0;
+
+        /// <summary>
+        /// カーソルのスクリーン座標を設定する。
+        /// </summary>
+        /// <param name="position">設定するスクリーン座標。</param>
+        virtual void SetScreenPosition(Point position) = 0;
+
+        /// <summary>
+        /// カーソルのスクリーン座標を取得する。
+        /// </summary>
+        /// <returns>現在のスクリーン座標。</returns>
+        [[nodiscard]] virtual Point GetScreenPosition() const = 0;
+    };
+}

--- a/Platform/Source/IEventLoop.h
+++ b/Platform/Source/IEventLoop.h
@@ -1,0 +1,24 @@
+#pragma once
+
+namespace Xelqoria::Platform
+{
+    /// <summary>
+    /// OS のイベントループとメッセージ処理を抽象化する。
+    /// </summary>
+    class IEventLoop
+    {
+    public:
+        virtual ~IEventLoop() = default;
+
+        /// <summary>
+        /// 保留中の OS イベントを 1 回分処理する。
+        /// </summary>
+        /// <returns>アプリケーション継続中は true。終了要求を受け取った場合は false。</returns>
+        virtual bool PumpEvents() = 0;
+
+        /// <summary>
+        /// イベントループに終了を要求する。
+        /// </summary>
+        virtual void RequestQuit() = 0;
+    };
+}

--- a/Platform/Source/IFileDialog.h
+++ b/Platform/Source/IFileDialog.h
@@ -1,0 +1,28 @@
+#pragma once
+
+#include <filesystem>
+#include <optional>
+
+namespace Xelqoria::Platform
+{
+    /// <summary>
+    /// OS 標準のファイル選択ダイアログを抽象化する。
+    /// </summary>
+    class IFileDialog
+    {
+    public:
+        virtual ~IFileDialog() = default;
+
+        /// <summary>
+        /// ファイルを開くダイアログを表示する。
+        /// </summary>
+        /// <returns>選択されたパス。キャンセル時は std::nullopt。</returns>
+        [[nodiscard]] virtual std::optional<std::filesystem::path> OpenFile() = 0;
+
+        /// <summary>
+        /// ファイルを保存するダイアログを表示する。
+        /// </summary>
+        /// <returns>選択された保存先パス。キャンセル時は std::nullopt。</returns>
+        [[nodiscard]] virtual std::optional<std::filesystem::path> SaveFile() = 0;
+    };
+}

--- a/Platform/Source/IInput.h
+++ b/Platform/Source/IInput.h
@@ -1,0 +1,42 @@
+#pragma once
+
+#include "PlatformTypes.h"
+
+#include <cstdint>
+
+namespace Xelqoria::Platform
+{
+    /// <summary>
+    /// OS から取得する入力状態を抽象化する。
+    /// </summary>
+    class IInput
+    {
+    public:
+        virtual ~IInput() = default;
+
+        /// <summary>
+        /// 現在フレームの入力状態を更新する。
+        /// </summary>
+        virtual void Update() = 0;
+
+        /// <summary>
+        /// 指定キーが現在押下中かを取得する。
+        /// </summary>
+        /// <param name="keyCode">プラットフォーム実装が解釈するキーコード。</param>
+        /// <returns>押下中の場合は true。</returns>
+        [[nodiscard]] virtual bool IsKeyDown(std::uint32_t keyCode) const = 0;
+
+        /// <summary>
+        /// 指定マウスボタンが現在押下中かを取得する。
+        /// </summary>
+        /// <param name="buttonCode">プラットフォーム実装が解釈するマウスボタンコード。</param>
+        /// <returns>押下中の場合は true。</returns>
+        [[nodiscard]] virtual bool IsMouseButtonDown(std::uint32_t buttonCode) const = 0;
+
+        /// <summary>
+        /// カーソルのスクリーン座標を取得する。
+        /// </summary>
+        /// <returns>現在のスクリーン座標。</returns>
+        [[nodiscard]] virtual Point GetCursorScreenPosition() const = 0;
+    };
+}

--- a/Platform/Source/IWindow.h
+++ b/Platform/Source/IWindow.h
@@ -1,0 +1,61 @@
+#pragma once
+
+#include "PlatformTypes.h"
+
+#include <cstdint>
+#include <string>
+
+namespace Xelqoria::Platform
+{
+    /// <summary>
+    /// OS 固有のウィンドウ生成と基本操作を抽象化する。
+    /// </summary>
+    class IWindow
+    {
+    public:
+        virtual ~IWindow() = default;
+
+        /// <summary>
+        /// 指定サイズとタイトルでウィンドウを作成する。
+        /// </summary>
+        /// <param name="title">ウィンドウタイトル。</param>
+        /// <param name="clientWidth">クライアント領域の幅。</param>
+        /// <param name="clientHeight">クライアント領域の高さ。</param>
+        /// <returns>作成に成功した場合は true。</returns>
+        virtual bool Create(const std::wstring& title, std::uint32_t clientWidth, std::uint32_t clientHeight) = 0;
+
+        /// <summary>
+        /// ウィンドウを表示する。
+        /// </summary>
+        virtual void Show() = 0;
+
+        /// <summary>
+        /// ウィンドウを閉じる。
+        /// </summary>
+        virtual void Close() = 0;
+
+        /// <summary>
+        /// ウィンドウが有効かを取得する。
+        /// </summary>
+        /// <returns>有効な場合は true。</returns>
+        [[nodiscard]] virtual bool IsOpen() const = 0;
+
+        /// <summary>
+        /// OS 固有のウィンドウハンドルを取得する。
+        /// </summary>
+        /// <returns>不透明なネイティブウィンドウハンドル。</returns>
+        [[nodiscard]] virtual NativeWindowHandle GetNativeHandle() const = 0;
+
+        /// <summary>
+        /// クライアント領域の幅を取得する。
+        /// </summary>
+        /// <returns>クライアント領域の幅。</returns>
+        [[nodiscard]] virtual std::uint32_t GetClientWidth() const = 0;
+
+        /// <summary>
+        /// クライアント領域の高さを取得する。
+        /// </summary>
+        /// <returns>クライアント領域の高さ。</returns>
+        [[nodiscard]] virtual std::uint32_t GetClientHeight() const = 0;
+    };
+}

--- a/Platform/Source/PlatformAnchor.cpp
+++ b/Platform/Source/PlatformAnchor.cpp
@@ -1,0 +1,17 @@
+#include "IApplication.h"
+#include "IClipboard.h"
+#include "ICursor.h"
+#include "IEventLoop.h"
+#include "IFileDialog.h"
+#include "IInput.h"
+#include "IWindow.h"
+
+namespace Xelqoria::Platform
+{
+    /// <summary>
+    /// ヘッダーのみの抽象プロジェクトにリンク対象の翻訳単位を用意する。
+    /// </summary>
+    void PlatformAnchor()
+    {
+    }
+}

--- a/Platform/Source/PlatformTypes.h
+++ b/Platform/Source/PlatformTypes.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include <cstdint>
+
+namespace Xelqoria::Platform
+{
+    /// <summary>
+    /// OS 固有のウィンドウハンドルを保持する不透明な値を表す。
+    /// </summary>
+    using NativeWindowHandle = void*;
+
+    /// <summary>
+    /// OS 固有のアプリケーションインスタンスハンドルを保持する不透明な値を表す。
+    /// </summary>
+    using NativeApplicationHandle = void*;
+
+    /// <summary>
+    /// 2 次元の整数座標を表す。
+    /// </summary>
+    struct Point
+    {
+        std::int32_t x = 0;
+        std::int32_t y = 0;
+    };
+}

--- a/Platform/Xelqoria.Platform.vcxproj
+++ b/Platform/Xelqoria.Platform.vcxproj
@@ -1,0 +1,138 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="Source\PlatformAnchor.cpp" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="Source\IApplication.h" />
+    <ClInclude Include="Source\IClipboard.h" />
+    <ClInclude Include="Source\ICursor.h" />
+    <ClInclude Include="Source\IEventLoop.h" />
+    <ClInclude Include="Source\IFileDialog.h" />
+    <ClInclude Include="Source\IInput.h" />
+    <ClInclude Include="Source\IWindow.h" />
+    <ClInclude Include="Source\PlatformTypes.h" />
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <VCProjectVersion>18.0</VCProjectVersion>
+    <Keyword>Win32Proj</Keyword>
+    <ProjectGuid>{FBC1E45E-2F7B-4E99-B813-916509583283}</ProjectGuid>
+    <RootNamespace>XelqoriaPlatform</RootNamespace>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v145</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v145</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v145</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v145</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings" />
+  <ImportGroup Label="Shared" />
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup>
+    <OutDir>$(SolutionDir)artifacts\$(Platform)\$(Configuration)\</OutDir>
+    <IntDir>$(SolutionDir)build\$(ProjectName)\$(Platform)\$(Configuration)\</IntDir>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>WIN32;_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+      <LanguageStandard>stdcpp20</LanguageStandard>
+      <AdditionalIncludeDirectories>$(ProjectDir)Source;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalOptions>/utf-8 %(AdditionalOptions)</AdditionalOptions>
+    </ClCompile>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>WIN32;NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+      <LanguageStandard>stdcpp20</LanguageStandard>
+      <AdditionalIncludeDirectories>$(ProjectDir)Source;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalOptions>/utf-8 %(AdditionalOptions)</AdditionalOptions>
+    </ClCompile>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+      <LanguageStandard>stdcpp20</LanguageStandard>
+      <AdditionalIncludeDirectories>$(ProjectDir)Source;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalOptions>/utf-8 %(AdditionalOptions)</AdditionalOptions>
+    </ClCompile>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+      <LanguageStandard>stdcpp20</LanguageStandard>
+      <AdditionalIncludeDirectories>$(ProjectDir)Source;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalOptions>/utf-8 %(AdditionalOptions)</AdditionalOptions>
+    </ClCompile>
+  </ItemDefinitionGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets" />
+</Project>

--- a/Platform/Xelqoria.Platform.vcxproj.filters
+++ b/Platform/Xelqoria.Platform.vcxproj.filters
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Filter Include="Source">
+      <UniqueIdentifier>{7F9A39CC-2048-4A29-86DF-CF5B1F27445F}</UniqueIdentifier>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="Source\PlatformAnchor.cpp">
+      <Filter>Source</Filter>
+    </ClCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="Source\IApplication.h">
+      <Filter>Source</Filter>
+    </ClInclude>
+    <ClInclude Include="Source\IClipboard.h">
+      <Filter>Source</Filter>
+    </ClInclude>
+    <ClInclude Include="Source\ICursor.h">
+      <Filter>Source</Filter>
+    </ClInclude>
+    <ClInclude Include="Source\IEventLoop.h">
+      <Filter>Source</Filter>
+    </ClInclude>
+    <ClInclude Include="Source\IFileDialog.h">
+      <Filter>Source</Filter>
+    </ClInclude>
+    <ClInclude Include="Source\IInput.h">
+      <Filter>Source</Filter>
+    </ClInclude>
+    <ClInclude Include="Source\IWindow.h">
+      <Filter>Source</Filter>
+    </ClInclude>
+    <ClInclude Include="Source\PlatformTypes.h">
+      <Filter>Source</Filter>
+    </ClInclude>
+  </ItemGroup>
+</Project>

--- a/Xelqoria.slnx
+++ b/Xelqoria.slnx
@@ -122,6 +122,14 @@
   <Project Path="Editor/Xelqoria.Editor.vcxproj" Id="2a2fc413-07f6-41d7-ab02-079ce112c042" />
   <Project Path="Game/Xelqoria.Game.vcxproj" Id="b43e8e97-59ef-4caa-8a27-bd9192d8833a" />
   <Project Path="Graphics/Xelqoria.Graphics.vcxproj" Id="7693792a-4ad4-445a-98f7-b90d6989a837" />
+  <Project Path="Platform.Mac/Xelqoria.Platform.Mac.vcxproj" Id="2bbdb336-af96-404d-aab6-42c1f36ca1a3">
+    <Configuration Solution="Debug|x64" Project="Debug|x64|NoBuild" />
+    <Configuration Solution="Debug|x86" Project="Debug|Win32|NoBuild" />
+    <Configuration Solution="Release|x64" Project="Release|x64|NoBuild" />
+    <Configuration Solution="Release|x86" Project="Release|Win32|NoBuild" />
+  </Project>
+  <Project Path="Platform.Win32/Xelqoria.Platform.Win32.vcxproj" Id="e121a6f2-effe-44e6-8123-02cced1196fc" />
+  <Project Path="Platform/Xelqoria.Platform.vcxproj" Id="fbc1e45e-2f7b-4e99-b813-916509583283" />
   <Project Path="RHI/Xelqoria.RHI.vcxproj" Id="158b81fc-b108-4237-8a37-eb8c6ef29392" />
   <Project Path="Xelqoria.Math/Xelqoria.Math.vcxproj" Id="9143e43a-0447-43e1-9fe4-9c3edec98212" />
 </Solution>


### PR DESCRIPTION
## Summary\n- Add Xelqoria.Platform with OS abstraction interfaces.\n- Add Xelqoria.Platform.Win32 and Xelqoria.Platform.Mac project stubs.\n- Keep Xelqoria.Platform.Mac out of Windows builds via solution NoBuild mapping and Windows no-op project configuration.\n\nParent: #198\nChild: #199\n\n## Verification\n- MSBuild Xelqoria.slnx Debug x64\n- tools/wsl/test.sh --no-build -c Debug -p x64