### PR TITLE
#236 SpriteMaterial クラスを Graphics 層に追加する

### DIFF
--- a/Graphics/Source/SpriteMaterial.cpp
+++ b/Graphics/Source/SpriteMaterial.cpp
@@ -1,0 +1,66 @@
+#include "SpriteMaterial.h"
+
+#include <utility>
+
+namespace Xelqoria::Graphics
+{
+	void SpriteMaterial::SetTexture(std::shared_ptr<Texture2D> texture)
+	{
+		m_texture = std::move(texture);
+	}
+
+	std::shared_ptr<Texture2D> SpriteMaterial::GetTexture() const
+	{
+		return m_texture;
+	}
+
+	void SpriteMaterial::SetTextureAssetId(Core::AssetId assetId)
+	{
+		m_textureAssetId = std::move(assetId);
+	}
+
+	const Core::AssetId& SpriteMaterial::GetTextureAssetId() const
+	{
+		return m_textureAssetId;
+	}
+
+	void SpriteMaterial::SetColor(float red, float green, float blue, float alpha)
+	{
+		m_color = { red, green, blue, alpha };
+	}
+
+	const std::array<float, 4>& SpriteMaterial::GetColor() const
+	{
+		return m_color;
+	}
+
+	void SpriteMaterial::SetOutlineEnabled(bool enabled)
+	{
+		m_outlineEnabled = enabled;
+	}
+
+	bool SpriteMaterial::IsOutlineEnabled() const
+	{
+		return m_outlineEnabled;
+	}
+
+	void SpriteMaterial::SetOutlineThickness(float thickness)
+	{
+		m_outlineThickness = thickness;
+	}
+
+	float SpriteMaterial::GetOutlineThickness() const
+	{
+		return m_outlineThickness;
+	}
+
+	void SpriteMaterial::SetOutlineColor(float red, float green, float blue, float alpha)
+	{
+		m_outlineColor = { red, green, blue, alpha };
+	}
+
+	const std::array<float, 4>& SpriteMaterial::GetOutlineColor() const
+	{
+		return m_outlineColor;
+	}
+}

--- a/Graphics/Source/SpriteMaterial.h
+++ b/Graphics/Source/SpriteMaterial.h
@@ -1,0 +1,104 @@
+#pragma once
+
+#include "AssetId.h"
+
+#include <array>
+#include <memory>
+
+namespace Xelqoria::Graphics
+{
+	class Texture2D;
+
+	/// <summary>
+	/// 2D スプライトの描画方法に関する情報を保持する Material。
+	/// </summary>
+	class SpriteMaterial
+	{
+	public:
+		/// <summary>
+		/// 描画に使用するテクスチャを設定する。
+		/// </summary>
+		/// <param name="texture">設定するテクスチャ。</param>
+		void SetTexture(std::shared_ptr<Texture2D> texture);
+
+		/// <summary>
+		/// 描画に使用するテクスチャを取得する。
+		/// </summary>
+		/// <returns>設定されているテクスチャ。</returns>
+		std::shared_ptr<Texture2D> GetTexture() const;
+
+		/// <summary>
+		/// 描画に使用するテクスチャアセット識別子を設定する。
+		/// </summary>
+		/// <param name="assetId">設定するアセット識別子。</param>
+		void SetTextureAssetId(Core::AssetId assetId);
+
+		/// <summary>
+		/// 描画に使用するテクスチャアセット識別子を取得する。
+		/// </summary>
+		/// <returns>保持しているアセット識別子。</returns>
+		const Core::AssetId& GetTextureAssetId() const;
+
+		/// <summary>
+		/// RGBA 順の色乗算値を設定する。
+		/// </summary>
+		/// <param name="red">赤成分。</param>
+		/// <param name="green">緑成分。</param>
+		/// <param name="blue">青成分。</param>
+		/// <param name="alpha">アルファ成分。</param>
+		void SetColor(float red, float green, float blue, float alpha);
+
+		/// <summary>
+		/// RGBA 順の色乗算値を取得する。
+		/// </summary>
+		/// <returns>保持している色乗算値。</returns>
+		const std::array<float, 4>& GetColor() const;
+
+		/// <summary>
+		/// 外枠描画の有効状態を設定する。
+		/// </summary>
+		/// <param name="enabled">外枠描画を有効にする場合は true。</param>
+		void SetOutlineEnabled(bool enabled);
+
+		/// <summary>
+		/// 外枠描画が有効かを取得する。
+		/// </summary>
+		/// <returns>外枠描画が有効な場合は true。</returns>
+		bool IsOutlineEnabled() const;
+
+		/// <summary>
+		/// 外枠の太さを画面ピクセル単位で設定する。
+		/// </summary>
+		/// <param name="thickness">設定する外枠太さ。</param>
+		void SetOutlineThickness(float thickness);
+
+		/// <summary>
+		/// 外枠の太さを取得する。
+		/// </summary>
+		/// <returns>画面ピクセル単位の外枠太さ。</returns>
+		float GetOutlineThickness() const;
+
+		/// <summary>
+		/// RGBA 順の外枠色を設定する。
+		/// </summary>
+		/// <param name="red">赤成分。</param>
+		/// <param name="green">緑成分。</param>
+		/// <param name="blue">青成分。</param>
+		/// <param name="alpha">アルファ成分。</param>
+		void SetOutlineColor(float red, float green, float blue, float alpha);
+
+		/// <summary>
+		/// RGBA 順の外枠色を取得する。
+		/// </summary>
+		/// <returns>保持している外枠色。</returns>
+		const std::array<float, 4>& GetOutlineColor() const;
+
+	private:
+		std::shared_ptr<Texture2D> m_texture;
+		Core::AssetId m_textureAssetId{};
+		std::array<float, 4> m_color{ 1.0f, 1.0f, 1.0f, 1.0f };
+		bool m_outlineEnabled = false;
+		float m_outlineThickness = 1.0f;
+		std::array<float, 4> m_outlineColor{ 1.0f, 1.0f, 0.0f, 1.0f };
+	};
+}

