### PR TITLE
Reduce layout resize flicker

### DIFF
--- a/Editor/Source/Application.cpp
+++ b/Editor/Source/Application.cpp
@@ -40,6 +40,11 @@ namespace Xelqoria::Editor
         constexpr unsigned ViewMenuInspectorCommandId = 5204;
         constexpr unsigned ViewMenuLogOutputCommandId = 5205;
 
+        [[nodiscard]] std::filesystem::path GetEditorLayoutFilePath()
+        {
+            return std::filesystem::path("Saved") / "EditorLayout.txt";
+        }
+
         [[nodiscard]] std::filesystem::path SelectProjectFile(
             Platform::IFileDialog& fileDialog,
             HWND ownerWindow)
@@ -333,6 +338,7 @@ namespace Xelqoria::Editor
         {
             return false;
         }
+        (void)m_editorShell.LoadLayout(GetEditorLayoutFilePath());
 
         m_assetsPanelController.Bind(m_editorShell, m_cursor);
         m_hierarchyPanelController.Bind(m_editorShell);
@@ -468,7 +474,13 @@ namespace Xelqoria::Editor
 
     bool Application::HandleCloseRequest()
     {
-        return ConfirmSaveIfDirty();
+        const bool canClose = ConfirmSaveIfDirty();
+        if (canClose && m_editorInitialized)
+        {
+            (void)m_editorShell.SaveLayout(GetEditorLayoutFilePath());
+        }
+
+        return canClose;
     }
 
     void Application::HandleWindowResized(std::uint32_t width, std::uint32_t height)

--- a/Editor/Source/EditorShell.cpp
+++ b/Editor/Source/EditorShell.cpp
@@ -8,7 +8,10 @@
 #include <cstdlib>
 #include <cstdio>
 #include <cwchar>
+#include <fstream>
 #include <iterator>
+#include <string>
+#include <system_error>
 #include <utility>
 
 namespace Xelqoria::Editor
@@ -20,6 +23,68 @@ namespace Xelqoria::Editor
         constexpr const wchar_t* DockGuideWindowClassName = L"XelqoriaDockGuideWindow";
         constexpr const wchar_t* FloatingPanelWindowClassName = L"XelqoriaFloatingPanelWindow";
         constexpr ULONGLONG DockPanelDragDelayMilliseconds = 200;
+
+        struct SavedDockNode
+        {
+            bool isLeaf = true;
+            bool isHorizontalSplit = true;
+            float splitRatio = 0.5f;
+            int firstChild = -1;
+            int secondChild = -1;
+            int activeTabIndex = 0;
+            std::wstring tabKey{};
+            std::vector<EditorShell::EditorPanelId> panels{};
+        };
+
+        struct SavedFloatingGroup
+        {
+            RECT rect{};
+            int activeTabIndex = 0;
+            std::vector<EditorShell::EditorPanelId> panels{};
+        };
+
+        [[nodiscard]] constexpr std::array<EditorShell::EditorPanelId, 5> GetAllEditorPanels()
+        {
+            return {
+                EditorShell::EditorPanelId::Hierarchy,
+                EditorShell::EditorPanelId::Assets,
+                EditorShell::EditorPanelId::SceneView,
+                EditorShell::EditorPanelId::Inspector,
+                EditorShell::EditorPanelId::LogOutput
+            };
+        }
+
+        [[nodiscard]] const wchar_t* GetPanelLayoutName(EditorShell::EditorPanelId panelId)
+        {
+            switch (panelId)
+            {
+            case EditorShell::EditorPanelId::Hierarchy:
+                return L"Hierarchy";
+            case EditorShell::EditorPanelId::Assets:
+                return L"Assets";
+            case EditorShell::EditorPanelId::SceneView:
+                return L"SceneView";
+            case EditorShell::EditorPanelId::Inspector:
+                return L"Inspector";
+            case EditorShell::EditorPanelId::LogOutput:
+                return L"LogOutput";
+            default:
+                return L"SceneView";
+            }
+        }
+
+        [[nodiscard]] std::optional<EditorShell::EditorPanelId> TryParsePanelLayoutName(const std::wstring& name)
+        {
+            for (EditorShell::EditorPanelId panelId : GetAllEditorPanels())
+            {
+                if (name == GetPanelLayoutName(panelId))
+                {
+                    return panelId;
+                }
+            }
+
+            return std::nullopt;
+        }
 
         [[nodiscard]] POINT ToWin32Point(Platform::Point point)
         {
@@ -1967,6 +2032,266 @@ namespace Xelqoria::Editor
         m_layoutInitialized = false;
     }
 
