### PR TITLE
Move window and input through platform layer

### DIFF
--- a/App/Source/Application.cpp
+++ b/App/Source/Application.cpp
@@ -10,6 +10,7 @@
 #include "SpriteRenderer.h"
 #include "Texture2D.h"
 #include "GraphicsAPI.h"
+#include "Win32PlatformFactory.h"
 
 namespace Xelqoria::App
 {
@@ -69,7 +70,11 @@ namespace Xelqoria::App
         std::wstring title = L"Xelqoria - ";
         title += RHI::GraphicsAPIToString(api);
 
-        if (!m_window.Create(m_hInstance, title.c_str(), 1280, 720))
+        m_window.SetPlatformWindow(
+            Platform::Win32::CreateWin32Window(m_hInstance),
+            Platform::Win32::CreateWin32EventLoop());
+
+        if (!m_window.Create(title.c_str(), 1280, 720))
         {
             return false;
         }

--- a/App/Xelqoria.App.vcxproj
+++ b/App/Xelqoria.App.vcxproj
@@ -40,6 +40,9 @@
     <ProjectReference Include="..\Core\Xelqoria.Core.vcxproj">
       <Project>{79E8E826-7407-4766-B731-675CB84F6552}</Project>
     </ProjectReference>
+    <ProjectReference Include="..\Platform.Win32\Xelqoria.Platform.Win32.vcxproj">
+      <Project>{E121A6F2-EFFE-44E6-8123-02CCED1196FC}</Project>
+    </ProjectReference>
     <ProjectReference Include="..\RHI\Xelqoria.RHI.vcxproj">
       <Project>{158B81FC-B108-4237-8A37-EB8C6EF29392}</Project>
     </ProjectReference>
@@ -115,7 +118,7 @@
       <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <LanguageStandard>stdcpp20</LanguageStandard>
-      <AdditionalIncludeDirectories>$(ProjectDir)Source;$(RepoRootDir)Core\Source;$(RepoRootDir)Game\Source;$(RepoRootDir)Graphics\Source;$(RepoRootDir)RHI\Source;$(RepoRootDir)Xelqoria.Math\Source;$(RepoRootDir)Backends.D3D11\Source;$(RepoRootDir)Backends.D3D12\Source;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(ProjectDir)Source;$(RepoRootDir)Core\Source;$(RepoRootDir)Platform\Source;$(RepoRootDir)Platform.Win32\Source;$(RepoRootDir)Game\Source;$(RepoRootDir)Graphics\Source;$(RepoRootDir)RHI\Source;$(RepoRootDir)Xelqoria.Math\Source;$(RepoRootDir)Backends.D3D11\Source;$(RepoRootDir)Backends.D3D12\Source;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <AdditionalOptions>/utf-8 %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
@@ -133,7 +136,7 @@
       <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <LanguageStandard>stdcpp20</LanguageStandard>
-      <AdditionalIncludeDirectories>$(ProjectDir)Source;$(RepoRootDir)Core\Source;$(RepoRootDir)Game\Source;$(RepoRootDir)Graphics\Source;$(RepoRootDir)RHI\Source;$(RepoRootDir)Xelqoria.Math\Source;$(RepoRootDir)Backends.D3D11\Source;$(RepoRootDir)Backends.D3D12\Source;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(ProjectDir)Source;$(RepoRootDir)Core\Source;$(RepoRootDir)Platform\Source;$(RepoRootDir)Platform.Win32\Source;$(RepoRootDir)Game\Source;$(RepoRootDir)Graphics\Source;$(RepoRootDir)RHI\Source;$(RepoRootDir)Xelqoria.Math\Source;$(RepoRootDir)Backends.D3D11\Source;$(RepoRootDir)Backends.D3D12\Source;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <AdditionalOptions>/utf-8 %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
@@ -149,7 +152,7 @@
       <PreprocessorDefinitions>_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <LanguageStandard>stdcpp20</LanguageStandard>
-      <AdditionalIncludeDirectories>$(ProjectDir)Source;$(RepoRootDir)Core\Source;$(RepoRootDir)Game\Source;$(RepoRootDir)Graphics\Source;$(RepoRootDir)RHI\Source;$(RepoRootDir)Xelqoria.Math\Source;$(RepoRootDir)Backends.D3D11\Source;$(RepoRootDir)Backends.D3D12\Source;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(ProjectDir)Source;$(RepoRootDir)Core\Source;$(RepoRootDir)Platform\Source;$(RepoRootDir)Platform.Win32\Source;$(RepoRootDir)Game\Source;$(RepoRootDir)Graphics\Source;$(RepoRootDir)RHI\Source;$(RepoRootDir)Xelqoria.Math\Source;$(RepoRootDir)Backends.D3D11\Source;$(RepoRootDir)Backends.D3D12\Source;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <AdditionalOptions>/utf-8 %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
@@ -167,7 +170,7 @@
       <PreprocessorDefinitions>NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <LanguageStandard>stdcpp20</LanguageStandard>
-      <AdditionalIncludeDirectories>$(ProjectDir)Source;$(RepoRootDir)Core\Source;$(RepoRootDir)Game\Source;$(RepoRootDir)Graphics\Source;$(RepoRootDir)RHI\Source;$(RepoRootDir)Xelqoria.Math\Source;$(RepoRootDir)Backends.D3D11\Source;$(RepoRootDir)Backends.D3D12\Source;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(ProjectDir)Source;$(RepoRootDir)Core\Source;$(RepoRootDir)Platform\Source;$(RepoRootDir)Platform.Win32\Source;$(RepoRootDir)Game\Source;$(RepoRootDir)Graphics\Source;$(RepoRootDir)RHI\Source;$(RepoRootDir)Xelqoria.Math\Source;$(RepoRootDir)Backends.D3D11\Source;$(RepoRootDir)Backends.D3D12\Source;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <AdditionalOptions>/utf-8 %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>

--- a/Core/Source/InputSystem.cpp
+++ b/Core/Source/InputSystem.cpp
@@ -1,17 +1,25 @@
 #include "InputSystem.h"
 
 #include <utility>
-#include <Windows.h>
-#include <array>
 
 namespace Xelqoria::Core
 {
+    namespace
+    {
+        constexpr std::uint32_t LeftMouseButtonCode = 0x01;
+
+        [[nodiscard]] bool IsValidInputCode(int keyCode)
+        {
+            return 0 <= keyCode && keyCode < static_cast<int>(InputSnapshot::KeyStateCount);
+        }
+    }
+
     InputSnapshot::InputSnapshot(
         const std::array<bool, KeyStateCount>& keyDownStates,
         const std::array<bool, KeyStateCount>& previousKeyDownStates,
         bool isLeftMouseButtonDown,
         bool wasLeftMouseButtonDown,
-        POINT cursorScreenPoint,
+        Platform::Point cursorScreenPoint,
         int mouseWheelDelta)
         : m_keyDownStates(keyDownStates)
         , m_previousKeyDownStates(previousKeyDownStates)
@@ -22,35 +30,35 @@ namespace Xelqoria::Core
     {
     }
 
-    bool InputSnapshot::IsKeyDown(int virtualKeyCode) const
+    bool InputSnapshot::IsKeyDown(int keyCode) const
     {
-        if (false == IsValidVirtualKeyCode(virtualKeyCode))
+        if (false == IsValidKeyCode(keyCode))
         {
             return false;
         }
 
-        return m_keyDownStates[static_cast<std::size_t>(virtualKeyCode)];
+        return m_keyDownStates[static_cast<std::size_t>(keyCode)];
     }
 
-    bool InputSnapshot::WasKeyPressed(int virtualKeyCode) const
+    bool InputSnapshot::WasKeyPressed(int keyCode) const
     {
-        if (false == IsValidVirtualKeyCode(virtualKeyCode))
+        if (false == IsValidKeyCode(keyCode))
         {
             return false;
         }
 
-        const std::size_t stateIndex = static_cast<std::size_t>(virtualKeyCode);
+        const std::size_t stateIndex = static_cast<std::size_t>(keyCode);
         return m_keyDownStates[stateIndex] && false == m_previousKeyDownStates[stateIndex];
     }
 
-    bool InputSnapshot::WasKeyReleased(int virtualKeyCode) const
+    bool InputSnapshot::WasKeyReleased(int keyCode) const
     {
-        if (false == IsValidVirtualKeyCode(virtualKeyCode))
+        if (false == IsValidKeyCode(keyCode))
         {
             return false;
         }
 
-        const std::size_t stateIndex = static_cast<std::size_t>(virtualKeyCode);
+        const std::size_t stateIndex = static_cast<std::size_t>(keyCode);
         return false == m_keyDownStates[stateIndex] && true == m_previousKeyDownStates[stateIndex];
     }
 
@@ -84,7 +92,7 @@ namespace Xelqoria::Core
         return false;
     }
 
-    POINT InputSnapshot::GetCursorScreenPoint() const
+    Platform::Point InputSnapshot::GetCursorScreenPoint() const
     {
         return m_cursorScreenPoint;
     }
@@ -94,28 +102,32 @@ namespace Xelqoria::Core
         return m_mouseWheelDelta;
     }
 
-    bool InputSnapshot::IsValidVirtualKeyCode(int virtualKeyCode)
+    bool InputSnapshot::IsValidKeyCode(int keyCode)
     {
-        return 0 <= virtualKeyCode && virtualKeyCode < static_cast<int>(KeyStateCount);
+        return 0 <= keyCode && keyCode < static_cast<int>(KeyStateCount);
     }
 
     InputSystem::InputSystem()
         : InputSystem(
-            [](int virtualKeyCode)
+            [](int)
             {
-                return 0 != (::GetAsyncKeyState(virtualKeyCode) & 0x8000);
+                return false;
             },
             []
             {
-                POINT cursorScreenPoint{};
-                ::GetCursorPos(&cursorScreenPoint);
-                return cursorScreenPoint;
+                return Platform::Point{};
             },
             []
             {
                 return 0;
             })
     {
+    }
+
+    InputSystem::InputSystem(std::unique_ptr<Platform::IInput> input)
+        : InputSystem()
+    {
+        SetPlatformInput(std::move(input));
     }
 
     InputSystem::InputSystem(KeyStateReader keyStateReader, CursorPositionReader cursorPositionReader)
@@ -133,6 +145,41 @@ namespace Xelqoria::Core
     {
     }
 
