### PR TITLE
feat: support floating window tabs

### DIFF
--- a/Editor/Source/EditorShell.cpp
+++ b/Editor/Source/EditorShell.cpp
@@ -2415,6 +2415,15 @@ namespace Xelqoria::Editor
         if (DockGuideTargetKind::None == guideTarget.kind || DockGuideTargetKind::Float == guideTarget.kind)
         {
             const POINT cursorScreenPoint = GetCursorScreenPoint(m_cursor);
+            const HWND targetFloatingWindow = HitTestFloatingWindow(cursorScreenPoint, GetFloatingWindowRef(panelId));
+            if (nullptr != targetFloatingWindow)
+            {
+                AttachPanelToFloatingWindow(panelId, targetFloatingWindow);
+                SyncDockTabs();
+                m_layoutInitialized = false;
+                return;
+            }
+
             RemovePanelFromDockTree(panelId);
             FloatPanel(panelId, cursorScreenPoint, parentWindow);
             SyncDockTabs();
@@ -2737,9 +2746,27 @@ namespace Xelqoria::Editor
         }
         GetFloatingWindowRef(panelId) = floatingWindow;
 
+        HWND tabControl = CreateChildWindow(
+            floatingWindow,
+            reinterpret_cast<HINSTANCE>(GetWindowLongPtrW(parentWindow, GWLP_HINSTANCE)),
+            WC_TABCONTROLW,
+            L"",
+            WS_CHILD | WS_VISIBLE | WS_CLIPSIBLINGS | TCS_TABS);
+        if (nullptr != tabControl)
+        {
+            SendMessageW(tabControl, WM_SETFONT, reinterpret_cast<WPARAM>(m_defaultFont), TRUE);
+        }
+        m_floatingPanelGroups.push_back(FloatingPanelGroup{
+            floatingWindow,
+            tabControl,
+            { panelId },
+            0
+        });
+
         SetPanelParent(panelId, floatingWindow);
         ShowPanelControls(panelId, true);
-        LayoutFloatingPanel(panelId, floatingWindow);
+        SyncFloatingPanelTabs(floatingWindow);
+        LayoutFloatingWindow(floatingWindow);
     }
 
     void EditorShell::BeginFloatingWindowDockDrag(EditorPanelId panelId)
@@ -2795,6 +2822,12 @@ namespace Xelqoria::Editor
 
         if (DockGuideTargetKind::None == guideTarget.kind || DockGuideTargetKind::Float == guideTarget.kind)
         {
+            const HWND targetFloatingWindow =
+                HitTestFloatingWindow(GetCursorScreenPoint(m_cursor), GetFloatingWindowRef(panelId));
+            if (nullptr != targetFloatingWindow)
+            {
+                AttachPanelToFloatingWindow(panelId, targetFloatingWindow);
+            }
             return;
         }
 