+    bool EditorShell::SaveLayout(const std::filesystem::path& layoutPath) const
+    {
+        std::error_code errorCode;
+        std::filesystem::create_directories(layoutPath.parent_path(), errorCode);
+        if (errorCode)
+        {
+            return false;
+        }
+
+        std::wofstream output(layoutPath, std::ios::binary | std::ios::trunc);
+        if (false == output.is_open())
+        {
+            return false;
+        }
+
+        output << L"XelqoriaEditorLayout 1\n";
+        output << L"Root " << m_rootDockNodeId << L'\n';
+        output << L"Nodes " << m_dockNodes.size() << L'\n';
+        for (std::size_t index = 0; index < m_dockNodes.size(); ++index)
+        {
+            const DockNode& dockNode = m_dockNodes[index];
+            output << L"Node "
+                << index << L' '
+                << (DockNodeKind::Leaf == dockNode.kind ? L"Leaf" : L"Split") << L' '
+                << (DockSplitOrientation::Horizontal == dockNode.splitOrientation ? L"Horizontal" : L"Vertical") << L' '
+                << dockNode.splitRatio << L' '
+                << dockNode.firstChild << L' '
+                << dockNode.secondChild << L' '
+                << dockNode.activeTabIndex << L' '
+                << GetDockTabLayoutKey(dockNode.tabControl) << L' '
+                << dockNode.panels.size();
+            for (EditorPanelId panelId : dockNode.panels)
+            {
+                output << L' ' << GetPanelLayoutName(panelId);
+            }
+            output << L'\n';
+        }
+
+        output << L"Floating " << m_floatingPanelGroups.size() << L'\n';
+        for (const FloatingPanelGroup& group : m_floatingPanelGroups)
+        {
+            RECT windowRect{};
+            if (nullptr != group.window)
+            {
+                GetWindowRect(group.window, &windowRect);
+            }
+
+            output << L"FloatingGroup "
+                << windowRect.left << L' '
+                << windowRect.top << L' '
+                << windowRect.right << L' '
+                << windowRect.bottom << L' '
+                << group.activeTabIndex << L' '
+                << group.panels.size();
+            for (EditorPanelId panelId : group.panels)
+            {
+                output << L' ' << GetPanelLayoutName(panelId);
+            }
+            output << L'\n';
+        }
+
+        return output.good();
+    }
+
+    bool EditorShell::LoadLayout(const std::filesystem::path& layoutPath)
+    {
+        if (nullptr == m_parentWindow)
+        {
+            return false;
+        }
+
+        std::wifstream input(layoutPath, std::ios::binary);
+        if (false == input.is_open())
+        {
+            return false;
+        }
+
+        std::wstring signature{};
+        int version = 0;
+        input >> signature >> version;
+        if (L"XelqoriaEditorLayout" != signature || 1 != version)
+        {
+            return false;
+        }
+
+        std::wstring section{};
+        DockNodeId rootDockNodeId = -1;
+        input >> section >> rootDockNodeId;
+        if (L"Root" != section)
+        {
+            return false;
+        }
+
+        std::size_t nodeCount = 0;
+        input >> section >> nodeCount;
+        if (L"Nodes" != section || 0 == nodeCount)
+        {
+            return false;
+        }
+
+        std::vector<SavedDockNode> savedNodes(nodeCount);
+        for (std::size_t index = 0; index < nodeCount; ++index)
+        {
+            std::wstring nodeToken{};
+            std::size_t savedIndex = 0;
+            std::wstring kind{};
+            std::wstring orientation{};
+            std::size_t panelCount = 0;
+            input >> nodeToken
+                >> savedIndex
+                >> kind
+                >> orientation
+                >> savedNodes[index].splitRatio
+                >> savedNodes[index].firstChild
+                >> savedNodes[index].secondChild
+                >> savedNodes[index].activeTabIndex
+                >> savedNodes[index].tabKey
+                >> panelCount;
+            if (L"Node" != nodeToken || savedIndex != index)
+            {
+                return false;
+            }
+
+            savedNodes[index].isLeaf = L"Leaf" == kind;
+            savedNodes[index].isHorizontalSplit = L"Horizontal" == orientation;
+            for (std::size_t panelIndex = 0; panelIndex < panelCount; ++panelIndex)
+            {
+                std::wstring panelName{};
+                input >> panelName;
+                const std::optional<EditorPanelId> panelId = TryParsePanelLayoutName(panelName);
+                if (panelId.has_value())
+                {
+                    savedNodes[index].panels.push_back(*panelId);
+                }
+            }
+        }
+
+        std::size_t floatingGroupCount = 0;
+        input >> section >> floatingGroupCount;
+        if (L"Floating" != section)
+        {
+            return false;
+        }
+
+        std::vector<SavedFloatingGroup> savedFloatingGroups{};
+        savedFloatingGroups.reserve(floatingGroupCount);
+        for (std::size_t index = 0; index < floatingGroupCount; ++index)
+        {
+            std::wstring groupToken{};
+            SavedFloatingGroup group{};
+            std::size_t panelCount = 0;
+            input >> groupToken
+                >> group.rect.left
+                >> group.rect.top
+                >> group.rect.right
+                >> group.rect.bottom
+                >> group.activeTabIndex
+                >> panelCount;
+            if (L"FloatingGroup" != groupToken)
+            {
+                return false;
+            }
+
+            for (std::size_t panelIndex = 0; panelIndex < panelCount; ++panelIndex)
+            {
+                std::wstring panelName{};
+                input >> panelName;
+                const std::optional<EditorPanelId> panelId = TryParsePanelLayoutName(panelName);
+                if (panelId.has_value())
+                {
+                    group.panels.push_back(*panelId);
+                }
+            }
+            if (false == group.panels.empty())
+            {
+                savedFloatingGroups.push_back(std::move(group));
+            }
+        }
+
+        ResetDockLayout();
+        for (HWND tabControl : m_dynamicDockTabs)
+        {
+            if (nullptr != tabControl)
+            {
+                DestroyWindow(tabControl);
+            }
+        }
+        m_dynamicDockTabs.clear();
+        m_logOutputDockTab = nullptr;
+        m_dockNodes.clear();
+        m_dockNodes.reserve(savedNodes.size());
+
+        for (const SavedDockNode& savedNode : savedNodes)
+        {
+            DockNode dockNode{};
+            dockNode.kind = savedNode.isLeaf ? DockNodeKind::Leaf : DockNodeKind::Split;
+            dockNode.splitOrientation = savedNode.isHorizontalSplit
+                ? DockSplitOrientation::Horizontal
+                : DockSplitOrientation::Vertical;
+            dockNode.splitRatio = (std::max)(0.05f, (std::min)(0.95f, savedNode.splitRatio));
+            dockNode.firstChild = savedNode.firstChild;
+            dockNode.secondChild = savedNode.secondChild;
+            dockNode.activeTabIndex = savedNode.activeTabIndex;
+            dockNode.panels = savedNode.panels;
+            if (DockNodeKind::Leaf == dockNode.kind)
+            {
+                dockNode.tabControl = CreateDockTabControlForLayoutKey(savedNode.tabKey);
+            }
+            m_dockNodes.push_back(std::move(dockNode));
+        }
+        m_rootDockNodeId = rootDockNodeId;
+
+        for (const SavedFloatingGroup& group : savedFloatingGroups)
+        {
+            for (EditorPanelId panelId : group.panels)
+            {
+                RemovePanelFromDockTree(panelId, false);
+            }
+
+            const int width =
+                (std::max)(ScaleMetric(240), static_cast<int>(group.rect.right - group.rect.left));
+            const int height =
+                (std::max)(ScaleMetric(180), static_cast<int>(group.rect.bottom - group.rect.top));
+            FloatPanel(group.panels.front(), POINT{ group.rect.left, group.rect.top }, m_parentWindow);
+            HWND floatingWindow = GetFloatingWindowRef(group.panels.front());
+            if (nullptr == floatingWindow)
+            {
+                continue;
+            }
+
+            SetWindowPos(
+                floatingWindow,
+                nullptr,
+                group.rect.left,
+                group.rect.top,
+                width,
+                height,
+                SWP_NOZORDER | SWP_NOACTIVATE);
+            for (std::size_t panelIndex = 1; panelIndex < group.panels.size(); ++panelIndex)
+            {
+                AttachPanelToFloatingWindow(group.panels[panelIndex], floatingWindow);
+            }
+
+            const int groupIndex = FindFloatingPanelGroupIndex(floatingWindow);
+            if (groupIndex >= 0)
+            {
+                FloatingPanelGroup& floatingGroup = m_floatingPanelGroups[static_cast<std::size_t>(groupIndex)];
+                floatingGroup.activeTabIndex =
+                    (std::max)(0, (std::min)(group.activeTabIndex, static_cast<int>(floatingGroup.panels.size()) - 1));
+                SyncFloatingPanelTabs(floatingWindow);
+                LayoutFloatingWindow(floatingWindow);
+            }
+        }
+
+        RestoreMissingPanelsToDefaultDock();
+        SyncDockTabs();
+        m_layoutInitialized = false;
+        return true;
+    }
+
     void EditorShell::ShowPanelControls(EditorPanelId panelId, bool visible) const
     {
         const int showCommand = visible ? SW_SHOW : SW_HIDE;
@@ -2379,6 +2704,11 @@ namespace Xelqoria::Editor
         }
 
         return -1;