+    void InputSystem::SetPlatformInput(std::unique_ptr<Platform::IInput> input)
+    {
+        m_input = std::move(input);
+        m_keyStateReader =
+            [this](int keyCode)
+            {
+                if (nullptr == m_input || false == IsValidInputCode(keyCode))
+                {
+                    return false;
+                }
+
+                return m_input->IsKeyDown(static_cast<std::uint32_t>(keyCode));
+            };
+        m_cursorPositionReader =
+            [this]()
+            {
+                if (nullptr == m_input)
+                {
+                    return Platform::Point{};
+                }
+
+                return m_input->GetCursorScreenPosition();
+            };
+        m_mouseWheelDeltaReader =
+            [this]()
+            {
+                if (nullptr == m_input)
+                {
+                    return 0;
+                }
+
+                return m_input->GetMouseWheelDelta();
+            };
+    }
+
     void InputSystem::SetMouseWheelDeltaReader(MouseWheelDeltaReader mouseWheelDeltaReader)
     {
         m_mouseWheelDeltaReader = std::move(mouseWheelDeltaReader);
@@ -140,6 +187,11 @@ namespace Xelqoria::Core
 
     void InputSystem::Update()
     {
+        if (m_input)
+        {
+            m_input->Update();
+        }
+
         std::array<bool, InputSnapshot::KeyStateCount> keyDownStates{};
         std::array<bool, InputSnapshot::KeyStateCount> previousKeyDownStates{};
         for (std::size_t index = 0; index < keyDownStates.size(); ++index)
@@ -149,7 +201,7 @@ namespace Xelqoria::Core
         }
 
         const bool wasLeftMouseButtonDown = m_snapshot.IsMouseButtonDown(MouseButton::Left);
-        const bool isLeftMouseButtonDown = m_keyStateReader(VK_LBUTTON);
+        const bool isLeftMouseButtonDown = m_keyStateReader(static_cast<int>(LeftMouseButtonCode));
         m_snapshot = InputSnapshot(
             keyDownStates,
             previousKeyDownStates,

--- a/Core/Source/InputSystem.h
+++ b/Core/Source/InputSystem.h
@@ -1,8 +1,12 @@
 #pragma once
 
-#include <Windows.h>
+#include "IInput.h"
+#include "PlatformTypes.h"
+
 #include <array>
+#include <cstdint>
 #include <functional>
+#include <memory>
 
 namespace Xelqoria::Core
 {
@@ -41,29 +45,29 @@ namespace Xelqoria::Core
             const std::array<bool, KeyStateCount>& previousKeyDownStates,
             bool isLeftMouseButtonDown,
             bool wasLeftMouseButtonDown,
-            POINT cursorScreenPoint,
+            Platform::Point cursorScreenPoint,
             int mouseWheelDelta);
 
         /// <summary>
-        /// 指定した仮想キーが現在押下中かを取得する。
+        /// 指定したキーコードが現在押下中かを取得する。
         /// </summary>
-        /// <param name="virtualKeyCode">Win32 仮想キーコード。</param>
+        /// <param name="keyCode">入力実装が解釈するキーコード。</param>
         /// <returns>押下中の場合は true。</returns>
-        [[nodiscard]] bool IsKeyDown(int virtualKeyCode) const;
+        [[nodiscard]] bool IsKeyDown(int keyCode) const;
 
         /// <summary>
-        /// 指定した仮想キーが今フレームで押下されたかを取得する。
+        /// 指定したキーコードが今フレームで押下されたかを取得する。
         /// </summary>
-        /// <param name="virtualKeyCode">Win32 仮想キーコード。</param>
+        /// <param name="keyCode">入力実装が解釈するキーコード。</param>
         /// <returns>今フレームで押下された場合は true。</returns>
-        [[nodiscard]] bool WasKeyPressed(int virtualKeyCode) const;
+        [[nodiscard]] bool WasKeyPressed(int keyCode) const;
 
         /// <summary>
-        /// 指定した仮想キーが今フレームで解放されたかを取得する。
+        /// 指定したキーコードが今フレームで解放されたかを取得する。
         /// </summary>
-        /// <param name="virtualKeyCode">Win32 仮想キーコード。</param>
+        /// <param name="keyCode">入力実装が解釈するキーコード。</param>
         /// <returns>今フレームで解放された場合は true。</returns>
-        [[nodiscard]] bool WasKeyReleased(int virtualKeyCode) const;
+        [[nodiscard]] bool WasKeyReleased(int keyCode) const;
 
         /// <summary>
         /// 指定したマウスボタンが現在押下中かを取得する。
@@ -90,7 +94,7 @@ namespace Xelqoria::Core
         /// 現在のカーソル位置をスクリーン座標で取得する。
         /// </summary>
         /// <returns>スクリーン座標のカーソル位置。</returns>
-        [[nodiscard]] POINT GetCursorScreenPoint() const;
+        [[nodiscard]] Platform::Point GetCursorScreenPoint() const;
 
         /// <summary>
         /// 現在フレームのマウスホイール差分を取得する。
@@ -99,31 +103,31 @@ namespace Xelqoria::Core
         [[nodiscard]] int GetMouseWheelDelta() const;
 
     private:
-        [[nodiscard]] static bool IsValidVirtualKeyCode(int virtualKeyCode);
+        [[nodiscard]] static bool IsValidKeyCode(int keyCode);
 
         std::array<bool, KeyStateCount> m_keyDownStates{};
         std::array<bool, KeyStateCount> m_previousKeyDownStates{};
         bool m_isLeftMouseButtonDown = false;
         bool m_wasLeftMouseButtonDown = false;
-        POINT m_cursorScreenPoint{};
+        Platform::Point m_cursorScreenPoint{};
         int m_mouseWheelDelta = 0;
     };
 
     /// <summary>
-    /// Win32 入力を毎フレーム収集して InputSnapshot として保持する。
+    /// Platform 入力を毎フレーム収集して InputSnapshot として保持する。
     /// </summary>
     class InputSystem
     {
     public:
         /// <summary>
-        /// 仮想キーの押下状態を読み取る関数型を表す。
+        /// キーの押下状態を読み取る関数型を表す。
         /// </summary>
         using KeyStateReader = std::function<bool(int)>;
 
         /// <summary>
         /// カーソル位置を読み取る関数型を表す。
         /// </summary>
-        using CursorPositionReader = std::function<POINT()>;
+        using CursorPositionReader = std::function<Platform::Point()>;
 
         /// <summary>
         /// マウスホイール差分を読み取る関数型を表す。
@@ -131,27 +135,39 @@ namespace Xelqoria::Core
         using MouseWheelDeltaReader = std::function<int()>;
 
         /// <summary>
-        /// Win32 API を入力元として InputSystem を生成する。
+        /// 入力元未設定の InputSystem を生成する。
         /// </summary>
         InputSystem();
 
         /// <summary>
+        /// Platform 入力を使って InputSystem を生成する。
+        /// </summary>
+        /// <param name="input">OS 固有の入力実装。</param>
+        explicit InputSystem(std::unique_ptr<Platform::IInput> input);
+
+        /// <summary>
         /// 任意の入力読み取り関数を使って InputSystem を生成する。
         /// </summary>
-        /// <param name="keyStateReader">仮想キー押下状態の読み取り関数。</param>
+        /// <param name="keyStateReader">キー押下状態の読み取り関数。</param>
         /// <param name="cursorPositionReader">カーソル位置の読み取り関数。</param>
         InputSystem(KeyStateReader keyStateReader, CursorPositionReader cursorPositionReader);
 
         /// <summary>
         /// 任意の入力読み取り関数を使って InputSystem を生成する。
         /// </summary>
-        /// <param name="keyStateReader">仮想キー押下状態の読み取り関数。</param>
+        /// <param name="keyStateReader">キー押下状態の読み取り関数。</param>
         /// <param name="cursorPositionReader">カーソル位置の読み取り関数。</param>
         /// <param name="mouseWheelDeltaReader">マウスホイール差分の読み取り関数。</param>
         InputSystem(
             KeyStateReader keyStateReader,
             CursorPositionReader cursorPositionReader,
             MouseWheelDeltaReader mouseWheelDeltaReader);
+
+        /// <summary>
+        /// 使用する Platform 入力実装を設定する。
+        /// </summary>
+        /// <param name="input">OS 固有の入力実装。</param>
+        void SetPlatformInput(std::unique_ptr<Platform::IInput> input);
 
         /// <summary>
         /// マウスホイール差分を読み取る関数を設定する。
@@ -174,6 +190,7 @@ namespace Xelqoria::Core
         KeyStateReader m_keyStateReader{};
         CursorPositionReader m_cursorPositionReader{};
         MouseWheelDeltaReader m_mouseWheelDeltaReader{};
+        std::unique_ptr<Platform::IInput> m_input{};
         InputSnapshot m_snapshot{};
     };
 }

--- a/Core/Source/Window.cpp
+++ b/Core/Source/Window.cpp
@@ -1,258 +1,131 @@
 #include "Window.h"
-#include <Windows.h>
-#include <utility>
 
