### PR TITLE
feat: add view restore menu

### DIFF
--- a/Editor/Source/Application.cpp
+++ b/Editor/Source/Application.cpp
@@ -34,6 +34,11 @@ namespace Xelqoria::Editor
         constexpr unsigned ProjectMenuOpenCommandId = 5104;
         constexpr unsigned ProjectMenuSettingsCommandId = 5105;
         constexpr unsigned ProjectMenuResetLayoutCommandId = 5106;
+        constexpr unsigned ViewMenuHierarchyCommandId = 5201;
+        constexpr unsigned ViewMenuAssetsCommandId = 5202;
+        constexpr unsigned ViewMenuSceneViewCommandId = 5203;
+        constexpr unsigned ViewMenuInspectorCommandId = 5204;
+        constexpr unsigned ViewMenuLogOutputCommandId = 5205;
 
         [[nodiscard]] std::filesystem::path SelectProjectFile(
             Platform::IFileDialog& fileDialog,
@@ -376,6 +381,7 @@ namespace Xelqoria::Editor
     void Application::InitializeProjectMenu()
     {
         m_projectMenu = CreatePopupMenu();
+        m_viewMenu = CreatePopupMenu();
         AppendMenuW(m_projectMenu, MF_STRING, ProjectMenuCreateCommandId, L"プロジェクトを作成する");
         AppendMenuW(m_projectMenu, MF_STRING, ProjectMenuSaveCommandId, L"プロジェクトを保存する");
         AppendMenuW(m_projectMenu, MF_STRING, ProjectMenuSaveAsCommandId, L"プロジェクトを別名で保存する");
@@ -384,8 +390,15 @@ namespace Xelqoria::Editor
         AppendMenuW(m_projectMenu, MF_SEPARATOR, 0, nullptr);
         AppendMenuW(m_projectMenu, MF_STRING, ProjectMenuResetLayoutCommandId, L"画面レイアウトを初期状態に戻す");
 
+        AppendMenuW(m_viewMenu, MF_STRING, ViewMenuHierarchyCommandId, L"Hierarchy");
+        AppendMenuW(m_viewMenu, MF_STRING, ViewMenuAssetsCommandId, L"Assets");
+        AppendMenuW(m_viewMenu, MF_STRING, ViewMenuSceneViewCommandId, L"SceneView");
+        AppendMenuW(m_viewMenu, MF_STRING, ViewMenuInspectorCommandId, L"Inspector");
+        AppendMenuW(m_viewMenu, MF_STRING, ViewMenuLogOutputCommandId, L"LogOutput");
+
         HMENU menuBar = CreateMenu();
         AppendMenuW(menuBar, MF_POPUP, reinterpret_cast<UINT_PTR>(m_projectMenu), L"プロジェクト");
+        AppendMenuW(menuBar, MF_POPUP, reinterpret_cast<UINT_PTR>(m_viewMenu), L"表示");
         SetMenu(GetMainWindowHandle(), menuBar);
     }
 
@@ -416,6 +429,36 @@ namespace Xelqoria::Editor
             {
                 m_editorShell.ResetDockLayout();
                 SetWindowTextW(m_editorShell.GetSceneViewPlanLabel(), L"画面レイアウトを初期状態に戻しました。");
+            }
+            break;
+        case ViewMenuHierarchyCommandId:
+            if (m_editorInitialized)
+            {
+                m_editorShell.ShowPanelAtDefaultDock(EditorShell::EditorPanelId::Hierarchy);
+            }
+            break;
+        case ViewMenuAssetsCommandId:
+            if (m_editorInitialized)
+            {
+                m_editorShell.ShowPanelAtDefaultDock(EditorShell::EditorPanelId::Assets);
+            }
+            break;
+        case ViewMenuSceneViewCommandId:
+            if (m_editorInitialized)
+            {
+                m_editorShell.ShowPanelAtDefaultDock(EditorShell::EditorPanelId::SceneView);
+            }
+            break;
+        case ViewMenuInspectorCommandId:
+            if (m_editorInitialized)
+            {
+                m_editorShell.ShowPanelAtDefaultDock(EditorShell::EditorPanelId::Inspector);
+            }
+            break;
+        case ViewMenuLogOutputCommandId:
+            if (m_editorInitialized)
+            {
+                m_editorShell.ShowPanelAtDefaultDock(EditorShell::EditorPanelId::LogOutput);
             }
             break;
         default:

--- a/Editor/Source/Application.h
+++ b/Editor/Source/Application.h
@@ -289,6 +289,7 @@ namespace Xelqoria::Editor
         bool m_editorInitialized = false;
         bool m_projectDirty = false;
         HMENU m_projectMenu = nullptr;
+        HMENU m_viewMenu = nullptr;
         Platform::Win32::Win32FileDialog m_fileDialog{};
         Platform::Win32::Win32Clipboard m_clipboard{};
         Platform::Win32::Win32Cursor m_cursor{};

--- a/Editor/Source/EditorShell.cpp
+++ b/Editor/Source/EditorShell.cpp
@@ -1081,6 +1081,7 @@ namespace Xelqoria::Editor
         logOutputNode.kind = DockNodeKind::Leaf;
         logOutputNode.panels = { EditorPanelId::LogOutput };
         logOutputNode.tabControl = CreateAdditionalDockTabControl(m_parentWindow);
+        m_logOutputDockTab = logOutputNode.tabControl;
         const DockNodeId logOutputNodeId = AddDockNode(std::move(logOutputNode));
 
         DockNode inspectorNode{};
@@ -1232,6 +1233,85 @@ namespace Xelqoria::Editor
         const DockNodeId dockNodeId = static_cast<DockNodeId>(m_dockNodes.size());
         m_dockNodes.push_back(std::move(node));
         return dockNodeId;
+    }
+
+    EditorShell::DockNodeId EditorShell::EnsureDefaultDockLeaf(EditorPanelId panelId)
+    {
+        HWND targetTabControl = GetDefaultDockTabControl(panelId);
+        std::vector<DockNodeId> dockLeafNodeIds{};
+        CollectReachableDockLeaves(m_rootDockNodeId, dockLeafNodeIds);
+        for (DockNodeId dockNodeId : dockLeafNodeIds)
+        {
+            const DockNode& dockNode = m_dockNodes[static_cast<std::size_t>(dockNodeId)];
+            if (DockNodeKind::Leaf == dockNode.kind && dockNode.tabControl == targetTabControl)
+            {
+                return dockNodeId;
+            }
+        }
+
+        if (EditorPanelId::LogOutput == panelId || nullptr == targetTabControl)
+        {
+            targetTabControl = CreateAdditionalDockTabControl(m_parentWindow);
+            if (EditorPanelId::LogOutput == panelId)
+            {
+                m_logOutputDockTab = targetTabControl;
+            }
+        }
+
+        DockNode newLeaf{};
+        newLeaf.kind = DockNodeKind::Leaf;
+        newLeaf.tabControl = targetTabControl;
+        const DockNodeId newLeafNodeId = AddDockNode(std::move(newLeaf));
+        if (m_rootDockNodeId < 0 || static_cast<std::size_t>(m_rootDockNodeId) >= m_dockNodes.size())
+        {
+            m_rootDockNodeId = newLeafNodeId;
+            return newLeafNodeId;
+        }
+
+        const DockNode oldRootNode = m_dockNodes[static_cast<std::size_t>(m_rootDockNodeId)];
+        const DockNodeId oldRootNodeId = AddDockNode(oldRootNode);
+        DockNode splitNode{};
+        splitNode.kind = DockNodeKind::Split;
+        splitNode.splitOrientation =
+            EditorPanelId::LogOutput == panelId || EditorPanelId::SceneView == panelId
+                ? DockSplitOrientation::Vertical
+                : DockSplitOrientation::Horizontal;
+        splitNode.splitRatio = 0.5f;
+
+        if (EditorPanelId::Hierarchy == panelId || EditorPanelId::Assets == panelId || EditorPanelId::SceneView == panelId)
+        {
+            splitNode.firstChild = newLeafNodeId;
+            splitNode.secondChild = oldRootNodeId;
+            splitNode.splitRatio = EditorPanelId::SceneView == panelId ? 0.70f : 0.18f;
+        }
+        else
+        {
+            splitNode.firstChild = oldRootNodeId;
+            splitNode.secondChild = newLeafNodeId;
+            splitNode.splitRatio = EditorPanelId::LogOutput == panelId ? 0.75f : 0.84f;
+        }
+
+        m_dockNodes[static_cast<std::size_t>(m_rootDockNodeId)] = splitNode;
+        return newLeafNodeId;
+    }
+
+    HWND EditorShell::GetDefaultDockTabControl(EditorPanelId panelId)
+    {
+        switch (panelId)
+        {
+        case EditorPanelId::Hierarchy:
+            return m_leftTopDockTab;
+        case EditorPanelId::Assets:
+            return m_leftBottomDockTab;
+        case EditorPanelId::SceneView:
+            return m_centerDockTab;
+        case EditorPanelId::Inspector:
+            return m_rightDockTab;
+        case EditorPanelId::LogOutput:
+            return m_logOutputDockTab;
+        default:
+            return m_centerDockTab;
+        }
     }
 
     void EditorShell::LayoutHierarchyPanelInRect(const RECT& panelRect)