+    }
+
+    bool EditorShell::IsPanelInDockTree(EditorPanelId panelId) const
+    {
+        return FindPanelDockLeaf(panelId) >= 0;
     }
 
     void EditorShell::RemovePanelFromDockTree(EditorPanelId panelId, bool collapseEmptyLeaves)
@@ -3293,6 +3623,72 @@ namespace Xelqoria::Editor
         ShowWindow(tabControl, SW_HIDE);
         m_dynamicDockTabs.push_back(tabControl);
         return tabControl;
+    }
+
+    HWND EditorShell::CreateDockTabControlForLayoutKey(const std::wstring& layoutKey)
+    {
+        if (L"LeftTop" == layoutKey)
+        {
+            return m_leftTopDockTab;
+        }
+        if (L"LeftBottom" == layoutKey)
+        {
+            return m_leftBottomDockTab;
+        }
+        if (L"Center" == layoutKey)
+        {
+            return m_centerDockTab;
+        }
+        if (L"Right" == layoutKey)
+        {
+            return m_rightDockTab;
+        }
+
+        HWND tabControl = CreateAdditionalDockTabControl(m_parentWindow);
+        if (L"LogOutput" == layoutKey)
+        {
+            m_logOutputDockTab = tabControl;
+        }
+        return tabControl;
+    }
+
+    std::wstring EditorShell::GetDockTabLayoutKey(HWND tabControl) const
+    {
+        if (tabControl == m_leftTopDockTab)
+        {
+            return L"LeftTop";
+        }
+        if (tabControl == m_leftBottomDockTab)
+        {
+            return L"LeftBottom";
+        }
+        if (tabControl == m_centerDockTab)
+        {
+            return L"Center";
+        }
+        if (tabControl == m_rightDockTab)
+        {
+            return L"Right";
+        }
+        if (tabControl == m_logOutputDockTab)
+        {
+            return L"LogOutput";
+        }
+
+        return L"Dynamic";
+    }
+
+    void EditorShell::RestoreMissingPanelsToDefaultDock()
+    {
+        for (EditorPanelId panelId : GetAllEditorPanels())
+        {
+            if (IsPanelInDockTree(panelId) || FindFloatingPanelGroupIndex(panelId) >= 0)
+            {
+                continue;
+            }
+
+            ShowPanelAtDefaultDock(panelId);
+        }
     }
 
     void EditorShell::SyncDockAreaTabs(DockAreaId dockAreaId)

