### PR TITLE
feat: move docked panel during tab drag

### DIFF
--- a/Editor/Source/EditorShell.cpp
+++ b/Editor/Source/EditorShell.cpp
@@ -1718,11 +1718,14 @@ namespace Xelqoria::Editor
                     m_pendingDockDragPanelId.reset();
                     m_currentGuideTarget = DockGuideTarget{};
                     m_hasDockPreview = false;
+                    BeginDockPanelDrag(*m_dragPanelId, parentWindow, cursorScreenPoint);
+                    changed = true;
                 }
             }
 
             if (DockDragKind::Panel == m_dragKind && m_dragPanelId.has_value())
             {
+                UpdateDockPanelDragWindow(*m_dragPanelId, cursorScreenPoint);
                 UpdateDockGuideWindows(parentWindow, cursorScreenPoint);
                 m_currentGuideTarget = HitTestDockGuideTarget(parentWindow, cursorScreenPoint);
                 m_hasDockPreview = DockGuideTargetKind::None != m_currentGuideTarget.kind
@@ -1777,6 +1780,7 @@ namespace Xelqoria::Editor
             m_pendingDockDragStartTick = 0;
             m_dragSplitNodeId = -1;
             m_hasDockPreview = false;
+            m_dragPanelWindowOffset = POINT{};
             ReleaseCapture();
             HideDockGuideWindows();
             UpdateDockPreviewWindow(parentWindow);
@@ -2636,6 +2640,57 @@ namespace Xelqoria::Editor
 
         SyncDockTabs();
         m_layoutInitialized = false;
+    }
+
+    void EditorShell::BeginDockPanelDrag(EditorPanelId panelId, HWND parentWindow, POINT cursorScreenPoint)
+    {
+        if (nullptr == parentWindow)
+        {
+            return;
+        }
+
+        RECT captionRect = GetPanelCaptionRect(panelId);
+        if (captionRect.right <= captionRect.left || captionRect.bottom <= captionRect.top)
+        {
+            captionRect = RECT{
+                cursorScreenPoint.x - ScaleMetric(24),
+                cursorScreenPoint.y - ScaleMetric(12),
+                cursorScreenPoint.x + ScaleMetric(336),
+                cursorScreenPoint.y + ScaleMetric(348)
+            };
+        }
+
+        m_dragPanelWindowOffset = POINT{
+            (std::max)(ScaleMetric(8), cursorScreenPoint.x - captionRect.left),
+            (std::max)(ScaleMetric(8), cursorScreenPoint.y - captionRect.top)
+        };
+
+        RemovePanelFromDockTree(panelId);
+        const POINT floatingOrigin{
+            cursorScreenPoint.x - m_dragPanelWindowOffset.x,
+            cursorScreenPoint.y - m_dragPanelWindowOffset.y
+        };
+        FloatPanel(panelId, floatingOrigin, parentWindow);
+        SyncDockTabs();
+        m_layoutInitialized = false;
+    }
+
+    void EditorShell::UpdateDockPanelDragWindow(EditorPanelId panelId, POINT cursorScreenPoint)
+    {
+        HWND floatingWindow = GetFloatingWindowRef(panelId);
+        if (nullptr == floatingWindow)
+        {
+            return;
+        }
+
+        SetWindowPos(
+            floatingWindow,
+            HWND_TOP,
+            cursorScreenPoint.x - m_dragPanelWindowOffset.x,
+            cursorScreenPoint.y - m_dragPanelWindowOffset.y,
+            0,
+            0,
+            SWP_NOSIZE | SWP_NOACTIVATE | SWP_SHOWWINDOW);
     }
 
     void EditorShell::FloatPanel(EditorPanelId panelId, POINT screenPoint, HWND parentWindow)

--- a/Editor/Source/EditorShell.h
+++ b/Editor/Source/EditorShell.h
@@ -536,6 +536,16 @@ namespace Xelqoria::Editor
         void MovePanelToDockArea(EditorPanelId panelId, DockAreaId dockAreaId, HWND parentWindow);
 
         /// <summary>