@@ -2804,22 +2837,62 @@ namespace Xelqoria::Editor
 
     void EditorShell::LayoutFloatingPanel(EditorPanelId panelId, HWND floatingWindow)
     {
+        (void)panelId;
         if (nullptr == floatingWindow)
         {
             return;
         }
 
+        LayoutFloatingWindow(floatingWindow);
+    }
+
+    void EditorShell::LayoutFloatingWindow(HWND floatingWindow)
+    {
+        const int groupIndex = FindFloatingPanelGroupIndex(floatingWindow);
+        if (groupIndex < 0)
+        {
+            return;
+        }
+
+        FloatingPanelGroup& group = m_floatingPanelGroups[static_cast<std::size_t>(groupIndex)];
         RECT clientRect{};
         GetClientRect(floatingWindow, &clientRect);
         const int padding = ScaleMetric(8);
+        const int tabHeight = ScaleMetric(28);
+        const bool showsTabs = nullptr != group.tabControl && group.panels.size() > 1;
+        if (nullptr != group.tabControl)
+        {
+            if (showsTabs)
+            {
+                MoveChildWindowNoRedraw(
+                    group.tabControl,
+                    clientRect.left + padding,
+                    clientRect.top + padding,
+                    (std::max)(0, static_cast<int>(clientRect.right - clientRect.left) - padding * 2),
+                    tabHeight);
+                ShowWindow(group.tabControl, SW_SHOW);
+            }
+            else
+            {
+                ShowWindow(group.tabControl, SW_HIDE);
+            }
+        }
+
+        group.activeTabIndex = (std::max)(0, (std::min)(group.activeTabIndex, static_cast<int>(group.panels.size()) - 1));
+        const EditorPanelId activePanelId = group.panels[static_cast<std::size_t>(group.activeTabIndex)];
+        for (EditorPanelId panelId : group.panels)
+        {
+            ShowPanelControls(panelId, activePanelId == panelId);
+        }
+
         const RECT panelRect{
             clientRect.left + padding,
-            clientRect.top + padding,
+            clientRect.top + padding + (showsTabs ? tabHeight + ScaleMetric(4) : 0),
             (std::max)(clientRect.left + padding, clientRect.right - padding),
             (std::max)(clientRect.top + padding, clientRect.bottom - padding)
         };
 
-        switch (panelId)
+        switch (activePanelId)
         {
         case EditorPanelId::Hierarchy:
             LayoutHierarchyPanelInRect(panelRect);
@@ -2842,48 +2915,78 @@ namespace Xelqoria::Editor
 
         SendGroupBoxesToBack();
         RedrawLayout(floatingWindow);
-        if (EditorPanelId::SceneView == panelId)
+        if (EditorPanelId::SceneView == activePanelId)
         {
             (void)UpdateSceneViewHostSize();
         }
     }
 
-    void EditorShell::HandleFloatingWindowClose(EditorPanelId panelId, HWND floatingWindow)
+    void EditorShell::AttachPanelToFloatingWindow(EditorPanelId panelId, HWND floatingWindow)
     {
-        HWND& floatingWindowRef = GetFloatingWindowRef(panelId);
-        if (floatingWindowRef == floatingWindow)
+        const HWND targetWindow = floatingWindow;
+        DestroyFloatingWindow(panelId);
+        const int targetGroupIndex = FindFloatingPanelGroupIndex(floatingWindow);
+        if (targetGroupIndex < 0)
         {
-            floatingWindowRef = nullptr;
+            return;
         }
 
-        SetPanelParent(panelId, m_parentWindow);
-        RemovePanelFromDockTree(panelId, false);
-
-        DockNodeId targetLeafNodeId = -1;
-        std::vector<DockNodeId> dockLeafNodeIds{};
-        CollectReachableDockLeaves(m_rootDockNodeId, dockLeafNodeIds);
-        for (DockNodeId dockNodeId : dockLeafNodeIds)
+        FloatingPanelGroup& targetGroup = m_floatingPanelGroups[static_cast<std::size_t>(targetGroupIndex)];
+        if (targetGroup.panels.end() == std::find(targetGroup.panels.begin(), targetGroup.panels.end(), panelId))
         {
-            const DockNode& dockNode = m_dockNodes[static_cast<std::size_t>(dockNodeId)];
-            if (dockNode.tabControl == m_centerDockTab)
+            targetGroup.panels.push_back(panelId);
+        }
+        targetGroup.activeTabIndex = static_cast<int>(targetGroup.panels.size()) - 1;
+        GetFloatingWindowRef(panelId) = targetWindow;
+        SetPanelParent(panelId, targetWindow);
+        ShowPanelControls(panelId, true);
+        SyncFloatingPanelTabs(targetWindow);
+        LayoutFloatingWindow(targetWindow);
+    }
+
+    HWND EditorShell::HitTestFloatingWindow(POINT cursorScreenPoint, HWND excludedWindow) const
+    {
+        for (const FloatingPanelGroup& group : m_floatingPanelGroups)
+        {
+            if (nullptr == group.window || group.window == excludedWindow || false == IsWindowVisible(group.window))
             {
-                targetLeafNodeId = dockNodeId;
-                break;
+                continue;
+            }
+
+            RECT windowRect{};
+            GetWindowRect(group.window, &windowRect);
+            if (PtInRect(&windowRect, cursorScreenPoint))
+            {
+                return group.window;
             }
         }
 
-        if (targetLeafNodeId < 0 && false == dockLeafNodeIds.empty())
+        return nullptr;
+    }
+
+    void EditorShell::HandleFloatingWindowClose(EditorPanelId panelId, HWND floatingWindow)
+    {
+        (void)panelId;
+        const int groupIndex = FindFloatingPanelGroupIndex(floatingWindow);
+        if (groupIndex < 0)
         {
-            targetLeafNodeId = dockLeafNodeIds.front();
+            return;
         }
 
-        if (0 <= targetLeafNodeId && static_cast<std::size_t>(targetLeafNodeId) < m_dockNodes.size())
+        const FloatingPanelGroup group = m_floatingPanelGroups[static_cast<std::size_t>(groupIndex)];
+        for (EditorPanelId floatingPanelId : group.panels)
         {
-            DockNode& dockNode = m_dockNodes[static_cast<std::size_t>(targetLeafNodeId)];
-            dockNode.panels.push_back(panelId);
-            dockNode.activeTabIndex = static_cast<int>(dockNode.panels.size()) - 1;
+            HWND& floatingWindowRef = GetFloatingWindowRef(floatingPanelId);
+            if (floatingWindowRef == floatingWindow)
+            {
+                floatingWindowRef = nullptr;
+            }
+            SetPanelParent(floatingPanelId, m_parentWindow);
+            RemovePanelFromDockTree(floatingPanelId, false);
+            ShowPanelControls(floatingPanelId, false);
         }
 
+        m_floatingPanelGroups.erase(m_floatingPanelGroups.begin() + groupIndex);
         SyncDockTabs();
         m_layoutInitialized = false;
         DestroyWindow(floatingWindow);
@@ -2892,13 +2995,38 @@ namespace Xelqoria::Editor
     void EditorShell::DestroyFloatingWindow(EditorPanelId panelId)
     {
         HWND& floatingWindow = GetFloatingWindowRef(panelId);
-        if (nullptr != floatingWindow)
+        if (nullptr == floatingWindow)
         {
-            SetPanelParent(panelId, m_parentWindow);
-            const HWND windowToDestroy = floatingWindow;
-            floatingWindow = nullptr;
-            DestroyWindow(windowToDestroy);
+            return;
         }
+
+        const HWND windowToUpdate = floatingWindow;
+        SetPanelParent(panelId, m_parentWindow);
+        floatingWindow = nullptr;
+
+        const int groupIndex = FindFloatingPanelGroupIndex(windowToUpdate);
+        if (groupIndex < 0)
+        {
+            DestroyWindow(windowToUpdate);
+            return;
+        }
+
+        FloatingPanelGroup& group = m_floatingPanelGroups[static_cast<std::size_t>(groupIndex)];
+        group.panels.erase(std::remove(group.panels.begin(), group.panels.end(), panelId), group.panels.end());
+        if (group.activeTabIndex >= static_cast<int>(group.panels.size()))
+        {
+            group.activeTabIndex = (std::max)(0, static_cast<int>(group.panels.size()) - 1);
+        }
+
+        if (group.panels.empty())
+        {
+            m_floatingPanelGroups.erase(m_floatingPanelGroups.begin() + groupIndex);
+            DestroyWindow(windowToUpdate);
+            return;
+        }
+
+        SyncFloatingPanelTabs(windowToUpdate);
+        LayoutFloatingWindow(windowToUpdate);
     }
 
     HWND& EditorShell::GetFloatingWindowRef(EditorPanelId panelId)
@@ -2918,6 +3046,77 @@ namespace Xelqoria::Editor
         default:
             return m_sceneViewFloatingWindow;
         }
+    }
+
+    void EditorShell::SyncFloatingPanelTabs(HWND floatingWindow)
+    {
+        const int groupIndex = FindFloatingPanelGroupIndex(floatingWindow);
+        if (groupIndex < 0)
+        {
+            return;
+        }
+
+        FloatingPanelGroup& group = m_floatingPanelGroups[static_cast<std::size_t>(groupIndex)];
+        if (nullptr == group.tabControl)
+        {
+            return;
+        }
+
+        TabCtrl_DeleteAllItems(group.tabControl);
+        for (std::size_t index = 0; index < group.panels.size(); ++index)
+        {
+            TCITEMW item{};
+            item.mask = TCIF_TEXT;
+            item.pszText = const_cast<LPWSTR>(GetPanelTitle(group.panels[index]));
+            TabCtrl_InsertItem(group.tabControl, static_cast<int>(index), &item);
+        }
+        group.activeTabIndex = (std::max)(0, (std::min)(group.activeTabIndex, static_cast<int>(group.panels.size()) - 1));
+        TabCtrl_SetCurSel(group.tabControl, group.activeTabIndex);
+    }
+
+    int EditorShell::FindFloatingPanelGroupIndex(HWND floatingWindow) const
+    {
+        for (std::size_t index = 0; index < m_floatingPanelGroups.size(); ++index)
+        {
+            if (m_floatingPanelGroups[index].window == floatingWindow)
+            {
+                return static_cast<int>(index);
+            }
+        }
+
+        return -1;
+    }
+
+    int EditorShell::FindFloatingPanelGroupIndex(EditorPanelId panelId) const
+    {
+        for (std::size_t index = 0; index < m_floatingPanelGroups.size(); ++index)
+        {
+            const std::vector<EditorPanelId>& panels = m_floatingPanelGroups[index].panels;
+            if (panels.end() != std::find(panels.begin(), panels.end(), panelId))
+            {
+                return static_cast<int>(index);
+            }
+        }
+
+        return -1;
+    }
+
+    EditorShell::EditorPanelId EditorShell::GetActiveFloatingPanel(HWND floatingWindow) const
+    {
+        const int groupIndex = FindFloatingPanelGroupIndex(floatingWindow);
+        if (groupIndex < 0)
+        {
+            return EditorPanelId::SceneView;
+        }
+
+        const FloatingPanelGroup& group = m_floatingPanelGroups[static_cast<std::size_t>(groupIndex)];
+        if (group.panels.empty())
+        {
+            return EditorPanelId::SceneView;
+        }
+
+        const int activeIndex = (std::max)(0, (std::min)(group.activeTabIndex, static_cast<int>(group.panels.size()) - 1));
+        return group.panels[static_cast<std::size_t>(activeIndex)];
     }
 
     void EditorShell::SyncDockTabs()