--- a/Editor/Source/EditorShell.cpp
+++ b/Editor/Source/EditorShell.cpp
@@ -3932,28 +3932,16 @@ namespace Xelqoria::Editor
 
     void EditorShell::RedrawLayout(HWND parentWindow) const
     {
-        if (nullptr != parentWindow)
+        if (nullptr == parentWindow)
         {
-            RedrawWindow(
-                parentWindow,
-                nullptr,
-                nullptr,
-                RDW_INVALIDATE | RDW_ERASE | RDW_ERASENOW | RDW_UPDATENOW | RDW_ALLCHILDREN | RDW_FRAME);
+            return;
         }
 
-        const std::array<HWND, 65> controls = CollectControls();
-
-        for (HWND control : controls)
-        {
-            if (nullptr != control)
-            {
-                RedrawWindow(
-                    control,
-                    nullptr,
-                    nullptr,
-                    RDW_INVALIDATE | RDW_ERASE | RDW_ERASENOW | RDW_UPDATENOW | RDW_FRAME);
-            }
-        }
+        RedrawWindow(
+            parentWindow,
+            nullptr,
+            nullptr,
+            RDW_INVALIDATE | RDW_ALLCHILDREN | RDW_FRAME);
     }
 
     bool EditorShell::UpdateSceneViewHostSize()