--- a/Graphics/Xelqoria.Graphics.vcxproj
+++ b/Graphics/Xelqoria.Graphics.vcxproj
@@ -20,6 +20,7 @@
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="Source\Sprite.cpp" />
+    <ClCompile Include="Source\SpriteMaterial.cpp" />
     <ClCompile Include="Source\SpriteRenderer.cpp" />
     <ClCompile Include="Source\TextureAssetRegistry.cpp" />
     <ClCompile Include="Source\Texture2D.cpp" />
@@ -30,6 +31,7 @@
     <ClInclude Include="Source\Sprite.h" />
     <ClInclude Include="Source\SpriteCulling.h" />
     <ClInclude Include="Source\SpriteDrawInput.h" />
+    <ClInclude Include="Source\SpriteMaterial.h" />
     <ClInclude Include="Source\SpriteRenderMath.h" />
     <ClInclude Include="Source\SpriteRenderer.h" />
     <ClInclude Include="Source\TextureAssetRegistry.h" />

--- a/Graphics/Xelqoria.Graphics.vcxproj.filters
+++ b/Graphics/Xelqoria.Graphics.vcxproj.filters
@@ -9,6 +9,9 @@
     <ClCompile Include="Source\Sprite.cpp">
       <Filter>Source</Filter>
     </ClCompile>
+    <ClCompile Include="Source\SpriteMaterial.cpp">
+      <Filter>Source</Filter>
+    </ClCompile>
     <ClCompile Include="Source\SpriteRenderer.cpp">
       <Filter>Source</Filter>
     </ClCompile>
@@ -33,6 +36,9 @@
       <Filter>Source</Filter>
     </ClInclude>
     <ClInclude Include="Source\SpriteDrawInput.h">
+      <Filter>Source</Filter>
+    </ClInclude>
+    <ClInclude Include="Source\SpriteMaterial.h">
       <Filter>Source</Filter>
     </ClInclude>
     <ClInclude Include="Source\SpriteRenderMath.h">

--- a/docs/plans/issue-236-sprite-material-class.md
+++ b/docs/plans/issue-236-sprite-material-class.md
@@ -1,0 +1,46 @@
+# ExecPlan: issue-236 SpriteMaterial クラスを Graphics 層に追加する
+
+## 目的
+
+Graphics 層に 2D Sprite 専用の SpriteMaterial クラスを追加し、Sprite の描画方法に関する Texture / TextureAssetId / Color / Outline 情報を保持できるようにする。
+
+## 対象範囲
+
+- 変更対象プロジェクト: Graphics
+- 変更対象ファイル: `Graphics/Source/SpriteMaterial.h`, `Graphics/Source/SpriteMaterial.cpp`, `Graphics/Xelqoria.Graphics.vcxproj`, `Graphics/Xelqoria.Graphics.vcxproj.filters`
+- 変更対象クラス: `Xelqoria::Graphics::SpriteMaterial`
+- 影響する機能: SpriteMaterial の保持データ定義
+
+## 前提
+
+- parent issue: issue-235
+- ブランチ運用ルール: `docs/agents/branch-rules.md`
+- parent issue ブランチ: `issue-235`
+- この child issue のブランチ: `issue-236`
+- PR の向き: `issue-236` から `issue-235`
+
+## 実装方針
+
+SpriteMaterial は Graphics 層の描画概念として追加し、Texture2D 参照、Core::AssetId、RGBA 色、OutlineEnabled、OutlineThickness、OutlineColor を保持する。RHI / Backends 固有型や描画処理は含めない。
+
+## 作業手順
+
+1. 関連コードを確認する
+2. SpriteMaterial の公開 API と保持メンバーを追加する
+3. Graphics プロジェクトファイルへ追加する
+4. ビルドまたはテストを実行する
+5. `branch-rules.md` に従って PR を作成する
+
+## 検証方法
+
+- 実行するビルド: 可能なら Graphics またはソリューションの Debug x64 ビルド
+- 実行するテスト: 可能なら Graphics テスト
+- 手動確認項目: SpriteMaterial に Direct3D 型が含まれず、RHI へ Material 概念が追加されていないこと
+
+## 完了条件
+
+- Graphics 層に SpriteMaterial が追加されている
+- SpriteMaterial が Texture / TextureAssetId / Color / OutlineEnabled / OutlineThickness / OutlineColor を保持できる
+- SpriteMaterial 自身に描画処理がない
+- レイヤー責務に違反していない
+- `branch-rules.md` に従った PR が作成されている


### PR DESCRIPTION
## 概要
- Graphics 層に SpriteMaterial を追加
- Texture / TextureAssetId / Color / Outline 情報の保持 API を追加
- Graphics プロジェクトへ SpriteMaterial の cpp/header を登録

## Issue
- Parent: #235
- Child: #236

## 検証
- MSBuild: Graphics/Xelqoria.Graphics.vcxproj Debug x64 成功
- LayerDependencyChecker passed