@@ -1835,6 +1915,7 @@ namespace Xelqoria::Editor
             }
         }
         m_dynamicDockTabs.clear();
+        m_logOutputDockTab = nullptr;
         m_hasDockPreview = false;
         m_currentGuideTarget = DockGuideTarget{};
         m_pendingDockDragPanelId.reset();
@@ -1855,6 +1936,33 @@ namespace Xelqoria::Editor
         DestroyFloatingWindow(EditorPanelId::SceneView);
         DestroyFloatingWindow(EditorPanelId::Inspector);
         DestroyFloatingWindow(EditorPanelId::LogOutput);
+        SyncDockTabs();
+        m_layoutInitialized = false;
+    }
+
+    void EditorShell::ShowPanelAtDefaultDock(EditorPanelId panelId)
+    {
+        if (nullptr == m_parentWindow)
+        {
+            return;
+        }
+
+        RemovePanelFromDockTree(panelId);
+        DestroyFloatingWindow(panelId);
+        SetPanelParent(panelId, m_parentWindow);
+        const DockNodeId targetDockNodeId = EnsureDefaultDockLeaf(panelId);
+        if (targetDockNodeId < 0 || static_cast<std::size_t>(targetDockNodeId) >= m_dockNodes.size())
+        {
+            return;
+        }
+
+        DockNode& targetDockNode = m_dockNodes[static_cast<std::size_t>(targetDockNodeId)];
+        if (targetDockNode.panels.end() == std::find(targetDockNode.panels.begin(), targetDockNode.panels.end(), panelId))
+        {
+            targetDockNode.panels.push_back(panelId);
+        }
+        targetDockNode.activeTabIndex = static_cast<int>(targetDockNode.panels.size()) - 1;
+        ShowPanelControls(panelId, true);
         SyncDockTabs();
         m_layoutInitialized = false;
     }