+        /// Dock タブからのパネルドラッグを開始し、ビュー本体を追従用 window へ移す。
+        /// </summary>
+        void BeginDockPanelDrag(EditorPanelId panelId, HWND parentWindow, POINT cursorScreenPoint);
+
+        /// <summary>
+        /// ドラッグ中のパネル本体をカーソル位置へ追従させる。
+        /// </summary>
+        void UpdateDockPanelDragWindow(EditorPanelId panelId, POINT cursorScreenPoint);
+
+        /// <summary>
         /// 指定パネルをフローティングウィンドウへ移動する。
         /// </summary>
         void FloatPanel(EditorPanelId panelId, POINT screenPoint, HWND parentWindow);
@@ -813,6 +823,7 @@ namespace Xelqoria::Editor
         bool m_hasDockPreview = false;
         RECT m_dockPreviewRect{};
         POINT m_dragStartScreenPoint{};
+        POINT m_dragPanelWindowOffset{};
         ULONGLONG m_pendingDockDragStartTick = 0;
         DockNodeId m_dragSplitNodeId = -1;
         float m_dragStartSplitRatio = 0.5f;

--- a/docs/plans/issue-219-dragging-panel-follow.md
+++ b/docs/plans/issue-219-dragging-panel-follow.md
@@ -1,0 +1,50 @@
+# ExecPlan: issue-219 ドラッグ中のビュー本体追従を安定化する
+
+## 目的
+
+ビュータブをドラッグしている間、ビュー本体を元の配置場所から一時的に取り外し、マウスに追従させる。
+
+## 対象範囲
+
+- 変更対象プロジェクト: Editor
+- 変更対象ファイル: `Editor/Source/EditorShell.cpp`, `Editor/Source/EditorShell.h`
+- 変更対象クラス: `Xelqoria::Editor::EditorShell`
+- 影響する機能: Dock タブドラッグ、ドラッグ中のパネル表示、ドロップ時の配置確定
+
+## 前提
+
+- parent issue: issue-214
+- ブランチ運用ルール: `branch-rules.md`
+- parent issue ブランチ: `issue-214`
+- この child issue のブランチ: `issue-219`
+- PR の向き: `issue-219` から `issue-214`
+
+## 実装方針
+
+Editor 専用の Win32 UI シェルである `EditorShell` 内に責務を閉じる。
+
+既存の floating panel window と Dock ガイド経路を使い、Dock タブからのドラッグ開始時に対象パネルを Dock ツリーから一時的に取り外す。ドラッグ中は floating window をカーソル位置へ追従させ、ドロップ時は既存の Dock ガイド適用処理で配置を確定する。
+
+## 作業手順
+
+1. 関連コードを確認する
+2. Dock タブドラッグ開始時にパネル本体を元 Dock leaf から取り外す
+3. ドラッグ中に floating window をカーソルへ追従させる
+4. ドラッグ終了時に既存の Dock ガイド処理へ接続する
+5. ビルドまたは関連テストを実行する
+6. `branch-rules.md` に従って PR を作成する
+
+## 検証方法
+
+- 実行するビルド: `tests/Editor/Xelqoria.Tests.Editor.vcxproj` Debug x64
+- 実行するテスト: `artifacts/x64/Debug/Xelqoria.Tests.Editor.exe`
+- 手動確認項目: タブドラッグ中に対象ビュー本体が元位置に残らず、カーソルへ追従し、ドロップ後に配置が確定すること
+
+## 完了条件
+
+- ビュータブをドラッグ中、ビュー本体がマウスに追従する
+- ドラッグ中、元の配置場所にビュー本体が残り続けない
+- ドラッグ終了時、ドロップ結果に応じてビューが配置される
+- レイヤー責務に違反していない
+- 不要な変更が含まれていない
+- `branch-rules.md` に従った PR が作成されている


### PR DESCRIPTION
## Summary
- Parent issue: #214
- Child issue: #219
- Detach the panel from the dock tree when a tab drag starts so the original location no longer keeps rendering the view body.
- Reuse the floating panel window path to keep the dragged view body following the cursor until drop.
- Add the child issue ExecPlan for drag-follow behavior.

## Verification
- Built: tests/Editor/Xelqoria.Tests.Editor.vcxproj Debug|x64
- Ran: ./artifacts/x64/Debug/Xelqoria.Tests.Editor.exe (66 passed)