-#ifndef WM_DPICHANGED
-#define WM_DPICHANGED 0x02E0
-#endif
-#include <cstdint>
-#include <functional>
+#include <utility>
 
 namespace Xelqoria::Core
 {
-
-    Window::~Window()
+    Window::Window(std::unique_ptr<Platform::IWindow> window, std::unique_ptr<Platform::IEventLoop> eventLoop)
+        : m_window(std::move(window))
+        , m_eventLoop(std::move(eventLoop))
     {
-        if (m_hWnd)
-        {
-            DestroyWindow(m_hWnd);
-            m_hWnd = nullptr;
-        }
-
-        if (m_hInstance)
-        {
-            UnregisterClassW(m_className.c_str(), m_hInstance);
-        }
     }
 
-    bool Window::Create(HINSTANCE hInstance, const wchar_t* title, uint32_t clientWidth, uint32_t clientHeight)
+    Window::~Window() = default;
+
+    void Window::SetPlatformWindow(
+        std::unique_ptr<Platform::IWindow> window,
+        std::unique_ptr<Platform::IEventLoop> eventLoop)
     {
-        m_hInstance = hInstance;
-        m_title = title;
-        m_width = clientWidth;
-        m_height = clientHeight;
+        m_window = std::move(window);
+        m_eventLoop = std::move(eventLoop);
+    }
 
-        WNDCLASSW wc{};
-        wc.style = CS_HREDRAW | CS_VREDRAW;
-        wc.lpfnWndProc = &Window::StaticWndProc;
-        wc.hInstance = m_hInstance;
-        wc.hCursor = LoadCursor(nullptr, IDC_ARROW);
-        wc.hbrBackground = reinterpret_cast<HBRUSH>(COLOR_BTNFACE + 1);
-        wc.lpszClassName = m_className.c_str();
-
-        if (!RegisterClassW(&wc))
+    bool Window::Create(const wchar_t* title, uint32_t clientWidth, uint32_t clientHeight)
+    {
+        if (nullptr == m_window)
         {
             return false;
         }
 
-        const DWORD style = WS_OVERLAPPEDWINDOW;
-
-        RECT rc{ 0, 0, static_cast<LONG>(m_width), static_cast<LONG>(m_height )};
-        if(!AdjustWindowRect(&rc, style, FALSE))
-        {
-            UnregisterClassW(wc.lpszClassName, m_hInstance);
-            return false;
-        }
-
-        m_hWnd = CreateWindowW(
-            m_className.c_str(),
-            m_title.c_str(),
-            style,
-            CW_USEDEFAULT,
-            CW_USEDEFAULT,
-            rc.right - rc.left,
-            rc.bottom - rc.top,
-            nullptr, 
-            nullptr, 
-            m_hInstance, 
-            this
-        );
-
-        return m_hWnd != nullptr;
+        return m_window->Create(std::wstring(title), clientWidth, clientHeight);
     }
 
-    void Window::Show(int nCmdShow)
+    void Window::Show(int showCommand)
     {
-        ShowWindow(m_hWnd, nCmdShow);
-        SetForegroundWindow(m_hWnd);
-        SetFocus(m_hWnd);
+        (void)showCommand;
+        if (nullptr != m_window)
+        {
+            m_window->Show();
+        }
     }
 
     bool Window::PumpMessages()
     {
-        MSG msg{};
-        while (PeekMessage(&msg, nullptr, 0, 0, PM_REMOVE))
+        if (nullptr == m_eventLoop)
         {
-            if (msg.message == WM_QUIT)
-            {
-                return false;
-            }
-
-            TranslateMessage(&msg);
-            DispatchMessage(&msg);
+            return false;
         }
 
-        return true;
+        return m_eventLoop->PumpEvents();
     }
 
-    HWND Window::GetHwnd() const 
-    { 
-        return m_hWnd; 
+    Platform::NativeWindowHandle Window::GetHwnd() const
+    {
+        if (nullptr == m_window)
+        {
+            return nullptr;
+        }
+
+        return m_window->GetNativeHandle();
     }
 
     void Window::SetCommandHandler(std::function<void(unsigned)> handler)
     {
-        m_commandHandler = std::move(handler);
+        if (nullptr != m_window)
+        {
+            m_window->SetCommandHandler(std::move(handler));
+        }
     }
 
-    void Window::SetNotifyHandler(std::function<bool(LPARAM)> handler)
+    void Window::SetNotifyHandler(std::function<bool(Platform::NativeMessageParameter)> handler)
     {
-        m_notifyHandler = std::move(handler);
+        if (nullptr != m_window)
+        {
+            m_window->SetNotifyHandler(std::move(handler));
+        }
     }
 
-    void Window::SetDrawItemHandler(std::function<bool(LPARAM)> handler)
+    void Window::SetDrawItemHandler(std::function<bool(Platform::NativeMessageParameter)> handler)
     {
-        m_drawItemHandler = std::move(handler);
+        if (nullptr != m_window)
+        {
+            m_window->SetDrawItemHandler(std::move(handler));
+        }
     }
 
     void Window::SetCloseRequestHandler(std::function<bool()> handler)
     {
-        m_closeRequestHandler = std::move(handler);
+        if (nullptr != m_window)
+        {
+            m_window->SetCloseRequestHandler(std::move(handler));
+        }
     }
 
     void Window::SetResizeHandler(std::function<void(uint32_t, uint32_t)> handler)
     {
-        m_resizeHandler = std::move(handler);
+        if (nullptr != m_window)
+        {
+            m_window->SetResizeHandler(std::move(handler));
+        }
     }
 
-    uint32_t Window::GetWidth() const 
-    { 
-        return m_width;
+    uint32_t Window::GetWidth() const
+    {
+        if (nullptr == m_window)
+        {
+            return 0;
+        }
+
+        return m_window->GetClientWidth();
     }
-    uint32_t Window::GetHeight() const 
-    { 
-        return m_height; 
+
+    uint32_t Window::GetHeight() const
+    {
+        if (nullptr == m_window)
+        {
+            return 0;
+        }
+
+        return m_window->GetClientHeight();
     }
 
     int Window::ConsumeMouseWheelDelta()
     {
-        const int mouseWheelDelta = m_pendingMouseWheelDelta;
-        m_pendingMouseWheelDelta = 0;
-        return mouseWheelDelta;
+        if (nullptr == m_window)
+        {
+            return 0;
+        }
+
+        return m_window->ConsumeMouseWheelDelta();
     }
-
-    LRESULT CALLBACK Window::StaticWndProc(HWND hWnd, UINT msg, WPARAM wp, LPARAM lp) 
-    {
-        Window* self = nullptr;
-    
-        if (msg == WM_NCCREATE) 
-        {
-            auto* cs = reinterpret_cast<CREATESTRUCTW*>(lp);
-            self = reinterpret_cast<Window*>(cs->lpCreateParams);
-            SetWindowLongPtrW(hWnd, GWLP_USERDATA, reinterpret_cast<LONG_PTR>(self));
-        }
-        else
-        {
-            self = reinterpret_cast<Window*>(GetWindowLongPtrW(hWnd, GWLP_USERDATA));
-        }
-
-        if (self)
-        {
-            return self->WndProc(hWnd, msg, wp, lp);
-        }
-
-        return DefWindowProcW(hWnd, msg, wp, lp);
-    }
-
-    LRESULT Window::WndProc(HWND hWnd, UINT msg, WPARAM wp, LPARAM lp)
-    {
-        switch (msg) 
-        {
-        case WM_COMMAND:
-            if (m_commandHandler)
-            {
-                m_commandHandler(LOWORD(wp));
-                return 0;
-            }
-            break;
-
-        case WM_NOTIFY:
-            if (m_notifyHandler && m_notifyHandler(lp))
-            {
-                return 0;
-            }
-            break;
-
-        case WM_DRAWITEM:
-            if (m_drawItemHandler && m_drawItemHandler(lp))
-            {
-                return TRUE;
-            }
-            break;
-
-        case WM_CLOSE:
-            if (m_closeRequestHandler && false == m_closeRequestHandler())
-            {
-                return 0;
-            }
-
-            DestroyWindow(hWnd);
-            return 0;
-        
-        case WM_DESTROY:
-            PostQuitMessage(0);
-            return 0;
-
-        case WM_SIZE:
-            if (wp != SIZE_MINIMIZED)
-            {
-                m_width = static_cast<uint32_t>(LOWORD(lp));
-                m_height = static_cast<uint32_t>(HIWORD(lp));
-                if (m_resizeHandler)
-                {
-                    m_resizeHandler(m_width, m_height);
-                }
-
-                InvalidateRect(hWnd, nullptr, TRUE);
-            }
-            return 0;
-
-        case WM_DPICHANGED:
-            if (0 != lp)
-            {
-                const RECT* suggestedRect = reinterpret_cast<RECT*>(lp);
-                SetWindowPos(
-                    hWnd,
-                    nullptr,
-                    suggestedRect->left,
-                    suggestedRect->top,
-                    suggestedRect->right - suggestedRect->left,
-                    suggestedRect->bottom - suggestedRect->top,
-                    SWP_NOZORDER | SWP_NOACTIVATE);
-            }
-
-            InvalidateRect(hWnd, nullptr, TRUE);
-            return 0;
-
-        case WM_MOUSEWHEEL:
-            m_pendingMouseWheelDelta += GET_WHEEL_DELTA_WPARAM(wp);
-            return 0;
-
-        case WM_KEYDOWN:
-            if (wp == VK_ESCAPE) 
-            {
-                if (m_closeRequestHandler && false == m_closeRequestHandler())
-                {
-                    return 0;
-                }
-
-                DestroyWindow(hWnd);
-                return 0;
-            }
-            break;
-        }
-
-        return DefWindowProcW(hWnd, msg, wp, lp);
-    }
-
-} // namespace Xelqoria::Core
+}

--- a/Core/Source/Window.h
+++ b/Core/Source/Window.h
@@ -1,21 +1,37 @@
 #pragma once
-#include <Windows.h>
+
+#include "IEventLoop.h"
+#include "IWindow.h"
+#include "PlatformTypes.h"
+
 #include <cstdint>
 #include <functional>
+#include <memory>
 #include <string>
 
 namespace Xelqoria::Core
 {
 	/// <summary>
-	/// Win32 API を使用してアプリケーションウィンドウを管理する。
+	/// Platform のウィンドウ実装を通じてアプリケーションウィンドウを管理する。
 	/// </summary>
 	class Window
 	{
 	public:
-		/// デフォルトコンストラクタ
+		/// <summary>
+		/// 空の Window を生成する。使用前に SetPlatformWindow を呼び出す必要がある。
+		/// </summary>
 		Window() = default;
 
-		/// ウィンドウリソースを解放する
+		/// <summary>
+		/// Platform 実装を受け取って Window を生成する。
+		/// </summary>
+		/// <param name="window">OS 固有のウィンドウ実装。</param>
+		/// <param name="eventLoop">OS 固有のイベントループ実装。</param>
+		Window(std::unique_ptr<Platform::IWindow> window, std::unique_ptr<Platform::IEventLoop> eventLoop);
+
+		/// <summary>
+		/// ウィンドウリソースを解放する。
+		/// </summary>
 		~Window();
 
 		Window(const Window&) = delete;
@@ -24,47 +40,56 @@ namespace Xelqoria::Core
 		Window& operator=(Window&&) = delete;
 
 		/// <summary>
-		/// 指定サイズとタイトルで Win32 ウィンドウを作成する。
+		/// 使用する Platform ウィンドウ実装を設定する。
 		/// </summary>
-		/// <param name="hInstance">アプリケーションインスタンスハンドル。</param>
+		/// <param name="window">OS 固有のウィンドウ実装。</param>
+		/// <param name="eventLoop">OS 固有のイベントループ実装。</param>
+		void SetPlatformWindow(std::unique_ptr<Platform::IWindow> window, std::unique_ptr<Platform::IEventLoop> eventLoop);
+
+		/// <summary>
+		/// 指定サイズとタイトルでウィンドウを作成する。
+		/// </summary>
 		/// <param name="title">ウィンドウタイトル。</param>
 		/// <param name="clientWidth">クライアント領域の幅。</param>
 		/// <param name="clientHeight">クライアント領域の高さ。</param>
 		/// <returns>作成に成功した場合は true。</returns>
-		bool Create(HINSTANCE hInstance, const wchar_t* title, uint32_t clientWidth, uint32_t clientHeight);
+		bool Create(const wchar_t* title, uint32_t clientWidth, uint32_t clientHeight);
 
 		/// <summary>
 		/// ウィンドウを表示する。
 		/// </summary>
-		/// <param name="nCmdShow">表示方法（SW_SHOW など）。</param>
-		void Show(int nCmdShow = SW_SHOW);
+		/// <param name="showCommand">互換性のために受け取る表示指定。Platform 実装が表示方法を決定する。</param>
+		void Show(int showCommand = 1);
 
 		/// <summary>
-		/// Win32 メッセージキューからメッセージを取得して処理する。
+		/// Platform のイベントキューからイベントを取得して処理する。
 		/// </summary>
 		/// <returns>アプリケーション終了要求があった場合は false。</returns>
 		bool PumpMessages();
 
-		/// ウィンドウハンドルを取得する
-		[[nodiscard]] HWND GetHwnd() const;
+		/// <summary>
+		/// OS 固有のウィンドウハンドルを取得する。
+		/// </summary>
+		/// <returns>不透明なネイティブウィンドウハンドル。</returns>
+		[[nodiscard]] Platform::NativeWindowHandle GetHwnd() const;
 
 		/// <summary>
-		/// WM_COMMAND を受け取るハンドラを設定する。
+		/// コマンド通知を受け取るハンドラを設定する。
 		/// </summary>
 		/// <param name="handler">コマンド ID を受け取るハンドラ。</param>
 		void SetCommandHandler(std::function<void(unsigned)> handler);
 
 		/// <summary>
-		/// WM_NOTIFY を受け取るハンドラを設定する。
+		/// OS 固有の通知メッセージを受け取るハンドラを設定する。
 		/// </summary>
-		/// <param name="handler">通知 LPARAM を処理し、消費した場合は true を返すハンドラ。</param>
-		void SetNotifyHandler(std::function<bool(LPARAM)> handler);
+		/// <param name="handler">通知メッセージ引数を処理し、消費した場合は true を返すハンドラ。</param>
+		void SetNotifyHandler(std::function<bool(Platform::NativeMessageParameter)> handler);
 
 		/// <summary>
-		/// WM_DRAWITEM を受け取るハンドラを設定する。
+		/// OS 固有のオーナー描画メッセージを受け取るハンドラを設定する。
 		/// </summary>
-		/// <param name="handler">DRAWITEMSTRUCT LPARAM を処理し、消費した場合は true を返すハンドラ。</param>
-		void SetDrawItemHandler(std::function<bool(LPARAM)> handler);
+		/// <param name="handler">描画メッセージ引数を処理し、消費した場合は true を返すハンドラ。</param>
+		void SetDrawItemHandler(std::function<bool(Platform::NativeMessageParameter)> handler);
 
 		/// <summary>
 		/// ウィンドウを閉じる前に呼ばれるハンドラを設定する。
@@ -78,10 +103,16 @@ namespace Xelqoria::Core
 		/// <param name="handler">新しいクライアント領域の幅と高さを受け取るハンドラ。</param>
 		void SetResizeHandler(std::function<void(uint32_t, uint32_t)> handler);
 
-		/// クライアント領域の幅を取得する
+		/// <summary>
+		/// クライアント領域の幅を取得する。
+		/// </summary>
+		/// <returns>クライアント領域の幅。</returns>
 		[[nodiscard]] uint32_t GetWidth() const;
 
-		/// クライアント領域の高さを取得する
+		/// <summary>
+		/// クライアント領域の高さを取得する。
+		/// </summary>
+		/// <returns>クライアント領域の高さ。</returns>
 		[[nodiscard]] uint32_t GetHeight() const;
 
 		/// <summary>
@@ -91,30 +122,7 @@ namespace Xelqoria::Core
 		[[nodiscard]] int ConsumeMouseWheelDelta();
 
 	private:
-		/// <summary>
-		/// Win32 API から呼び出される静的ウィンドウプロシージャ。
-		/// 実際の処理はインスタンスメンバ関数 WndProc に委譲する。
-		/// </summary>
-		static LRESULT CALLBACK StaticWndProc(HWND hWnd, UINT msg, WPARAM wp, LPARAM lp);
-
-		/// <summary>
-		/// 各ウィンドウインスタンスのメッセージ処理を行う。
-		/// </summary>
-		LRESULT WndProc(HWND hWnd, UINT msg, WPARAM wp, LPARAM lp);
-
-		HINSTANCE m_hInstance = nullptr;
-		HWND m_hWnd = nullptr;
-		std::function<void(unsigned)> m_commandHandler{};
-		std::function<bool(LPARAM)> m_notifyHandler{};
-		std::function<bool(LPARAM)> m_drawItemHandler{};
-		std::function<bool()> m_closeRequestHandler{};
-		std::function<void(uint32_t, uint32_t)> m_resizeHandler{};
-		int m_pendingMouseWheelDelta = 0;
-
-		std::wstring m_className = L"XelqoriaWindowClass";
-		std::wstring m_title = L"Xelqoria";
-
-		uint32_t m_width = 0;
-		uint32_t m_height = 0;
+		std::unique_ptr<Platform::IWindow> m_window{};
+		std::unique_ptr<Platform::IEventLoop> m_eventLoop{};
 	};
 }

--- a/Core/Xelqoria.Core.vcxproj
+++ b/Core/Xelqoria.Core.vcxproj
@@ -27,6 +27,11 @@
     <ClInclude Include="Source\InputSystem.h" />
     <ClInclude Include="Source\Window.h" />
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Platform\Xelqoria.Platform.vcxproj">
+      <Project>{FBC1E45E-2F7B-4E99-B813-916509583283}</Project>
+    </ProjectReference>
+  </ItemGroup>
   <PropertyGroup Label="Globals">
     <VCProjectVersion>18.0</VCProjectVersion>
     <Keyword>Win32Proj</Keyword>
@@ -88,7 +93,7 @@
       <PreprocessorDefinitions>WIN32;_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <LanguageStandard>stdcpp20</LanguageStandard>
-      <AdditionalIncludeDirectories>$(ProjectDir)Source;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(ProjectDir)Source;$(RepoRootDir)Platform\Source;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <AdditionalOptions>/utf-8 %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
   </ItemDefinitionGroup>
@@ -101,7 +106,7 @@
       <PreprocessorDefinitions>WIN32;NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <LanguageStandard>stdcpp20</LanguageStandard>
-      <AdditionalIncludeDirectories>$(ProjectDir)Source;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(ProjectDir)Source;$(RepoRootDir)Platform\Source;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <AdditionalOptions>/utf-8 %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
   </ItemDefinitionGroup>
@@ -112,7 +117,7 @@
       <PreprocessorDefinitions>_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <LanguageStandard>stdcpp20</LanguageStandard>
-      <AdditionalIncludeDirectories>$(ProjectDir)Source;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(ProjectDir)Source;$(RepoRootDir)Platform\Source;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <AdditionalOptions>/utf-8 %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
   </ItemDefinitionGroup>
@@ -125,7 +130,7 @@
       <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <LanguageStandard>stdcpp20</LanguageStandard>
-      <AdditionalIncludeDirectories>$(ProjectDir)Source;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(ProjectDir)Source;$(RepoRootDir)Platform\Source;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <AdditionalOptions>/utf-8 %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
   </ItemDefinitionGroup>

--- a/Editor.UI/Source/EditorShell.cpp
+++ b/Editor.UI/Source/EditorShell.cpp
@@ -21,6 +21,11 @@ namespace Xelqoria::Editor
         constexpr const wchar_t* FloatingPanelWindowClassName = L"XelqoriaFloatingPanelWindow";
         constexpr ULONGLONG DockPanelDragDelayMilliseconds = 200;
 
+        [[nodiscard]] POINT ToWin32Point(Platform::Point point)
+        {
+            return POINT{ static_cast<LONG>(point.x), static_cast<LONG>(point.y) };
+        }
+
         /// <summary>
         /// Dock 先プレビューの青い配置範囲を描画する。
         /// </summary>
@@ -1649,7 +1654,7 @@ namespace Xelqoria::Editor
         }
 
         bool changed = false;
-        const POINT cursorScreenPoint = inputSnapshot.GetCursorScreenPoint();
+        const POINT cursorScreenPoint = ToWin32Point(inputSnapshot.GetCursorScreenPoint());
 
         if (inputSnapshot.WasKeyPressed('R') && inputSnapshot.IsKeyDown(VK_CONTROL))
         {

--- a/Editor.UI/Xelqoria.Editor.UI.vcxproj
+++ b/Editor.UI/Xelqoria.Editor.UI.vcxproj
@@ -28,6 +28,9 @@
     <ProjectReference Include="..\Core\Xelqoria.Core.vcxproj">
       <Project>{79E8E826-7407-4766-B731-675CB84F6552}</Project>
     </ProjectReference>
+    <ProjectReference Include="..\Platform\Xelqoria.Platform.vcxproj">
+      <Project>{FBC1E45E-2F7B-4E99-B813-916509583283}</Project>
+    </ProjectReference>
   </ItemGroup>
   <PropertyGroup Label="Globals">
     <VCProjectVersion>18.0</VCProjectVersion>
@@ -91,7 +94,7 @@
       <PreprocessorDefinitions>WIN32;_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <LanguageStandard>stdcpp20</LanguageStandard>
-      <AdditionalIncludeDirectories>$(ProjectDir)Source;$(RepoRootDir)Core\Source;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(ProjectDir)Source;$(RepoRootDir)Core\Source;$(RepoRootDir)Platform\Source;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <AdditionalOptions>/utf-8 %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
   </ItemDefinitionGroup>
@@ -104,7 +107,7 @@
       <PreprocessorDefinitions>WIN32;NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <LanguageStandard>stdcpp20</LanguageStandard>
-      <AdditionalIncludeDirectories>$(ProjectDir)Source;$(RepoRootDir)Core\Source;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(ProjectDir)Source;$(RepoRootDir)Core\Source;$(RepoRootDir)Platform\Source;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <AdditionalOptions>/utf-8 %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
   </ItemDefinitionGroup>
@@ -115,7 +118,7 @@
       <PreprocessorDefinitions>_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <LanguageStandard>stdcpp20</LanguageStandard>
-      <AdditionalIncludeDirectories>$(ProjectDir)Source;$(RepoRootDir)Core\Source;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(ProjectDir)Source;$(RepoRootDir)Core\Source;$(RepoRootDir)Platform\Source;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <AdditionalOptions>/utf-8 %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
   </ItemDefinitionGroup>
@@ -128,7 +131,7 @@
       <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <LanguageStandard>stdcpp20</LanguageStandard>
-      <AdditionalIncludeDirectories>$(ProjectDir)Source;$(RepoRootDir)Core\Source;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(ProjectDir)Source;$(RepoRootDir)Core\Source;$(RepoRootDir)Platform\Source;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <AdditionalOptions>/utf-8 %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
   </ItemDefinitionGroup>

--- a/Editor/Source/Application.cpp
+++ b/Editor/Source/Application.cpp
@@ -23,6 +23,7 @@
 #include "SceneEditingOperations.h"
 #include "SceneViewInteractionTypes.h"
 #include "ScriptAssetService.h"
+#include "Win32PlatformFactory.h"
 #include <Entity.h>
 #include <cstdint>
 
@@ -272,7 +273,12 @@ namespace Xelqoria::Editor
         constexpr auto clientHeight = 900u;
 
         const std::wstring title = L"Xelqoria Editor";
-        if (false == m_window.Create(m_hInstance, title.c_str(), clientWidth, clientHeight))
+        m_window.SetPlatformWindow(
+            Platform::Win32::CreateWin32Window(m_hInstance),
+            Platform::Win32::CreateWin32EventLoop());
+        m_inputSystem.SetPlatformInput(Platform::Win32::CreateWin32Input());
+
+        if (false == m_window.Create(title.c_str(), clientWidth, clientHeight))
         {
             return false;
         }
@@ -289,19 +295,19 @@ namespace Xelqoria::Editor
                 HandleProjectMenuCommand(commandId);
             });
         m_window.SetNotifyHandler(
-            [this](LPARAM notifyParameter)
+            [this](Platform::NativeMessageParameter notifyParameter)
             {
-                if (m_editorShell.HandleNotify(notifyParameter))
+                if (m_editorShell.HandleNotify(static_cast<LPARAM>(notifyParameter)))
                 {
                     return true;
                 }
 
-                return m_assetsPanelController.HandleNotify(notifyParameter);
+                return m_assetsPanelController.HandleNotify(static_cast<LPARAM>(notifyParameter));
             });
         m_window.SetDrawItemHandler(
-            [this](LPARAM drawItemParameter)
+            [this](Platform::NativeMessageParameter drawItemParameter)
             {
-                return m_logOutputPanelController.HandleDrawItem(drawItemParameter);
+                return m_logOutputPanelController.HandleDrawItem(static_cast<LPARAM>(drawItemParameter));
             });
         m_window.SetCloseRequestHandler(
             [this]()
@@ -348,7 +354,7 @@ namespace Xelqoria::Editor
         m_pauseResumePlayButton = m_editorShell.GetPauseResumePlayButton();
         m_endPlayButton = m_editorShell.GetEndPlayButton();
 
-        const bool sceneViewSizeChanged = m_editorShell.UpdateLayout(m_window.GetHwnd());
+        const bool sceneViewSizeChanged = m_editorShell.UpdateLayout(GetMainWindowHandle());
         if (true == sceneViewSizeChanged)
         {
             m_sceneViewController.OnViewportChanged(
@@ -379,7 +385,7 @@ namespace Xelqoria::Editor
         AppendEditorLog(L"Editor ワークスペースを初期化しました。");
         m_editorCommandController.Reset(m_sceneDocument, m_hierarchyPanelController.GetSelectedEntityId());
         m_editorInitialized = true;
-        RedrawWindow(m_window.GetHwnd(), nullptr, nullptr, RDW_INVALIDATE | RDW_ERASE | RDW_ALLCHILDREN);
+        RedrawWindow(GetMainWindowHandle(), nullptr, nullptr, RDW_INVALIDATE | RDW_ERASE | RDW_ALLCHILDREN);
         return true;
     }
 
@@ -396,7 +402,7 @@ namespace Xelqoria::Editor
 
         HMENU menuBar = CreateMenu();
         AppendMenuW(menuBar, MF_POPUP, reinterpret_cast<UINT_PTR>(m_projectMenu), L"プロジェクト");
-        SetMenu(m_window.GetHwnd(), menuBar);
+        SetMenu(GetMainWindowHandle(), menuBar);
     }
 
     void Application::HandleProjectMenuCommand(unsigned commandId)
@@ -447,11 +453,11 @@ namespace Xelqoria::Editor
 
         if (false == m_editorInitialized)
         {
-            m_startupScreenController.UpdateLayout(m_window.GetHwnd());
+            m_startupScreenController.UpdateLayout(GetMainWindowHandle());
             return;
         }
 
-        const bool sceneViewSizeChanged = m_editorShell.UpdateLayout(m_window.GetHwnd());
+        const bool sceneViewSizeChanged = m_editorShell.UpdateLayout(GetMainWindowHandle());
         if (sceneViewSizeChanged)
         {
             m_sceneViewController.OnViewportChanged(
@@ -525,7 +531,7 @@ namespace Xelqoria::Editor
             return;
         }
 
-        const std::filesystem::path parentDirectory = SelectFolder(m_window.GetHwnd(), L"プロジェクトの保存先フォルダを選択");
+        const std::filesystem::path parentDirectory = SelectFolder(GetMainWindowHandle(), L"プロジェクトの保存先フォルダを選択");
         if (parentDirectory.empty())
         {
             return;
@@ -564,7 +570,7 @@ namespace Xelqoria::Editor
             return;
         }
 
-        const std::filesystem::path projectFilePath = SelectProjectFile(m_window.GetHwnd());
+        const std::filesystem::path projectFilePath = SelectProjectFile(GetMainWindowHandle());
         if (projectFilePath.empty())
         {
             return;
@@ -624,7 +630,7 @@ namespace Xelqoria::Editor
             return;
         }
 
-        const std::filesystem::path parentDirectory = SelectFolder(m_window.GetHwnd(), L"別名保存先フォルダを選択");
+        const std::filesystem::path parentDirectory = SelectFolder(GetMainWindowHandle(), L"別名保存先フォルダを選択");
         if (parentDirectory.empty())
         {
             return;
@@ -660,7 +666,7 @@ namespace Xelqoria::Editor
         }
 
         const int result = MessageBoxW(
-            m_window.GetHwnd(),
+            GetMainWindowHandle(),
             L"プロジェクトを保存しますか？",
             L"保存確認",
             MB_YESNOCANCEL | MB_ICONQUESTION);
@@ -857,7 +863,7 @@ namespace Xelqoria::Editor
     {
         const HierarchyButtonFrameInput frameInput{
             inputSnapshot.IsMouseButtonDown(Core::MouseButton::Left),
-            inputSnapshot.GetCursorScreenPoint()
+            ToWin32Point(inputSnapshot.GetCursorScreenPoint())
         };
 
         if (TryConsumeHierarchyButtonClick(m_buildAndPlayButton, frameInput, m_editorPlayButtonInputState))
@@ -901,7 +907,7 @@ namespace Xelqoria::Editor
 
         if (false == m_editorInitialized)
         {
-            m_startupScreenController.UpdateLayout(m_window.GetHwnd());
+            m_startupScreenController.UpdateLayout(GetMainWindowHandle());
             m_startupScreenController.Update(inputSnapshot);
             if (m_startupScreenController.HasCreateRequest())
             {
@@ -921,9 +927,9 @@ namespace Xelqoria::Editor
             return;
         }
 
-        (void)m_editorShell.UpdateDocking(m_window.GetHwnd(), inputSnapshot);
+        (void)m_editorShell.UpdateDocking(GetMainWindowHandle(), inputSnapshot);
         m_logOutputPanelController.Update(inputSnapshot);
-        const bool sceneViewSizeChanged = m_editorShell.UpdateLayout(m_window.GetHwnd());
+        const bool sceneViewSizeChanged = m_editorShell.UpdateLayout(GetMainWindowHandle());
         if (true == sceneViewSizeChanged)
         {
             m_sceneViewController.OnViewportChanged(
@@ -1028,7 +1034,7 @@ namespace Xelqoria::Editor
                 ? m_sceneDocument.GetProjectInfo()->projectFilePath.parent_path()
                 : std::filesystem::path{};
             const std::filesystem::path scriptAssetPath =
-                SelectScriptAssetFile(m_window.GetHwnd(), projectRootDirectory);
+                SelectScriptAssetFile(GetMainWindowHandle(), projectRootDirectory);
             if (false == scriptAssetPath.empty())
             {
                 if (true == m_sceneDocument.AssignScriptAssetToSpriteAssetFile(spriteAssetPath, scriptAssetPath))
@@ -1120,7 +1126,7 @@ namespace Xelqoria::Editor
                     ? m_sceneDocument.GetProjectInfo()->projectFilePath.parent_path()
                     : std::filesystem::path{};
                 const std::filesystem::path scriptAssetPath =
-                    SelectScriptAssetFile(m_window.GetHwnd(), projectRootDirectory);
+                    SelectScriptAssetFile(GetMainWindowHandle(), projectRootDirectory);
                 if (false == scriptAssetPath.empty())
                 {
                     const std::optional<Core::AssetId> scriptTargetSpriteAssetId =
@@ -1324,6 +1330,11 @@ namespace Xelqoria::Editor
             m_hierarchyPanelController.GetSelectedEntityId(),
             m_sceneViewController.GetEditMode(),
             m_sceneViewController.GetDragPreviewState());
+    }
+
+    HWND Application::GetMainWindowHandle() const
+    {
+        return reinterpret_cast<HWND>(m_window.GetHwnd());
     }
 
     void Application::RefreshEditorPanels(bool canAddSpriteComponent, bool resetTrackedEntity)

--- a/Editor/Source/Application.h
+++ b/Editor/Source/Application.h
@@ -202,6 +202,12 @@ namespace Xelqoria::Editor
         void Render();
 
         /// <summary>
+        /// メインウィンドウの Win32 ハンドルを取得する。
+        /// </summary>
+        /// <returns>メインウィンドウの HWND。</returns>
+        [[nodiscard]] HWND GetMainWindowHandle() const;
+
+        /// <summary>
         /// Assets パネル、Hierarchy、Inspector の表示を現在状態へ同期する。
         /// </summary>
         /// <param name="canAddSpriteComponent">SpriteComponent を追加可能な場合は true。</param>

--- a/Editor/Source/AssetsPanelController.cpp
+++ b/Editor/Source/AssetsPanelController.cpp
@@ -31,6 +31,11 @@ namespace Xelqoria::Editor
         constexpr int DragPreviewCursorOffsetX = 14;
         constexpr int DragPreviewCursorOffsetY = 18;
 
+        [[nodiscard]] POINT ToWin32Point(Platform::Point point)
+        {
+            return POINT{ static_cast<LONG>(point.x), static_cast<LONG>(point.y) };
+        }
+
         /// <summary>
         /// ディレクトリエントリをフォルダ優先、名前順で並べる。
         /// </summary>
@@ -426,7 +431,7 @@ namespace Xelqoria::Editor
 
         if (m_isAssetDragActive)
         {
-            MoveDragImage(inputSnapshot.GetCursorScreenPoint());
+            MoveDragImage(ToWin32Point(inputSnapshot.GetCursorScreenPoint()));
         }
 
         if (false == inputSnapshot.WasMouseButtonPressed(Core::MouseButton::Left))
@@ -434,7 +439,7 @@ namespace Xelqoria::Editor
             return;
         }
 
-        const int hitIndex = HitTestListView(inputSnapshot.GetCursorScreenPoint());
+        const int hitIndex = HitTestListView(ToWin32Point(inputSnapshot.GetCursorScreenPoint()));
         if (hitIndex < 0)
         {
             return;
@@ -462,7 +467,7 @@ namespace Xelqoria::Editor
             m_canPlaceDraggingAssetInScene = false;
             if (m_isAssetDragActive)
             {
-                BeginDragImage(hitEntry.path, hitEntry.iconIndex, inputSnapshot.GetCursorScreenPoint());
+                BeginDragImage(hitEntry.path, hitEntry.iconIndex, ToWin32Point(inputSnapshot.GetCursorScreenPoint()));
             }
         }
         else if (false == hitEntry.isDirectory
@@ -478,7 +483,7 @@ namespace Xelqoria::Editor
             m_canPlaceDraggingAssetInScene = false;
             if (m_isAssetDragActive)
             {
-                BeginDragPreview(hitEntry.path, inputSnapshot.GetCursorScreenPoint());
+                BeginDragPreview(hitEntry.path, ToWin32Point(inputSnapshot.GetCursorScreenPoint()));
             }
         }
         else

--- a/Editor/Source/HierarchyPanelController.cpp
+++ b/Editor/Source/HierarchyPanelController.cpp
@@ -14,6 +14,14 @@
 
 namespace Xelqoria::Editor
 {
+    namespace
+    {
+        [[nodiscard]] POINT ToWin32Point(Platform::Point point)
+        {
+            return POINT{ static_cast<LONG>(point.x), static_cast<LONG>(point.y) };
+        }
+    }
+
     void HierarchyPanelController::Bind(const EditorShell& shell)
     {
         m_hierarchyListBox = shell.GetHierarchyListBox();
@@ -148,7 +156,7 @@ namespace Xelqoria::Editor
         const bool isEnterPressed = inputSnapshot.WasKeyPressed(VK_RETURN);
         const HierarchyButtonFrameInput frameInput{
             inputSnapshot.IsMouseButtonDown(Core::MouseButton::Left),
-            inputSnapshot.GetCursorScreenPoint()
+            ToWin32Point(inputSnapshot.GetCursorScreenPoint())
         };
 
         if (selectedEntity.has_value())

--- a/Editor/Source/InspectorPanelController.cpp
+++ b/Editor/Source/InspectorPanelController.cpp
@@ -17,6 +17,14 @@
 
 namespace Xelqoria::Editor
 {
+    namespace
+    {
+        [[nodiscard]] POINT ToWin32Point(Platform::Point point)
+        {
+            return POINT{ static_cast<LONG>(point.x), static_cast<LONG>(point.y) };
+        }
+    }
+
     void InspectorPanelController::Bind(const EditorShell& shell)
     {
         m_inspectorSummaryLabel = shell.GetInspectorSummaryLabel();
@@ -389,7 +397,7 @@ namespace Xelqoria::Editor
             return false;
         }
 
-        const POINT cursorScreenPoint = inputSnapshot.GetCursorScreenPoint();
+        const POINT cursorScreenPoint = ToWin32Point(inputSnapshot.GetCursorScreenPoint());
 
         RECT buttonRect{};
         GetWindowRect(buttonHandle, &buttonRect);

--- a/Editor/Source/SceneViewInputTracker.cpp
+++ b/Editor/Source/SceneViewInputTracker.cpp
@@ -27,6 +27,11 @@ namespace Xelqoria::Editor
     {
         constexpr float UntexturedSpriteSizeWorldUnits = 64.0f;
 
+        [[nodiscard]] POINT ToWin32Point(Platform::Point point)
+        {
+            return POINT{ static_cast<LONG>(point.x), static_cast<LONG>(point.y) };
+        }
+
         /// <summary>
         /// 指定編集モードキーの押下から次の編集モードを決定する。
         /// </summary>
@@ -114,7 +119,7 @@ namespace Xelqoria::Editor
             return result;
         }
 
-        const POINT screenPoint = inputSnapshot.GetCursorScreenPoint();
+        const POINT screenPoint = ToWin32Point(inputSnapshot.GetCursorScreenPoint());
 
         RECT sceneHostRect{};
         GetWindowRect(m_sceneViewHost, &sceneHostRect);

--- a/Editor/Source/StartupScreenController.cpp
+++ b/Editor/Source/StartupScreenController.cpp
@@ -23,6 +23,11 @@ namespace Xelqoria::Editor
         constexpr int CreateCancelButtonId = 4305;
         constexpr const wchar_t* CreateProjectWindowClassName = L"XelqoriaCreateProjectWindow";
 
+        [[nodiscard]] POINT ToWin32Point(Platform::Point point)
+        {
+            return POINT{ static_cast<LONG>(point.x), static_cast<LONG>(point.y) };
+        }
+
         UINT GetWindowDpi(HWND window)
         {
             HMODULE user32 = GetModuleHandleW(L"user32.dll");
@@ -229,7 +234,7 @@ namespace Xelqoria::Editor
 
         m_wasLeftMouseDown = false;
 
-        const POINT cursorPosition = inputSnapshot.GetCursorScreenPoint();
+        const POINT cursorPosition = ToWin32Point(inputSnapshot.GetCursorScreenPoint());
         const HWND clickedWindow = WindowFromPoint(cursorPosition);
         if (clickedWindow == m_createButton)
         {

--- a/Editor/Xelqoria.Editor.vcxproj
+++ b/Editor/Xelqoria.Editor.vcxproj
@@ -75,6 +75,9 @@
     <ProjectReference Include="..\Core\Xelqoria.Core.vcxproj">
       <Project>{79E8E826-7407-4766-B731-675CB84F6552}</Project>
     </ProjectReference>
+    <ProjectReference Include="..\Platform.Win32\Xelqoria.Platform.Win32.vcxproj">
+      <Project>{E121A6F2-EFFE-44E6-8123-02CCED1196FC}</Project>
+    </ProjectReference>
     <ProjectReference Include="..\Editor.UI\Xelqoria.Editor.UI.vcxproj">
       <Project>{66FA8A19-4FCE-418A-B450-638F3A42681E}</Project>
     </ProjectReference>
@@ -159,7 +162,7 @@
       <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <LanguageStandard>stdcpp20</LanguageStandard>
-      <AdditionalIncludeDirectories>$(ProjectDir)Source;$(RepoRootDir)Editor.UI\Source;$(RepoRootDir)Core\Source;$(RepoRootDir)Game\Source;$(RepoRootDir)Graphics\Source;$(RepoRootDir)RHI\Source;$(RepoRootDir)Xelqoria.Math\Source;$(RepoRootDir)Backends.D3D11\Source;$(RepoRootDir)Backends.D3D12\Source;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(ProjectDir)Source;$(RepoRootDir)Editor.UI\Source;$(RepoRootDir)Core\Source;$(RepoRootDir)Platform\Source;$(RepoRootDir)Platform.Win32\Source;$(RepoRootDir)Game\Source;$(RepoRootDir)Graphics\Source;$(RepoRootDir)RHI\Source;$(RepoRootDir)Xelqoria.Math\Source;$(RepoRootDir)Backends.D3D11\Source;$(RepoRootDir)Backends.D3D12\Source;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <AdditionalOptions>/utf-8 %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
@@ -177,7 +180,7 @@
       <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <LanguageStandard>stdcpp20</LanguageStandard>
-      <AdditionalIncludeDirectories>$(ProjectDir)Source;$(RepoRootDir)Editor.UI\Source;$(RepoRootDir)Core\Source;$(RepoRootDir)Game\Source;$(RepoRootDir)Graphics\Source;$(RepoRootDir)RHI\Source;$(RepoRootDir)Xelqoria.Math\Source;$(RepoRootDir)Backends.D3D11\Source;$(RepoRootDir)Backends.D3D12\Source;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(ProjectDir)Source;$(RepoRootDir)Editor.UI\Source;$(RepoRootDir)Core\Source;$(RepoRootDir)Platform\Source;$(RepoRootDir)Platform.Win32\Source;$(RepoRootDir)Game\Source;$(RepoRootDir)Graphics\Source;$(RepoRootDir)RHI\Source;$(RepoRootDir)Xelqoria.Math\Source;$(RepoRootDir)Backends.D3D11\Source;$(RepoRootDir)Backends.D3D12\Source;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <AdditionalOptions>/utf-8 %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
@@ -193,7 +196,7 @@
       <PreprocessorDefinitions>_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <LanguageStandard>stdcpp20</LanguageStandard>
-      <AdditionalIncludeDirectories>$(ProjectDir)Source;$(RepoRootDir)Editor.UI\Source;$(RepoRootDir)Core\Source;$(RepoRootDir)Game\Source;$(RepoRootDir)Graphics\Source;$(RepoRootDir)RHI\Source;$(RepoRootDir)Xelqoria.Math\Source;$(RepoRootDir)Backends.D3D11\Source;$(RepoRootDir)Backends.D3D12\Source;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(ProjectDir)Source;$(RepoRootDir)Editor.UI\Source;$(RepoRootDir)Core\Source;$(RepoRootDir)Platform\Source;$(RepoRootDir)Platform.Win32\Source;$(RepoRootDir)Game\Source;$(RepoRootDir)Graphics\Source;$(RepoRootDir)RHI\Source;$(RepoRootDir)Xelqoria.Math\Source;$(RepoRootDir)Backends.D3D11\Source;$(RepoRootDir)Backends.D3D12\Source;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <AdditionalOptions>/utf-8 %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
@@ -211,7 +214,7 @@
       <PreprocessorDefinitions>NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <LanguageStandard>stdcpp20</LanguageStandard>
-      <AdditionalIncludeDirectories>$(ProjectDir)Source;$(RepoRootDir)Editor.UI\Source;$(RepoRootDir)Core\Source;$(RepoRootDir)Game\Source;$(RepoRootDir)Graphics\Source;$(RepoRootDir)RHI\Source;$(RepoRootDir)Xelqoria.Math\Source;$(RepoRootDir)Backends.D3D11\Source;$(RepoRootDir)Backends.D3D12\Source;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(ProjectDir)Source;$(RepoRootDir)Editor.UI\Source;$(RepoRootDir)Core\Source;$(RepoRootDir)Platform\Source;$(RepoRootDir)Platform.Win32\Source;$(RepoRootDir)Game\Source;$(RepoRootDir)Graphics\Source;$(RepoRootDir)RHI\Source;$(RepoRootDir)Xelqoria.Math\Source;$(RepoRootDir)Backends.D3D11\Source;$(RepoRootDir)Backends.D3D12\Source;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <AdditionalOptions>/utf-8 %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>

--- a/Platform.Mac/Source/MacPlatformAnchor.cpp
+++ b/Platform.Mac/Source/MacPlatformAnchor.cpp
@@ -1,0 +1,11 @@
+#include "IApplication.h"
+
+namespace Xelqoria::Platform::Mac
+{
+    /// <summary>
+    /// Mac プラットフォーム実装プロジェクトのリンク対象翻訳単位を用意する。
+    /// </summary>
+    void MacPlatformAnchor()
+    {
+    }
+}

--- a/Platform.Mac/Xelqoria.Platform.Mac.vcxproj
+++ b/Platform.Mac/Xelqoria.Platform.Mac.vcxproj
@@ -1,0 +1,140 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <ItemGroup Condition="'$(OS)'!='Windows_NT'">
+    <ClCompile Include="Source\MacPlatformAnchor.cpp" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Platform\Xelqoria.Platform.vcxproj">
+      <Project>{FBC1E45E-2F7B-4E99-B813-916509583283}</Project>
+    </ProjectReference>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <VCProjectVersion>18.0</VCProjectVersion>
+    <Keyword>Win32Proj</Keyword>
+    <ProjectGuid>{2BBDB336-AF96-404D-AAB6-42C1F36CA1A3}</ProjectGuid>
+    <RootNamespace>XelqoriaPlatformMac</RootNamespace>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType Condition="'$(OS)'=='Windows_NT'">Utility</ConfigurationType>
+    <ConfigurationType Condition="'$(OS)'!='Windows_NT'">StaticLibrary</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v145</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType Condition="'$(OS)'=='Windows_NT'">Utility</ConfigurationType>
+    <ConfigurationType Condition="'$(OS)'!='Windows_NT'">StaticLibrary</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v145</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType Condition="'$(OS)'=='Windows_NT'">Utility</ConfigurationType>
+    <ConfigurationType Condition="'$(OS)'!='Windows_NT'">StaticLibrary</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v145</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType Condition="'$(OS)'=='Windows_NT'">Utility</ConfigurationType>
+    <ConfigurationType Condition="'$(OS)'!='Windows_NT'">StaticLibrary</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v145</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings" />
+  <ImportGroup Label="Shared" />
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup>
+    <OutDir>$(SolutionDir)artifacts\$(Platform)\$(Configuration)\</OutDir>
+    <IntDir>$(SolutionDir)build\$(ProjectName)\$(Platform)\$(Configuration)\</IntDir>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>WIN32;_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+      <LanguageStandard>stdcpp20</LanguageStandard>
+      <AdditionalIncludeDirectories>$(ProjectDir)Source;$(RepoRootDir)Platform\Source;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalOptions>/utf-8 %(AdditionalOptions)</AdditionalOptions>
+    </ClCompile>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>WIN32;NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+      <LanguageStandard>stdcpp20</LanguageStandard>
+      <AdditionalIncludeDirectories>$(ProjectDir)Source;$(RepoRootDir)Platform\Source;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalOptions>/utf-8 %(AdditionalOptions)</AdditionalOptions>
+    </ClCompile>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+      <LanguageStandard>stdcpp20</LanguageStandard>
+      <AdditionalIncludeDirectories>$(ProjectDir)Source;$(RepoRootDir)Platform\Source;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalOptions>/utf-8 %(AdditionalOptions)</AdditionalOptions>
+    </ClCompile>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+      <LanguageStandard>stdcpp20</LanguageStandard>
+      <AdditionalIncludeDirectories>$(ProjectDir)Source;$(RepoRootDir)Platform\Source;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalOptions>/utf-8 %(AdditionalOptions)</AdditionalOptions>
+    </ClCompile>
+  </ItemDefinitionGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <PropertyGroup>
+    <RepoRootDir>$(MSBuildProjectDirectory)\..\</RepoRootDir>
+  </PropertyGroup>
+  <ImportGroup Label="ExtensionTargets" />
+</Project>

--- a/Platform.Mac/Xelqoria.Platform.Mac.vcxproj.filters
+++ b/Platform.Mac/Xelqoria.Platform.Mac.vcxproj.filters
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Filter Include="Source">
+      <UniqueIdentifier>{E6C5B3DE-DFAE-409C-B160-32F2CE84CC18}</UniqueIdentifier>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="Source\MacPlatformAnchor.cpp">
+      <Filter>Source</Filter>
+    </ClCompile>
+  </ItemGroup>
+</Project>

--- a/Platform.Win32/Source/Win32EventLoop.cpp
+++ b/Platform.Win32/Source/Win32EventLoop.cpp
@@ -1,0 +1,28 @@
+#include "Win32EventLoop.h"
+
+#include <Windows.h>
+
+namespace Xelqoria::Platform::Win32
+{
+    bool Win32EventLoop::PumpEvents()
+    {
+        MSG message{};
+        while (PeekMessageW(&message, nullptr, 0, 0, PM_REMOVE))
+        {
+            if (WM_QUIT == message.message)
+            {
+                return false;
+            }
+
+            TranslateMessage(&message);
+            DispatchMessageW(&message);
+        }
+
+        return true;
+    }
+
+    void Win32EventLoop::RequestQuit()
+    {
+        PostQuitMessage(0);
+    }
+}

--- a/Platform.Win32/Source/Win32EventLoop.h
+++ b/Platform.Win32/Source/Win32EventLoop.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include "IEventLoop.h"
+
+namespace Xelqoria::Platform::Win32
+{
+    /// <summary>
+    /// Win32 メッセージキューを使用してイベントループを処理する。
+    /// </summary>
+    class Win32EventLoop final : public IEventLoop
+    {
+    public:
+        bool PumpEvents() override;
+        void RequestQuit() override;
+    };
+}

--- a/Platform.Win32/Source/Win32Input.cpp
+++ b/Platform.Win32/Source/Win32Input.cpp
@@ -1,0 +1,35 @@
+#include "Win32Input.h"
+
+#include <Windows.h>
+
+namespace Xelqoria::Platform::Win32
+{
+    void Win32Input::Update()
+    {
+    }
+
+    bool Win32Input::IsKeyDown(std::uint32_t keyCode) const
+    {
+        return 0 != (::GetAsyncKeyState(static_cast<int>(keyCode)) & 0x8000);
+    }
+
+    bool Win32Input::IsMouseButtonDown(std::uint32_t buttonCode) const
+    {
+        return IsKeyDown(buttonCode);
+    }
+
+    Point Win32Input::GetCursorScreenPosition() const
+    {
+        POINT cursorScreenPoint{};
+        ::GetCursorPos(&cursorScreenPoint);
+        return Point{
+            static_cast<std::int32_t>(cursorScreenPoint.x),
+            static_cast<std::int32_t>(cursorScreenPoint.y)
+        };
+    }
+
+    int Win32Input::GetMouseWheelDelta() const
+    {
+        return 0;
+    }
+}

--- a/Platform.Win32/Source/Win32Input.h
+++ b/Platform.Win32/Source/Win32Input.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include "IInput.h"
+
+namespace Xelqoria::Platform::Win32
+{
+    /// <summary>
+    /// Win32 API から現在の入力状態を読み取る。
+    /// </summary>
+    class Win32Input final : public IInput
+    {
+    public:
+        void Update() override;
+        [[nodiscard]] bool IsKeyDown(std::uint32_t keyCode) const override;
+        [[nodiscard]] bool IsMouseButtonDown(std::uint32_t buttonCode) const override;
+        [[nodiscard]] Point GetCursorScreenPosition() const override;
+        [[nodiscard]] int GetMouseWheelDelta() const override;
+    };
+}

--- a/Platform.Win32/Source/Win32PlatformAnchor.cpp
+++ b/Platform.Win32/Source/Win32PlatformAnchor.cpp
@@ -1,0 +1,11 @@
+#include "IApplication.h"
+
+namespace Xelqoria::Platform::Win32
+{
+    /// <summary>
+    /// Win32 プラットフォーム実装プロジェクトのリンク対象翻訳単位を用意する。
+    /// </summary>
+    void Win32PlatformAnchor()
+    {
+    }
+}

--- a/Platform.Win32/Source/Win32PlatformFactory.cpp
+++ b/Platform.Win32/Source/Win32PlatformFactory.cpp
@@ -1,0 +1,23 @@
+#include "Win32PlatformFactory.h"
+
+#include "Win32EventLoop.h"
+#include "Win32Input.h"
+#include "Win32Window.h"
+
+namespace Xelqoria::Platform::Win32
+{
+    std::unique_ptr<IWindow> CreateWin32Window(NativeApplicationHandle applicationHandle)
+    {
+        return std::make_unique<Win32Window>(applicationHandle);
+    }
+
+    std::unique_ptr<IEventLoop> CreateWin32EventLoop()
+    {
+        return std::make_unique<Win32EventLoop>();
+    }
+
+    std::unique_ptr<IInput> CreateWin32Input()
+    {
+        return std::make_unique<Win32Input>();
+    }
+}

--- a/Platform.Win32/Source/Win32PlatformFactory.h
+++ b/Platform.Win32/Source/Win32PlatformFactory.h
@@ -1,0 +1,30 @@
+#pragma once
+
+#include "IEventLoop.h"
+#include "IInput.h"
+#include "IWindow.h"
+#include "PlatformTypes.h"
+
+#include <memory>
+
+namespace Xelqoria::Platform::Win32
+{
+    /// <summary>
+    /// Win32 実装のウィンドウを生成する。
+    /// </summary>
+    /// <param name="applicationHandle">Win32 アプリケーションインスタンスハンドル。</param>
+    /// <returns>生成されたウィンドウ実装。</returns>
+    [[nodiscard]] std::unique_ptr<IWindow> CreateWin32Window(NativeApplicationHandle applicationHandle);
+
+    /// <summary>
+    /// Win32 実装のイベントループを生成する。
+    /// </summary>
+    /// <returns>生成されたイベントループ実装。</returns>
+    [[nodiscard]] std::unique_ptr<IEventLoop> CreateWin32EventLoop();
+
+    /// <summary>
+    /// Win32 実装の入力読み取りを生成する。
+    /// </summary>
+    /// <returns>生成された入力実装。</returns>
+    [[nodiscard]] std::unique_ptr<IInput> CreateWin32Input();
+}

--- a/Platform.Win32/Source/Win32Window.cpp
+++ b/Platform.Win32/Source/Win32Window.cpp
@@ -1,0 +1,257 @@
+#include "Win32Window.h"
+
+#include <utility>
+
+#ifndef WM_DPICHANGED
+#define WM_DPICHANGED 0x02E0
+#endif
+
+namespace Xelqoria::Platform::Win32
+{
+    Win32Window::Win32Window(NativeApplicationHandle applicationHandle)
+        : m_applicationHandle(reinterpret_cast<HINSTANCE>(applicationHandle))
+    {
+    }
+
+    Win32Window::~Win32Window()
+    {
+        if (nullptr != m_windowHandle)
+        {
+            DestroyWindow(m_windowHandle);
+            m_windowHandle = nullptr;
+        }
+
+        if (nullptr != m_applicationHandle)
+        {
+            UnregisterClassW(m_className.c_str(), m_applicationHandle);
+        }
+    }
+
+    bool Win32Window::Create(const std::wstring& title, std::uint32_t clientWidth, std::uint32_t clientHeight)
+    {
+        m_title = title;
+        m_width = clientWidth;
+        m_height = clientHeight;
+
+        WNDCLASSW windowClass{};
+        windowClass.style = CS_HREDRAW | CS_VREDRAW;
+        windowClass.lpfnWndProc = &Win32Window::StaticWndProc;
+        windowClass.hInstance = m_applicationHandle;
+        windowClass.hCursor = LoadCursor(nullptr, IDC_ARROW);
+        windowClass.hbrBackground = reinterpret_cast<HBRUSH>(COLOR_BTNFACE + 1);
+        windowClass.lpszClassName = m_className.c_str();
+
+        if (FALSE == RegisterClassW(&windowClass))
+        {
+            return false;
+        }
+
+        constexpr DWORD style = WS_OVERLAPPEDWINDOW;
+        RECT rect{ 0, 0, static_cast<LONG>(m_width), static_cast<LONG>(m_height) };
+        if (FALSE == AdjustWindowRect(&rect, style, FALSE))
+        {
+            UnregisterClassW(windowClass.lpszClassName, m_applicationHandle);
+            return false;
+        }
+
+        m_windowHandle = CreateWindowW(
+            m_className.c_str(),
+            m_title.c_str(),
+            style,
+            CW_USEDEFAULT,
+            CW_USEDEFAULT,
+            rect.right - rect.left,
+            rect.bottom - rect.top,
+            nullptr,
+            nullptr,
+            m_applicationHandle,
+            this);
+
+        return nullptr != m_windowHandle;
+    }
+
+    void Win32Window::Show()
+    {
+        ShowWindow(m_windowHandle, SW_SHOW);
+        SetForegroundWindow(m_windowHandle);
+        SetFocus(m_windowHandle);
+    }
+
+    void Win32Window::Close()
+    {
+        if (nullptr != m_windowHandle)
+        {
+            DestroyWindow(m_windowHandle);
+            m_windowHandle = nullptr;
+        }
+    }
+
+    bool Win32Window::IsOpen() const
+    {
+        return nullptr != m_windowHandle;
+    }
+
+    NativeWindowHandle Win32Window::GetNativeHandle() const
+    {
+        return m_windowHandle;
+    }
+
+    std::uint32_t Win32Window::GetClientWidth() const
+    {
+        return m_width;
+    }
+
+    std::uint32_t Win32Window::GetClientHeight() const
+    {
+        return m_height;
+    }
+
+    void Win32Window::SetCommandHandler(CommandHandler handler)
+    {
+        m_commandHandler = std::move(handler);
+    }
+
+    void Win32Window::SetNotifyHandler(NativeMessageHandler handler)
+    {
+        m_notifyHandler = std::move(handler);
+    }
+
+    void Win32Window::SetDrawItemHandler(NativeMessageHandler handler)
+    {
+        m_drawItemHandler = std::move(handler);
+    }
+
+    void Win32Window::SetCloseRequestHandler(CloseRequestHandler handler)
+    {
+        m_closeRequestHandler = std::move(handler);
+    }
+
+    void Win32Window::SetResizeHandler(ResizeHandler handler)
+    {
+        m_resizeHandler = std::move(handler);
+    }
+
+    int Win32Window::ConsumeMouseWheelDelta()
+    {
+        const int mouseWheelDelta = m_pendingMouseWheelDelta;
+        m_pendingMouseWheelDelta = 0;
+        return mouseWheelDelta;
+    }
+
+    LRESULT CALLBACK Win32Window::StaticWndProc(HWND windowHandle, UINT message, WPARAM wParam, LPARAM lParam)
+    {
+        Win32Window* self = nullptr;
+
+        if (WM_NCCREATE == message)
+        {
+            auto* createStruct = reinterpret_cast<CREATESTRUCTW*>(lParam);
+            self = reinterpret_cast<Win32Window*>(createStruct->lpCreateParams);
+            SetWindowLongPtrW(windowHandle, GWLP_USERDATA, reinterpret_cast<LONG_PTR>(self));
+        }
+        else
+        {
+            self = reinterpret_cast<Win32Window*>(GetWindowLongPtrW(windowHandle, GWLP_USERDATA));
+        }
+
+        if (nullptr != self)
+        {
+            return self->WndProc(windowHandle, message, wParam, lParam);
+        }
+
+        return DefWindowProcW(windowHandle, message, wParam, lParam);
+    }
+
+    LRESULT Win32Window::WndProc(HWND windowHandle, UINT message, WPARAM wParam, LPARAM lParam)
+    {
+        switch (message)
+        {
+        case WM_COMMAND:
+            if (m_commandHandler)
+            {
+                m_commandHandler(LOWORD(wParam));
+                return 0;
+            }
+            break;
+
+        case WM_NOTIFY:
+            if (m_notifyHandler && m_notifyHandler(static_cast<NativeMessageParameter>(lParam)))
+            {
+                return 0;
+            }
+            break;
+
+        case WM_DRAWITEM:
+            if (m_drawItemHandler && m_drawItemHandler(static_cast<NativeMessageParameter>(lParam)))
+            {
+                return TRUE;
+            }
+            break;
+
+        case WM_CLOSE:
+            if (m_closeRequestHandler && false == m_closeRequestHandler())
+            {
+                return 0;
+            }
+
+            DestroyWindow(windowHandle);
+            m_windowHandle = nullptr;
+            return 0;
+
+        case WM_DESTROY:
+            m_windowHandle = nullptr;
+            PostQuitMessage(0);
+            return 0;
+
+        case WM_SIZE:
+            if (SIZE_MINIMIZED != wParam)
+            {
+                m_width = static_cast<std::uint32_t>(LOWORD(lParam));
+                m_height = static_cast<std::uint32_t>(HIWORD(lParam));
+                if (m_resizeHandler)
+                {
+                    m_resizeHandler(m_width, m_height);
+                }
+
+                InvalidateRect(windowHandle, nullptr, TRUE);
+            }
+            return 0;
+
+        case WM_DPICHANGED:
+            if (0 != lParam)
+            {
+                const RECT* suggestedRect = reinterpret_cast<RECT*>(lParam);
+                SetWindowPos(
+                    windowHandle,
+                    nullptr,
+                    suggestedRect->left,
+                    suggestedRect->top,
+                    suggestedRect->right - suggestedRect->left,
+                    suggestedRect->bottom - suggestedRect->top,
+                    SWP_NOZORDER | SWP_NOACTIVATE);
+            }
+
+            InvalidateRect(windowHandle, nullptr, TRUE);
+            return 0;
+
+        case WM_MOUSEWHEEL:
+            m_pendingMouseWheelDelta += GET_WHEEL_DELTA_WPARAM(wParam);
+            return 0;
+
+        case WM_KEYDOWN:
+            if (VK_ESCAPE == wParam)
+            {
+                if (m_closeRequestHandler && false == m_closeRequestHandler())
+                {
+                    return 0;
+                }
+
+                DestroyWindow(windowHandle);
+                m_windowHandle = nullptr;
+                return 0;
+            }
+            break;
+        }
+
+        return DefWindowProcW(windowHandle, message, wParam, lParam);
+    }
+}

--- a/Platform.Win32/Source/Win32Window.h
+++ b/Platform.Win32/Source/Win32Window.h
@@ -1,0 +1,72 @@
+#pragma once
+
+#include "IWindow.h"
+#include "PlatformTypes.h"
+
+#include <Windows.h>
+#include <cstdint>
+#include <string>
+
+namespace Xelqoria::Platform::Win32
+{
+    /// <summary>
+    /// Win32 API を使用してアプリケーションウィンドウを管理する。
+    /// </summary>
+    class Win32Window final : public IWindow
+    {
+    public:
+        /// <summary>
+        /// Win32 アプリケーションインスタンスに紐づくウィンドウ管理を生成する。
+        /// </summary>
+        /// <param name="applicationHandle">Win32 アプリケーションインスタンスハンドル。</param>
+        explicit Win32Window(NativeApplicationHandle applicationHandle);
+
+        /// <summary>
+        /// ウィンドウリソースを解放する。
+        /// </summary>
+        ~Win32Window() override;
+
+        Win32Window(const Win32Window&) = delete;
+        Win32Window& operator=(const Win32Window&) = delete;
+        Win32Window(Win32Window&&) = delete;
+        Win32Window& operator=(Win32Window&&) = delete;
+
+        bool Create(const std::wstring& title, std::uint32_t clientWidth, std::uint32_t clientHeight) override;
+        void Show() override;
+        void Close() override;
+        [[nodiscard]] bool IsOpen() const override;
+        [[nodiscard]] NativeWindowHandle GetNativeHandle() const override;
+        [[nodiscard]] std::uint32_t GetClientWidth() const override;
+        [[nodiscard]] std::uint32_t GetClientHeight() const override;
+        void SetCommandHandler(CommandHandler handler) override;
+        void SetNotifyHandler(NativeMessageHandler handler) override;
+        void SetDrawItemHandler(NativeMessageHandler handler) override;
+        void SetCloseRequestHandler(CloseRequestHandler handler) override;
+        void SetResizeHandler(ResizeHandler handler) override;
+        [[nodiscard]] int ConsumeMouseWheelDelta() override;
+
+    private:
+        /// <summary>
+        /// Win32 API から呼び出される静的ウィンドウプロシージャ。
+        /// </summary>
+        static LRESULT CALLBACK StaticWndProc(HWND windowHandle, UINT message, WPARAM wParam, LPARAM lParam);
+
+        /// <summary>
+        /// 各ウィンドウインスタンスのメッセージ処理を行う。
+        /// </summary>
+        LRESULT WndProc(HWND windowHandle, UINT message, WPARAM wParam, LPARAM lParam);
+
+        HINSTANCE m_applicationHandle = nullptr;
+        HWND m_windowHandle = nullptr;
+        CommandHandler m_commandHandler{};
+        NativeMessageHandler m_notifyHandler{};
+        NativeMessageHandler m_drawItemHandler{};
+        CloseRequestHandler m_closeRequestHandler{};
+        ResizeHandler m_resizeHandler{};
+        int m_pendingMouseWheelDelta = 0;
+        std::wstring m_className = L"XelqoriaWindowClass";
+        std::wstring m_title = L"Xelqoria";
+        std::uint32_t m_width = 0;
+        std::uint32_t m_height = 0;
+    };
+}

--- a/Platform.Win32/Xelqoria.Platform.Win32.vcxproj
+++ b/Platform.Win32/Xelqoria.Platform.Win32.vcxproj
@@ -19,7 +19,17 @@
     </ProjectConfiguration>
   </ItemGroup>
   <ItemGroup>
+    <ClCompile Include="Source\Win32EventLoop.cpp" />
+    <ClCompile Include="Source\Win32Input.cpp" />
     <ClCompile Include="Source\Win32PlatformAnchor.cpp" />
+    <ClCompile Include="Source\Win32PlatformFactory.cpp" />
+    <ClCompile Include="Source\Win32Window.cpp" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="Source\Win32EventLoop.h" />
+    <ClInclude Include="Source\Win32Input.h" />
+    <ClInclude Include="Source\Win32PlatformFactory.h" />
+    <ClInclude Include="Source\Win32Window.h" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Platform\Xelqoria.Platform.vcxproj">

--- a/Platform.Win32/Xelqoria.Platform.Win32.vcxproj
+++ b/Platform.Win32/Xelqoria.Platform.Win32.vcxproj
@@ -1,0 +1,136 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="Source\Win32PlatformAnchor.cpp" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Platform\Xelqoria.Platform.vcxproj">
+      <Project>{FBC1E45E-2F7B-4E99-B813-916509583283}</Project>
+    </ProjectReference>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <VCProjectVersion>18.0</VCProjectVersion>
+    <Keyword>Win32Proj</Keyword>
+    <ProjectGuid>{E121A6F2-EFFE-44E6-8123-02CCED1196FC}</ProjectGuid>
+    <RootNamespace>XelqoriaPlatformWin32</RootNamespace>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v145</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v145</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v145</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v145</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings" />
+  <ImportGroup Label="Shared" />
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup>
+    <OutDir>$(SolutionDir)artifacts\$(Platform)\$(Configuration)\</OutDir>
+    <IntDir>$(SolutionDir)build\$(ProjectName)\$(Platform)\$(Configuration)\</IntDir>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>WIN32;_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+      <LanguageStandard>stdcpp20</LanguageStandard>
+      <AdditionalIncludeDirectories>$(ProjectDir)Source;$(RepoRootDir)Platform\Source;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalOptions>/utf-8 %(AdditionalOptions)</AdditionalOptions>
+    </ClCompile>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>WIN32;NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+      <LanguageStandard>stdcpp20</LanguageStandard>
+      <AdditionalIncludeDirectories>$(ProjectDir)Source;$(RepoRootDir)Platform\Source;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalOptions>/utf-8 %(AdditionalOptions)</AdditionalOptions>
+    </ClCompile>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+      <LanguageStandard>stdcpp20</LanguageStandard>
+      <AdditionalIncludeDirectories>$(ProjectDir)Source;$(RepoRootDir)Platform\Source;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalOptions>/utf-8 %(AdditionalOptions)</AdditionalOptions>
+    </ClCompile>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+      <LanguageStandard>stdcpp20</LanguageStandard>
+      <AdditionalIncludeDirectories>$(ProjectDir)Source;$(RepoRootDir)Platform\Source;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalOptions>/utf-8 %(AdditionalOptions)</AdditionalOptions>
+    </ClCompile>
+  </ItemDefinitionGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <PropertyGroup>
+    <RepoRootDir>$(MSBuildProjectDirectory)\..\</RepoRootDir>
+  </PropertyGroup>
+  <ImportGroup Label="ExtensionTargets" />
+</Project>

--- a/Platform.Win32/Xelqoria.Platform.Win32.vcxproj.filters
+++ b/Platform.Win32/Xelqoria.Platform.Win32.vcxproj.filters
@@ -6,8 +6,34 @@
     </Filter>
   </ItemGroup>
   <ItemGroup>
+    <ClCompile Include="Source\Win32EventLoop.cpp">
+      <Filter>Source</Filter>
+    </ClCompile>
+    <ClCompile Include="Source\Win32Input.cpp">
+      <Filter>Source</Filter>
+    </ClCompile>
     <ClCompile Include="Source\Win32PlatformAnchor.cpp">
       <Filter>Source</Filter>
     </ClCompile>
+    <ClCompile Include="Source\Win32PlatformFactory.cpp">
+      <Filter>Source</Filter>
+    </ClCompile>
+    <ClCompile Include="Source\Win32Window.cpp">
+      <Filter>Source</Filter>
+    </ClCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="Source\Win32EventLoop.h">
+      <Filter>Source</Filter>
+    </ClInclude>
+    <ClInclude Include="Source\Win32Input.h">
+      <Filter>Source</Filter>
+    </ClInclude>
+    <ClInclude Include="Source\Win32PlatformFactory.h">
+      <Filter>Source</Filter>
+    </ClInclude>
+    <ClInclude Include="Source\Win32Window.h">
+      <Filter>Source</Filter>
+    </ClInclude>
   </ItemGroup>
 </Project>

--- a/Platform.Win32/Xelqoria.Platform.Win32.vcxproj.filters
+++ b/Platform.Win32/Xelqoria.Platform.Win32.vcxproj.filters
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Filter Include="Source">
+      <UniqueIdentifier>{F7998D79-1082-4AC6-8F25-8857C5589D21}</UniqueIdentifier>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="Source\Win32PlatformAnchor.cpp">
+      <Filter>Source</Filter>
+    </ClCompile>
+  </ItemGroup>
+</Project>

--- a/Platform/Source/IApplication.h
+++ b/Platform/Source/IApplication.h
@@ -1,0 +1,24 @@
+#pragma once
+
+namespace Xelqoria::Platform
+{
+    /// <summary>
+    /// OS 固有のアプリケーション初期化と終了処理を抽象化する。
+    /// </summary>
+    class IApplication
+    {
+    public:
+        virtual ~IApplication() = default;
+
+        /// <summary>
+        /// アプリケーション基盤を初期化する。
+        /// </summary>
+        /// <returns>初期化に成功した場合は true。</returns>
+        virtual bool Initialize() = 0;
+
+        /// <summary>
+        /// アプリケーション基盤を終了し、保持している OS リソースを解放する。
+        /// </summary>
+        virtual void Shutdown() = 0;
+    };
+}

--- a/Platform/Source/IClipboard.h
+++ b/Platform/Source/IClipboard.h
@@ -1,0 +1,28 @@
+#pragma once
+
+#include <string>
+
+namespace Xelqoria::Platform
+{
+    /// <summary>
+    /// OS のクリップボード操作を抽象化する。
+    /// </summary>
+    class IClipboard
+    {
+    public:
+        virtual ~IClipboard() = default;
+
+        /// <summary>
+        /// クリップボードにテキストを設定する。
+        /// </summary>
+        /// <param name="text">設定する Unicode テキスト。</param>
+        /// <returns>設定に成功した場合は true。</returns>
+        virtual bool SetText(const std::wstring& text) = 0;
+
+        /// <summary>
+        /// クリップボードからテキストを取得する。
+        /// </summary>
+        /// <returns>取得した Unicode テキスト。取得できない場合は空文字列。</returns>
+        [[nodiscard]] virtual std::wstring GetText() const = 0;
+    };
+}

--- a/Platform/Source/ICursor.h
+++ b/Platform/Source/ICursor.h
@@ -1,0 +1,37 @@
+#pragma once
+
+#include "PlatformTypes.h"
+
+namespace Xelqoria::Platform
+{
+    /// <summary>
+    /// OS のカーソル表示と座標操作を抽象化する。
+    /// </summary>
+    class ICursor
+    {
+    public:
+        virtual ~ICursor() = default;
+
+        /// <summary>
+        /// カーソルを表示する。
+        /// </summary>
+        virtual void Show() = 0;
+
+        /// <summary>
+        /// カーソルを非表示にする。
+        /// </summary>
+        virtual void Hide() = 0;
+
+        /// <summary>
+        /// カーソルのスクリーン座標を設定する。
+        /// </summary>
+        /// <param name="position">設定するスクリーン座標。</param>
+        virtual void SetScreenPosition(Point position) = 0;
+
+        /// <summary>
+        /// カーソルのスクリーン座標を取得する。
+        /// </summary>
+        /// <returns>現在のスクリーン座標。</returns>
+        [[nodiscard]] virtual Point GetScreenPosition() const = 0;
+    };
+}

--- a/Platform/Source/IEventLoop.h
+++ b/Platform/Source/IEventLoop.h
@@ -1,0 +1,24 @@
+#pragma once
+
+namespace Xelqoria::Platform
+{
+    /// <summary>
+    /// OS のイベントループとメッセージ処理を抽象化する。
+    /// </summary>
+    class IEventLoop
+    {
+    public:
+        virtual ~IEventLoop() = default;
+
+        /// <summary>
+        /// 保留中の OS イベントを 1 回分処理する。
+        /// </summary>
+        /// <returns>アプリケーション継続中は true。終了要求を受け取った場合は false。</returns>
+        virtual bool PumpEvents() = 0;
+
+        /// <summary>
+        /// イベントループに終了を要求する。
+        /// </summary>
+        virtual void RequestQuit() = 0;
+    };
+}

--- a/Platform/Source/IFileDialog.h
+++ b/Platform/Source/IFileDialog.h
@@ -1,0 +1,28 @@
+#pragma once
+
+#include <filesystem>
+#include <optional>
+
+namespace Xelqoria::Platform
+{
+    /// <summary>
+    /// OS 標準のファイル選択ダイアログを抽象化する。
+    /// </summary>
+    class IFileDialog
+    {
+    public:
+        virtual ~IFileDialog() = default;
+
+        /// <summary>
+        /// ファイルを開くダイアログを表示する。
+        /// </summary>
+        /// <returns>選択されたパス。キャンセル時は std::nullopt。</returns>
+        [[nodiscard]] virtual std::optional<std::filesystem::path> OpenFile() = 0;
+
+        /// <summary>
+        /// ファイルを保存するダイアログを表示する。
+        /// </summary>
+        /// <returns>選択された保存先パス。キャンセル時は std::nullopt。</returns>
+        [[nodiscard]] virtual std::optional<std::filesystem::path> SaveFile() = 0;
+    };
+}

--- a/Platform/Source/IInput.h
+++ b/Platform/Source/IInput.h
@@ -1,0 +1,42 @@
+#pragma once
+
+#include "PlatformTypes.h"
+
+#include <cstdint>
+
+namespace Xelqoria::Platform
+{
+    /// <summary>
+    /// OS から取得する入力状態を抽象化する。
+    /// </summary>
+    class IInput
+    {
+    public:
+        virtual ~IInput() = default;
+
+        /// <summary>
+        /// 現在フレームの入力状態を更新する。
+        /// </summary>
+        virtual void Update() = 0;
+
+        /// <summary>
+        /// 指定キーが現在押下中かを取得する。
+        /// </summary>
+        /// <param name="keyCode">プラットフォーム実装が解釈するキーコード。</param>
+        /// <returns>押下中の場合は true。</returns>
+        [[nodiscard]] virtual bool IsKeyDown(std::uint32_t keyCode) const = 0;
+
+        /// <summary>
+        /// 指定マウスボタンが現在押下中かを取得する。
+        /// </summary>
+        /// <param name="buttonCode">プラットフォーム実装が解釈するマウスボタンコード。</param>
+        /// <returns>押下中の場合は true。</returns>
+        [[nodiscard]] virtual bool IsMouseButtonDown(std::uint32_t buttonCode) const = 0;
+
+        /// <summary>
+        /// カーソルのスクリーン座標を取得する。
+        /// </summary>
+        /// <returns>現在のスクリーン座標。</returns>
+        [[nodiscard]] virtual Point GetCursorScreenPosition() const = 0;
+    };
+}

--- a/Platform/Source/IInput.h
+++ b/Platform/Source/IInput.h
@@ -38,5 +38,11 @@ namespace Xelqoria::Platform
         /// </summary>
         /// <returns>現在のスクリーン座標。</returns>
         [[nodiscard]] virtual Point GetCursorScreenPosition() const = 0;
+
+        /// <summary>
+        /// 現在フレームのマウスホイール差分を取得する。
+        /// </summary>
+        /// <returns>マウスホイール差分。</returns>
+        [[nodiscard]] virtual int GetMouseWheelDelta() const = 0;
     };
 }

--- a/Platform/Source/IWindow.h
+++ b/Platform/Source/IWindow.h
@@ -1,0 +1,61 @@
+#pragma once
+
+#include "PlatformTypes.h"
+
+#include <cstdint>
+#include <string>
+
+namespace Xelqoria::Platform
+{
+    /// <summary>
+    /// OS 固有のウィンドウ生成と基本操作を抽象化する。
+    /// </summary>
+    class IWindow
+    {
+    public:
+        virtual ~IWindow() = default;
+
+        /// <summary>
+        /// 指定サイズとタイトルでウィンドウを作成する。
+        /// </summary>
+        /// <param name="title">ウィンドウタイトル。</param>
+        /// <param name="clientWidth">クライアント領域の幅。</param>
+        /// <param name="clientHeight">クライアント領域の高さ。</param>
+        /// <returns>作成に成功した場合は true。</returns>
+        virtual bool Create(const std::wstring& title, std::uint32_t clientWidth, std::uint32_t clientHeight) = 0;
+
+        /// <summary>
+        /// ウィンドウを表示する。
+        /// </summary>
+        virtual void Show() = 0;
+
+        /// <summary>
+        /// ウィンドウを閉じる。
+        /// </summary>
+        virtual void Close() = 0;
+
+        /// <summary>
+        /// ウィンドウが有効かを取得する。
+        /// </summary>
+        /// <returns>有効な場合は true。</returns>
+        [[nodiscard]] virtual bool IsOpen() const = 0;
+
+        /// <summary>
+        /// OS 固有のウィンドウハンドルを取得する。
+        /// </summary>
+        /// <returns>不透明なネイティブウィンドウハンドル。</returns>
+        [[nodiscard]] virtual NativeWindowHandle GetNativeHandle() const = 0;
+
+        /// <summary>
+        /// クライアント領域の幅を取得する。
+        /// </summary>
+        /// <returns>クライアント領域の幅。</returns>
+        [[nodiscard]] virtual std::uint32_t GetClientWidth() const = 0;
+
+        /// <summary>
+        /// クライアント領域の高さを取得する。
+        /// </summary>
+        /// <returns>クライアント領域の高さ。</returns>
+        [[nodiscard]] virtual std::uint32_t GetClientHeight() const = 0;
+    };
+}

--- a/Platform/Source/IWindow.h
+++ b/Platform/Source/IWindow.h
@@ -3,6 +3,7 @@
 #include "PlatformTypes.h"
 
 #include <cstdint>
+#include <functional>
 #include <string>
 
 namespace Xelqoria::Platform
@@ -13,6 +14,26 @@ namespace Xelqoria::Platform
     class IWindow
     {
     public:
+        /// <summary>
+        /// コマンド ID を受け取る関数型を表す。
+        /// </summary>
+        using CommandHandler = std::function<void(unsigned)>;
+
+        /// <summary>
+        /// OS 固有メッセージ引数を処理する関数型を表す。
+        /// </summary>
+        using NativeMessageHandler = std::function<bool(NativeMessageParameter)>;
+
+        /// <summary>
+        /// ウィンドウ終了要求を処理する関数型を表す。
+        /// </summary>
+        using CloseRequestHandler = std::function<bool()>;
+
+        /// <summary>
+        /// クライアント領域のサイズ変更を受け取る関数型を表す。
+        /// </summary>
+        using ResizeHandler = std::function<void(std::uint32_t, std::uint32_t)>;
+
         virtual ~IWindow() = default;
 
         /// <summary>
@@ -57,5 +78,41 @@ namespace Xelqoria::Platform
         /// </summary>
         /// <returns>クライアント領域の高さ。</returns>
         [[nodiscard]] virtual std::uint32_t GetClientHeight() const = 0;
+
+        /// <summary>
+        /// コマンド通知を受け取るハンドラを設定する。
+        /// </summary>
+        /// <param name="handler">コマンド ID を受け取るハンドラ。</param>
+        virtual void SetCommandHandler(CommandHandler handler) = 0;
+
+        /// <summary>
+        /// OS 固有の通知メッセージを受け取るハンドラを設定する。
+        /// </summary>
+        /// <param name="handler">通知メッセージ引数を処理し、消費した場合は true を返すハンドラ。</param>
+        virtual void SetNotifyHandler(NativeMessageHandler handler) = 0;
+
+        /// <summary>
+        /// OS 固有のオーナー描画メッセージを受け取るハンドラを設定する。
+        /// </summary>
+        /// <param name="handler">描画メッセージ引数を処理し、消費した場合は true を返すハンドラ。</param>
+        virtual void SetDrawItemHandler(NativeMessageHandler handler) = 0;
+
+        /// <summary>
+        /// ウィンドウを閉じる前に呼ばれるハンドラを設定する。
+        /// </summary>
+        /// <param name="handler">閉じてよい場合は true を返すハンドラ。</param>
+        virtual void SetCloseRequestHandler(CloseRequestHandler handler) = 0;
+
+        /// <summary>
+        /// クライアント領域サイズ変更時に呼ばれるハンドラを設定する。
+        /// </summary>
+        /// <param name="handler">新しいクライアント領域の幅と高さを受け取るハンドラ。</param>
+        virtual void SetResizeHandler(ResizeHandler handler) = 0;
+
+        /// <summary>
+        /// 前回取得以降に蓄積されたマウスホイール差分を取得して消費する。
+        /// </summary>
+        /// <returns>蓄積されたマウスホイール差分。</returns>
+        [[nodiscard]] virtual int ConsumeMouseWheelDelta() = 0;
     };
 }

--- a/Platform/Source/PlatformAnchor.cpp
+++ b/Platform/Source/PlatformAnchor.cpp
@@ -1,0 +1,17 @@
+#include "IApplication.h"
+#include "IClipboard.h"
+#include "ICursor.h"
+#include "IEventLoop.h"
+#include "IFileDialog.h"
+#include "IInput.h"
+#include "IWindow.h"
+
+namespace Xelqoria::Platform
+{
+    /// <summary>
+    /// ヘッダーのみの抽象プロジェクトにリンク対象の翻訳単位を用意する。
+    /// </summary>
+    void PlatformAnchor()
+    {
+    }
+}

--- a/Platform/Source/PlatformTypes.h
+++ b/Platform/Source/PlatformTypes.h
@@ -15,6 +15,11 @@ namespace Xelqoria::Platform
     using NativeApplicationHandle = void*;
 
     /// <summary>
+    /// OS 固有のメッセージ引数を保持する不透明な整数値を表す。
+    /// </summary>
+    using NativeMessageParameter = std::intptr_t;
+
+    /// <summary>
     /// 2 次元の整数座標を表す。
     /// </summary>
     struct Point

--- a/Platform/Source/PlatformTypes.h
+++ b/Platform/Source/PlatformTypes.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include <cstdint>
+
+namespace Xelqoria::Platform
+{
+    /// <summary>
+    /// OS 固有のウィンドウハンドルを保持する不透明な値を表す。
+    /// </summary>
+    using NativeWindowHandle = void*;
+
+    /// <summary>
+    /// OS 固有のアプリケーションインスタンスハンドルを保持する不透明な値を表す。
+    /// </summary>
+    using NativeApplicationHandle = void*;
+
+    /// <summary>
+    /// 2 次元の整数座標を表す。
+    /// </summary>
+    struct Point
+    {
+        std::int32_t x = 0;
+        std::int32_t y = 0;
+    };
+}

--- a/Platform/Xelqoria.Platform.vcxproj
+++ b/Platform/Xelqoria.Platform.vcxproj
@@ -1,0 +1,138 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="Source\PlatformAnchor.cpp" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="Source\IApplication.h" />
+    <ClInclude Include="Source\IClipboard.h" />
+    <ClInclude Include="Source\ICursor.h" />
+    <ClInclude Include="Source\IEventLoop.h" />
+    <ClInclude Include="Source\IFileDialog.h" />
+    <ClInclude Include="Source\IInput.h" />
+    <ClInclude Include="Source\IWindow.h" />
+    <ClInclude Include="Source\PlatformTypes.h" />
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <VCProjectVersion>18.0</VCProjectVersion>
+    <Keyword>Win32Proj</Keyword>
+    <ProjectGuid>{FBC1E45E-2F7B-4E99-B813-916509583283}</ProjectGuid>
+    <RootNamespace>XelqoriaPlatform</RootNamespace>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v145</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v145</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v145</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v145</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings" />
+  <ImportGroup Label="Shared" />
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup>
+    <OutDir>$(SolutionDir)artifacts\$(Platform)\$(Configuration)\</OutDir>
+    <IntDir>$(SolutionDir)build\$(ProjectName)\$(Platform)\$(Configuration)\</IntDir>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>WIN32;_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+      <LanguageStandard>stdcpp20</LanguageStandard>
+      <AdditionalIncludeDirectories>$(ProjectDir)Source;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalOptions>/utf-8 %(AdditionalOptions)</AdditionalOptions>
+    </ClCompile>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>WIN32;NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+      <LanguageStandard>stdcpp20</LanguageStandard>
+      <AdditionalIncludeDirectories>$(ProjectDir)Source;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalOptions>/utf-8 %(AdditionalOptions)</AdditionalOptions>
+    </ClCompile>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+      <LanguageStandard>stdcpp20</LanguageStandard>
+      <AdditionalIncludeDirectories>$(ProjectDir)Source;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalOptions>/utf-8 %(AdditionalOptions)</AdditionalOptions>
+    </ClCompile>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+      <LanguageStandard>stdcpp20</LanguageStandard>
+      <AdditionalIncludeDirectories>$(ProjectDir)Source;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalOptions>/utf-8 %(AdditionalOptions)</AdditionalOptions>
+    </ClCompile>
+  </ItemDefinitionGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets" />
+</Project>

--- a/Platform/Xelqoria.Platform.vcxproj.filters
+++ b/Platform/Xelqoria.Platform.vcxproj.filters
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Filter Include="Source">
+      <UniqueIdentifier>{7F9A39CC-2048-4A29-86DF-CF5B1F27445F}</UniqueIdentifier>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="Source\PlatformAnchor.cpp">
+      <Filter>Source</Filter>
+    </ClCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="Source\IApplication.h">
+      <Filter>Source</Filter>
+    </ClInclude>
+    <ClInclude Include="Source\IClipboard.h">
+      <Filter>Source</Filter>
+    </ClInclude>
+    <ClInclude Include="Source\ICursor.h">
+      <Filter>Source</Filter>
+    </ClInclude>
+    <ClInclude Include="Source\IEventLoop.h">
+      <Filter>Source</Filter>
+    </ClInclude>
+    <ClInclude Include="Source\IFileDialog.h">
+      <Filter>Source</Filter>
+    </ClInclude>
+    <ClInclude Include="Source\IInput.h">
+      <Filter>Source</Filter>
+    </ClInclude>
+    <ClInclude Include="Source\IWindow.h">
+      <Filter>Source</Filter>
+    </ClInclude>
+    <ClInclude Include="Source\PlatformTypes.h">
+      <Filter>Source</Filter>
+    </ClInclude>
+  </ItemGroup>
+</Project>

--- a/Xelqoria.slnx
+++ b/Xelqoria.slnx
@@ -122,6 +122,14 @@
   <Project Path="Editor/Xelqoria.Editor.vcxproj" Id="2a2fc413-07f6-41d7-ab02-079ce112c042" />
   <Project Path="Game/Xelqoria.Game.vcxproj" Id="b43e8e97-59ef-4caa-8a27-bd9192d8833a" />
   <Project Path="Graphics/Xelqoria.Graphics.vcxproj" Id="7693792a-4ad4-445a-98f7-b90d6989a837" />
+  <Project Path="Platform.Mac/Xelqoria.Platform.Mac.vcxproj" Id="2bbdb336-af96-404d-aab6-42c1f36ca1a3">
+    <Configuration Solution="Debug|x64" Project="Debug|x64|NoBuild" />
+    <Configuration Solution="Debug|x86" Project="Debug|Win32|NoBuild" />
+    <Configuration Solution="Release|x64" Project="Release|x64|NoBuild" />
+    <Configuration Solution="Release|x86" Project="Release|Win32|NoBuild" />
+  </Project>
+  <Project Path="Platform.Win32/Xelqoria.Platform.Win32.vcxproj" Id="e121a6f2-effe-44e6-8123-02cced1196fc" />
+  <Project Path="Platform/Xelqoria.Platform.vcxproj" Id="fbc1e45e-2f7b-4e99-b813-916509583283" />
   <Project Path="RHI/Xelqoria.RHI.vcxproj" Id="158b81fc-b108-4237-8a37-eb8c6ef29392" />
   <Project Path="Xelqoria.Math/Xelqoria.Math.vcxproj" Id="9143e43a-0447-43e1-9fe4-9c3edec98212" />
 </Solution>

--- a/tests/Core/Source/InputSystemTests.cpp
+++ b/tests/Core/Source/InputSystemTests.cpp
@@ -12,7 +12,7 @@ TEST(InputSystemTests, KeyPressedIsTrueOnlyOnTransitionToDown)
         },
         []
         {
-            return POINT{ 10, 20 };
+            return Xelqoria::Platform::Point{ 10, 20 };
         });
 
     inputSystem.Update();
@@ -40,7 +40,7 @@ TEST(InputSystemTests, KeyReleasedIsTrueOnlyOnTransitionToUp)
         },
         []
         {
-            return POINT{};
+            return Xelqoria::Platform::Point{};
         });
 
     inputSystem.Update();
@@ -60,11 +60,11 @@ TEST(InputSystemTests, KeyReleasedIsTrueOnlyOnTransitionToUp)
 TEST(InputSystemTests, MouseLeftButtonTracksTransitionsAndCursorPosition)
 {
     bool isLeftButtonDown = false;
-    POINT cursorPoint{ 30, 40 };
+    Xelqoria::Platform::Point cursorPoint{ 30, 40 };
     Xelqoria::Core::InputSystem inputSystem(
         [&isLeftButtonDown](int virtualKeyCode)
         {
-            return virtualKeyCode == VK_LBUTTON && isLeftButtonDown;
+            return virtualKeyCode == 0x01 && isLeftButtonDown;
         },
         [&cursorPoint]
         {
@@ -77,7 +77,7 @@ TEST(InputSystemTests, MouseLeftButtonTracksTransitionsAndCursorPosition)
     EXPECT_EQ(40, inputSystem.GetSnapshot().GetCursorScreenPoint().y);
 
     isLeftButtonDown = true;
-    cursorPoint = POINT{ 50, 60 };
+    cursorPoint = Xelqoria::Platform::Point{ 50, 60 };
     inputSystem.Update();
     EXPECT_TRUE(inputSystem.GetSnapshot().IsMouseButtonDown(Xelqoria::Core::MouseButton::Left));
     EXPECT_TRUE(inputSystem.GetSnapshot().WasMouseButtonPressed(Xelqoria::Core::MouseButton::Left));
@@ -100,7 +100,7 @@ TEST(InputSystemTests, MouseWheelDeltaIsCapturedPerUpdate)
         },
         []
         {
-            return POINT{};
+            return Xelqoria::Platform::Point{};
         },
         [&mouseWheelDelta]
         {

--- a/tests/Core/Xelqoria.Tests.Core.vcxproj
+++ b/tests/Core/Xelqoria.Tests.Core.vcxproj
@@ -29,6 +29,9 @@
     <ProjectReference Include="..\..\Core\Xelqoria.Core.vcxproj">
       <Project>{79E8E826-7407-4766-B731-675CB84F6552}</Project>
     </ProjectReference>
+    <ProjectReference Include="..\..\Platform\Xelqoria.Platform.vcxproj">
+      <Project>{FBC1E45E-2F7B-4E99-B813-916509583283}</Project>
+    </ProjectReference>
   </ItemGroup>
   <PropertyGroup Label="Globals">
     <VCProjectVersion>18.0</VCProjectVersion>
@@ -92,7 +95,7 @@
       <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <LanguageStandard>stdcpp20</LanguageStandard>
-      <AdditionalIncludeDirectories>$(RepoRootDir)Core\Source;$(RepoRootDir)third_party\googletest\googletest\include;$(ProjectDir)Source;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(RepoRootDir)Core\Source;$(RepoRootDir)Platform\Source;$(RepoRootDir)third_party\googletest\googletest\include;$(ProjectDir)Source;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <AdditionalOptions>/utf-8 %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
@@ -112,7 +115,7 @@
       <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <LanguageStandard>stdcpp20</LanguageStandard>
-      <AdditionalIncludeDirectories>$(RepoRootDir)Core\Source;$(RepoRootDir)third_party\googletest\googletest\include;$(ProjectDir)Source;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(RepoRootDir)Core\Source;$(RepoRootDir)Platform\Source;$(RepoRootDir)third_party\googletest\googletest\include;$(ProjectDir)Source;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <AdditionalOptions>/utf-8 %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
@@ -130,7 +133,7 @@
       <PreprocessorDefinitions>_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <LanguageStandard>stdcpp20</LanguageStandard>
-      <AdditionalIncludeDirectories>$(RepoRootDir)Core\Source;$(RepoRootDir)third_party\googletest\googletest\include;$(ProjectDir)Source;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(RepoRootDir)Core\Source;$(RepoRootDir)Platform\Source;$(RepoRootDir)third_party\googletest\googletest\include;$(ProjectDir)Source;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <AdditionalOptions>/utf-8 %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
@@ -150,7 +153,7 @@
       <PreprocessorDefinitions>NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <LanguageStandard>stdcpp20</LanguageStandard>
-      <AdditionalIncludeDirectories>$(RepoRootDir)Core\Source;$(RepoRootDir)third_party\googletest\googletest\include;$(ProjectDir)Source;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(RepoRootDir)Core\Source;$(RepoRootDir)Platform\Source;$(RepoRootDir)third_party\googletest\googletest\include;$(ProjectDir)Source;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <AdditionalOptions>/utf-8 %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>


### PR DESCRIPTION
Parent: #198\nChild: #200\n\n## Summary\n- Move Core Window and InputSystem to Platform abstractions.\n- Add Win32 window, event loop, and input implementations.\n- Wire App and Editor startup through the Win32 Platform factory.\n\n## Verification\n- Pending final parent workflow verification.