@@ -2688,8 +2796,8 @@ namespace Xelqoria::Editor
         }
 
         m_dragPanelWindowOffset = POINT{
-            (std::max)(ScaleMetric(8), cursorScreenPoint.x - captionRect.left),
-            (std::max)(ScaleMetric(8), cursorScreenPoint.y - captionRect.top)
+            static_cast<LONG>((std::max)(ScaleMetric(8), static_cast<int>(cursorScreenPoint.x - captionRect.left))),
+            static_cast<LONG>((std::max)(ScaleMetric(8), static_cast<int>(cursorScreenPoint.y - captionRect.top)))
         };
 
         RemovePanelFromDockTree(panelId);

--- a/Editor/Source/EditorShell.h
+++ b/Editor/Source/EditorShell.h
@@ -18,6 +18,15 @@ namespace Xelqoria::Editor
     class EditorShell
     {
     public:
+        enum class EditorPanelId
+        {
+            Hierarchy,
+            Assets,
+            SceneView,
+            Inspector,
+            LogOutput
+        };
+
         /// <summary>
         /// EditorShell 用 child window 群を生成する。
         /// </summary>
@@ -275,16 +284,13 @@ namespace Xelqoria::Editor
         /// </summary>
         void ResetDockLayout();
 
-    private:
-        enum class EditorPanelId
-        {
-            Hierarchy,
-            Assets,
-            SceneView,
-            Inspector,
-            LogOutput
-        };
+        /// <summary>
+        /// 指定ビューを既定の Dock 位置へ表示する。
+        /// </summary>
+        /// <param name="panelId">再表示するビュー。</param>
+        void ShowPanelAtDefaultDock(EditorPanelId panelId);
 
+    private:
         enum class DockAreaId
         {
             LeftTop,
@@ -429,6 +435,16 @@ namespace Xelqoria::Editor
         /// Dock node を追加して ID を返す。
         /// </summary>
         [[nodiscard]] DockNodeId AddDockNode(DockNode node);
+
+        /// <summary>
+        /// 指定ビューの既定 Dock leaf を返す。存在しない場合は生成する。
+        /// </summary>
+        [[nodiscard]] DockNodeId EnsureDefaultDockLeaf(EditorPanelId panelId);
+
+        /// <summary>
+        /// 指定ビューの既定 Dock tab control を返す。
+        /// </summary>
+        [[nodiscard]] HWND GetDefaultDockTabControl(EditorPanelId panelId);
 
         /// <summary>
         /// カーソル位置にある Dock leaf を返す。
@@ -800,6 +816,7 @@ namespace Xelqoria::Editor
         HWND m_leftBottomDockTab = nullptr;
         HWND m_centerDockTab = nullptr;
         HWND m_rightDockTab = nullptr;
+        HWND m_logOutputDockTab = nullptr;
         std::vector<HWND> m_dynamicDockTabs{};
         HWND m_dockPreviewWindow = nullptr;
         std::array<HWND, 9> m_dockGuideWindows{};

--- a/docs/plans/issue-217-view-menu-restore.md
+++ b/docs/plans/issue-217-view-menu-restore.md
@@ -1,0 +1,50 @@
+# ExecPlan: issue-217 「表示」ボタンとビュー再表示機能を追加する
+
+## 目的
+
+メインウィンドウに「表示」メニューを追加し、非表示になった各ビューを既定のドッキング位置へ再表示できるようにする。
+
+## 対象範囲
+
+- 変更対象プロジェクト: Editor
+- 変更対象ファイル: `Editor/Source/Application.cpp`, `Editor/Source/Application.h`, `Editor/Source/EditorShell.cpp`, `Editor/Source/EditorShell.h`
+- 変更対象クラス: `Xelqoria::Editor::Application`, `Xelqoria::Editor::EditorShell`
+- 影響する機能: メニューバー、ビュー再表示、既定 Dock 位置復帰
+
+## 前提
+
+- parent issue: issue-214
+- ブランチ運用ルール: `branch-rules.md`
+- parent issue ブランチ: `issue-214`
+- この child issue のブランチ: `issue-217`
+- PR の向き: `issue-217` から `issue-214`
+
+## 実装方針
+
+Editor 専用の Win32 UI シェルである `EditorShell` 内にビュー再表示と既定 Dock 位置復帰の責務を置く。`Application` はメニュー項目とコマンド振り分けのみ担当する。
+
+表示状態の保存は非スコープのため、永続化は行わない。
+
+## 作業手順
+
+1. 関連コードを確認する
+2. メニューバーに `表示` メニューを追加する
+3. 各ビューの表示コマンドを追加する
+4. `EditorShell` に既定 Dock 位置への再表示 API を追加する
+5. ビルドまたは関連テストを実行する
+6. `branch-rules.md` に従って PR を作成する
+
+## 検証方法
+
+- 実行するビルド: `tests/Editor/Xelqoria.Tests.Editor.vcxproj` Debug x64
+- 実行するテスト: `artifacts/x64/Debug/Xelqoria.Tests.Editor.exe`
+- 手動確認項目: `表示` メニューから各ビューを再表示し、既定 Dock 位置へ戻ること
+
+## 完了条件
+
+- メインウィンドウの `プロジェクト` メニュー右側に `表示` メニューが表示される
+- `表示` メニューから各ビューを再表示できる
+- 再表示したビューは既定の Dock 位置に表示される
+- レイヤー責務に違反していない
+- 不要な変更が含まれていない
+- `branch-rules.md` に従った PR が作成されている


### PR DESCRIPTION
## Summary
- Parent issue: #214
- Child issue: #217
- Add a top-level 表示 menu next to プロジェクト with commands for each existing view.
- Add EditorShell support for restoring a selected view to its default dock location.
- Keep view visibility persistence out of scope.
- Add the child issue ExecPlan for view restore behavior.

## Verification
- Built: Editor/Xelqoria.Editor.vcxproj Debug|x64
- Built: tests/Editor/Xelqoria.Tests.Editor.vcxproj Debug|x64
- Ran: ./artifacts/x64/Debug/Xelqoria.Tests.Editor.exe (66 passed)