@@ -3427,19 +3626,36 @@ namespace Xelqoria::Editor
         {
             if (WM_SIZE == message)
             {
-                windowData->shell->LayoutFloatingPanel(windowData->panelId, window);
+                windowData->shell->LayoutFloatingWindow(window);
                 return 0;
+            }
+
+            if (WM_NOTIFY == message)
+            {
+                NMHDR* notifyHeader = reinterpret_cast<NMHDR*>(lParam);
+                const int groupIndex = windowData->shell->FindFloatingPanelGroupIndex(window);
+                if (nullptr != notifyHeader
+                    && groupIndex >= 0
+                    && TCN_SELCHANGE == notifyHeader->code
+                    && notifyHeader->hwndFrom == windowData->shell->m_floatingPanelGroups[static_cast<std::size_t>(groupIndex)].tabControl)
+                {
+                    FloatingPanelGroup& group =
+                        windowData->shell->m_floatingPanelGroups[static_cast<std::size_t>(groupIndex)];
+                    group.activeTabIndex = TabCtrl_GetCurSel(group.tabControl);
+                    windowData->shell->LayoutFloatingWindow(window);
+                    return 0;
+                }
             }
 
             if (WM_MOVING == message)
             {
-                windowData->shell->BeginFloatingWindowDockDrag(windowData->panelId);
+                windowData->shell->BeginFloatingWindowDockDrag(windowData->shell->GetActiveFloatingPanel(window));
                 windowData->shell->UpdateFloatingWindowDockDrag();
             }
 
             if (WM_EXITSIZEMOVE == message)
             {
-                windowData->shell->CompleteFloatingWindowDockDrag(windowData->panelId);
+                windowData->shell->CompleteFloatingWindowDockDrag(windowData->shell->GetActiveFloatingPanel(window));
             }
 
             if (WM_CLOSE == message)

--- a/Editor/Source/EditorShell.h
+++ b/Editor/Source/EditorShell.h
@@ -561,6 +561,21 @@ namespace Xelqoria::Editor
         void LayoutFloatingPanel(EditorPanelId panelId, HWND floatingWindow);
 
         /// <summary>
+        /// 指定フローティングウィンドウ内の表示パネルを現在のタブ選択に合わせて配置する。
+        /// </summary>
+        void LayoutFloatingWindow(HWND floatingWindow);
+
+        /// <summary>
+        /// 指定パネルを既存のフローティングウィンドウへタブとして追加する。
+        /// </summary>
+        void AttachPanelToFloatingWindow(EditorPanelId panelId, HWND floatingWindow);
+
+        /// <summary>
+        /// カーソル位置にあるフローティングウィンドウを返す。
+        /// </summary>
+        [[nodiscard]] HWND HitTestFloatingWindow(POINT cursorScreenPoint, HWND excludedWindow) const;
+
+        /// <summary>
         /// フローティングウィンドウの移動による Dock 操作を開始する。
         /// </summary>
         void BeginFloatingWindowDockDrag(EditorPanelId panelId);
@@ -589,6 +604,26 @@ namespace Xelqoria::Editor
         /// 指定パネルに対応するフローティングウィンドウ格納先を返す。
         /// </summary>
         [[nodiscard]] HWND& GetFloatingWindowRef(EditorPanelId panelId);
+
+        /// <summary>
+        /// 指定フローティングウィンドウのタブ表示を同期する。
+        /// </summary>
+        void SyncFloatingPanelTabs(HWND floatingWindow);
+
+        /// <summary>
+        /// 指定フローティングウィンドウに対応する group index を返す。
+        /// </summary>
+        [[nodiscard]] int FindFloatingPanelGroupIndex(HWND floatingWindow) const;
+
+        /// <summary>
+        /// 指定パネルを含む floating group index を返す。
+        /// </summary>
+        [[nodiscard]] int FindFloatingPanelGroupIndex(EditorPanelId panelId) const;
+
+        /// <summary>
+        /// 指定フローティングウィンドウで現在選択されているパネルを返す。
+        /// </summary>
+        [[nodiscard]] EditorPanelId GetActiveFloatingPanel(HWND floatingWindow) const;
 
         /// <summary>
         /// Dock TabControl の表示を現在状態へ同期する。
@@ -749,6 +784,14 @@ namespace Xelqoria::Editor
             EditorPanelId panelId = EditorPanelId::SceneView;
         };
 