--- a/Editor/Source/EditorShell.h
+++ b/Editor/Source/EditorShell.h
@@ -3,7 +3,9 @@
 #include <Windows.h>
 #include <array>
 #include <cstdint>
+#include <filesystem>
 #include <optional>
+#include <string>
 #include <vector>
 
 #include "ICursor.h"
@@ -290,6 +292,20 @@ namespace Xelqoria::Editor
         /// <param name="panelId">再表示するビュー。</param>
         void ShowPanelAtDefaultDock(EditorPanelId panelId);
 
+        /// <summary>
+        /// 現在の Dock / Floating レイアウトを保存する。
+        /// </summary>
+        /// <param name="layoutPath">保存先ファイル。</param>
+        /// <returns>保存に成功した場合は true。</returns>
+        [[nodiscard]] bool SaveLayout(const std::filesystem::path& layoutPath) const;
+
+        /// <summary>
+        /// 保存済み Dock / Floating レイアウトを復元する。
+        /// </summary>
+        /// <param name="layoutPath">復元元ファイル。</param>
+        /// <returns>復元に成功した場合は true。</returns>
+        [[nodiscard]] bool LoadLayout(const std::filesystem::path& layoutPath);
+
     private:
         enum class DockAreaId
         {
@@ -482,6 +498,11 @@ namespace Xelqoria::Editor
         [[nodiscard]] DockNodeId FindPanelDockLeaf(EditorPanelId panelId) const;
 
         /// <summary>
+        /// 指定パネルが Dock tree に含まれているかを返す。
+        /// </summary>
+        [[nodiscard]] bool IsPanelInDockTree(EditorPanelId panelId) const;
+
+        /// <summary>
         /// Dock ツリーから指定パネルを取り除く。
         /// </summary>
         void RemovePanelFromDockTree(EditorPanelId panelId, bool collapseEmptyLeaves = true);
@@ -650,6 +671,21 @@ namespace Xelqoria::Editor
         /// split Dock leaf 用の TabControl を追加生成する。
         /// </summary>
         [[nodiscard]] HWND CreateAdditionalDockTabControl(HWND parentWindow);
+
+        /// <summary>
+        /// 保存データに記録された Dock leaf 用 TabControl を取得または生成する。
+        /// </summary>
+        [[nodiscard]] HWND CreateDockTabControlForLayoutKey(const std::wstring& layoutKey);
+
+        /// <summary>
+        /// Dock leaf の TabControl を保存用識別子へ変換する。
+        /// </summary>
+        [[nodiscard]] std::wstring GetDockTabLayoutKey(HWND tabControl) const;
+
+        /// <summary>
+        /// 保存データから欠けたビューを既定 Dock 位置へ戻す。
+        /// </summary>
+        void RestoreMissingPanelsToDefaultDock();
 
         /// <summary>
         /// 指定 TabControl に DockArea のタブを設定する。

--- a/docs/plans/issue-218-layout-persistence.md
+++ b/docs/plans/issue-218-layout-persistence.md
@@ -1,0 +1,48 @@
+# ExecPlan: issue-218 レイアウト保存・復元を追加する
+
+## 目的
+
+Editor の Dock / Floating レイアウトを終了時に保存し、次回起動時に復元できるようにする。
+
+## 対象範囲
+
+- 変更対象プロジェクト: Editor
+- 変更対象ファイル: `Editor/Source/EditorShell.h`, `Editor/Source/EditorShell.cpp`, `Editor/Source/Application.cpp`
+- 変更対象クラス: `Xelqoria::Editor::EditorShell`, `Xelqoria::Editor::Application`
+- 影響する機能: Dock 配置、タブ順、Floating window 位置・サイズ、Dock 分割比率
+
+## 前提
+
+- parent issue: issue-214
+- ブランチ運用ルール: `branch-rules.md`
+- parent issue ブランチ: `issue-214`
+- この child issue のブランチ: `issue-218`
+- PR の向き: `issue-218` から `issue-214`
+
+## 実装方針
+
+レイアウト保存・復元は Win32 Editor UI を所有する `EditorShell` に閉じる。保存形式は `Saved/EditorLayout.txt` の行指向テキストとし、Dock tree、leaf のタブ順、active tab、split ratio、Floating group の矩形とタブ順を保存する。
+
+表示・非表示状態は保存対象にしない。復元時に保存データから欠けているビューは既定 Dock 位置へ戻し、起動後に全ビューへ到達できる状態にする。
+
+## 作業手順
+
+1. 関連コードを確認する
+2. `EditorShell` に保存・復元 API とシリアライズ処理を追加する
+3. `Application` の初期化時と終了時に保存・復元を呼び出す
+4. ビルドを実行する
+5. `branch-rules.md` に従って PR を作成する
+
+## 検証方法
+
+- 実行するビルド: `tools/wsl/build.sh Editor/Xelqoria.Editor.vcxproj`
+- 実行するテスト: 追加なし
+- 手動確認項目: Dock / Floating / タブ順 / 分割位置が再起動後に復元され、閉じたビューは既定位置へ戻る
+
+## 完了条件
+
+- レイアウト保存・復元が実装されている
+- ビルドが通る
+- レイヤー責務に違反していない
+- 不要な変更が含まれていない
+- `branch-rules.md` に従った PR が作成されている

--- a/docs/plans/issue-220-resize-flicker.md
+++ b/docs/plans/issue-220-resize-flicker.md
@@ -1,0 +1,46 @@
+# ExecPlan: issue-220 ビューサイズ変更時のちらつきを修正する
+
+## 目的
+
+Dock splitter や window resize によるビューサイズ変更中、Editor の各ビューが不自然に消えたり大きくちらついたりしないようにする。
+
+## 対象範囲
+
+- 変更対象プロジェクト: Editor
+- 変更対象ファイル: `Editor/Source/EditorShell.cpp`
+- 変更対象クラス: `Xelqoria::Editor::EditorShell`
+- 影響する機能: Dock レイアウト更新後の Win32 child window 再描画
+
+## 前提
+
+- parent issue: issue-214
+- prerequisite branch: `issue-218` を作業ブランチへローカルマージ済み
+- ブランチ運用ルール: `branch-rules.md`
+- parent issue ブランチ: `issue-214`
+- この child issue のブランチ: `issue-220`
+- PR の向き: `issue-220` から `issue-214`
+
+## 実装方針
+
+リサイズ中の child window 移動は既存の `SWP_NOREDRAW` 経路を維持し、最後の `RedrawLayout` で強制 erase / synchronous repaint を繰り返さないようにする。親 window に対して child を含む invalidation を一度だけ行い、背景消去と即時再描画によるちらつきを抑える。
+
+## 作業手順
+
+1. レイアウト更新と再描画経路を確認する
+2. `RedrawLayout` の再描画フラグを調整する
+3. ビルドを実行する
+4. `branch-rules.md` に従って PR を作成する
+
+## 検証方法
+
+- 実行するビルド: `tools/wsl/build.sh Editor/Xelqoria.Editor.vcxproj`
+- 実行するテスト: 追加なし
+- 手動確認項目: Dock splitter / window resize 中のちらつきが抑制されること
+
+## 完了条件
+
+- リサイズ中の強制 erase / 即時再描画が抑制されている
+- ビルドが通る
+- レイヤー責務に違反していない
+- 不要な変更が含まれていない
+- `branch-rules.md` に従った PR が作成されている


### PR DESCRIPTION
## Summary
- Merge prerequisite branch issue-218 locally for the layout persistence baseline
- Reduce layout resize flicker by removing forced erase and synchronous repaint from EditorShell layout redraw
- Add issue-220 ExecPlan

## Verification
- tools/wsl/build.sh Editor/Xelqoria.Editor.vcxproj

Parent issue: #214
Child issue: #220
Prerequisite: #218