+        struct FloatingPanelGroup
+        {
+            HWND window = nullptr;
+            HWND tabControl = nullptr;
+            std::vector<EditorPanelId> panels{};
+            int activeTabIndex = 0;
+        };
+
         HFONT m_defaultFont = nullptr;
         UINT m_currentDpi = 96;
         bool m_ownsDefaultFont = false;
@@ -765,6 +808,7 @@ namespace Xelqoria::Editor
         HWND m_sceneViewFloatingWindow = nullptr;
         HWND m_inspectorFloatingWindow = nullptr;
         HWND m_logOutputFloatingWindow = nullptr;
+        std::vector<FloatingPanelGroup> m_floatingPanelGroups{};
         HWND m_hierarchyPanel = nullptr;
         HWND m_assetsPanel = nullptr;
         HWND m_inspectorPanel = nullptr;

--- a/docs/plans/issue-216-floating-window-tabs.md
+++ b/docs/plans/issue-216-floating-window-tabs.md
@@ -1,0 +1,52 @@
+# ExecPlan: issue-216 独立ウィンドウ化と独立ウィンドウ内タブ化を整備する
+
+## 目的
+
+タブ化されたビューを独立ウィンドウ化し、独立ウィンドウ内でも複数ビューをタブとしてまとめられるようにする。
+
+## 対象範囲
+
+- 変更対象プロジェクト: Editor
+- 変更対象ファイル: `Editor/Source/EditorShell.cpp`, `Editor/Source/EditorShell.h`
+- 変更対象クラス: `Xelqoria::Editor::EditorShell`
+- 影響する機能: 独立ウィンドウ、独立ウィンドウ内タブ、独立ウィンドウ close 時の非表示化
+
+## 前提
+
+- parent issue: issue-214
+- ブランチ運用ルール: `branch-rules.md`
+- parent issue ブランチ: `issue-214`
+- この child issue のブランチ: `issue-216`
+- PR の向き: `issue-216` から `issue-214`
+
+## 実装方針
+
+Editor 専用の Win32 UI シェルである `EditorShell` 内に責務を閉じる。
+
+既存の Dock ガイドや配置先仕様は変更せず、floating window 側に複数パネルを保持できるタブグループを追加する。独立ウィンドウを閉じた場合は、その window に含まれるビューを Dock へ戻さず非表示にする。
+
+## 作業手順
+
+1. 関連コードを確認する
+2. floating window ごとの panel group と TabControl を追加する
+3. floating window 内のタブ切り替えで表示 panel を切り替える
+4. drag/drop で既存 floating window へ panel をまとめられるようにする
+5. floating window close 時に含まれる panel を非表示にする
+6. ビルドまたは関連テストを実行する
+7. `branch-rules.md` に従って PR を作成する
+
+## 検証方法
+
+- 実行するビルド: `tests/Editor/Xelqoria.Tests.Editor.vcxproj` Debug x64
+- 実行するテスト: `artifacts/x64/Debug/Xelqoria.Tests.Editor.exe`
+- 手動確認項目: 独立ウィンドウ化、メインウィンドウ外移動、独立ウィンドウ内タブ化、close 時の非表示化
+
+## 完了条件
+
+- タブ化されたビューをドラッグして独立ウィンドウ化できる
+- 独立ウィンドウ化したビューをメインウィンドウ外へ移動できる
+- 独立ウィンドウ内で複数ビューをタブ化できる
+- 独立ウィンドウ化したビューを閉じると、そのビューは非表示になる
+- レイヤー責務に違反していない
+- 不要な変更が含まれていない
+- `branch-rules.md` に従った PR が作成されている


### PR DESCRIPTION
## Summary
- Parent issue: #214
- Child issue: #216
- Add floating window tab groups so multiple views can be grouped inside one independent window.
- Allow dropping a dragged view onto an existing floating window to tab it there.
- Change floating window close behavior to hide contained views instead of re-docking them.
- Add the child issue ExecPlan for floating window tabs.

## Verification
- Built: tests/Editor/Xelqoria.Tests.Editor.vcxproj Debug|x64
- Ran: ./artifacts/x64/Debug/Xelqoria.Tests.Editor.exe (66 passed)