### PR TITLE
#237 Sprite に SpriteMaterial 参照を導入する

### DIFF
--- a/Graphics/Source/Sprite.cpp
+++ b/Graphics/Source/Sprite.cpp
@@ -1,9 +1,32 @@
 #include "Sprite.h"
 
+#include "SpriteMaterial.h"
+
 #include <utility>
 
 namespace Xelqoria::Graphics
 {
+	Sprite::Sprite()
+		: m_material(std::make_shared<SpriteMaterial>())
+	{
+	}
+
+	void Sprite::SetMaterial(std::shared_ptr<SpriteMaterial> material)
+	{
+		if (material)
+		{
+			m_material = std::move(material);
+			return;
+		}
+
+		m_material = std::make_shared<SpriteMaterial>();
+	}
+
+	std::shared_ptr<SpriteMaterial> Sprite::GetMaterial() const
+	{
+		return m_material;
+	}
+
 	void Sprite::SetTexture(std::shared_ptr <Texture2D> texture)
 	{
 		m_texture = std::move(texture);

--- a/Graphics/Source/Sprite.h
+++ b/Graphics/Source/Sprite.h
@@ -9,6 +9,7 @@
 
 namespace Xelqoria::Graphics
 {
+	class SpriteMaterial;
 	class Texture2D;
 
 	/// <summary>
@@ -17,6 +18,23 @@ namespace Xelqoria::Graphics
 	class Sprite
 	{
 	public:
+		/// <summary>
+		/// default SpriteMaterial を持つスプライトを生成する。
+		/// </summary>
+		Sprite();
+
+		/// <summary>
+		/// スプライトに使用する Material を設定する。
+		/// </summary>
+		/// <param name="material">設定する Material。nullptr の場合は default Material に戻す。</param>
+		void SetMaterial(std::shared_ptr<SpriteMaterial> material);
+
+		/// <summary>
+		/// 現在設定されている Material を取得する。
+		/// </summary>
+		/// <returns>スプライトに紐づく Material。</returns>
+		std::shared_ptr<SpriteMaterial> GetMaterial() const;
+
 		/// <summary>
 		/// スプライトに使用するテクスチャを設定する。
 		/// </summary>
@@ -152,6 +170,7 @@ namespace Xelqoria::Graphics
 		[[nodiscard]] SpriteDrawInput ToDrawInput() const;
 
 	private:
+		std::shared_ptr<SpriteMaterial> m_material;
 		std::shared_ptr<Texture2D> m_texture;
 		Core::AssetId m_textureAssetId{};
 		Xelqoria::Math::Vector2 m_position{};

--- a/docs/plans/issue-237-sprite-material-reference.md
+++ b/docs/plans/issue-237-sprite-material-reference.md
@@ -1,0 +1,47 @@
+# ExecPlan: issue-237 Sprite に SpriteMaterial 参照を導入する
+
+## 目的
+
+Sprite に SpriteMaterial 参照を導入し、生成時点で default SpriteMaterial を持つ設計にする。
+
+## 対象範囲
+
+- 変更対象プロジェクト: Graphics
+- 変更対象ファイル: `Graphics/Source/Sprite.h`, `Graphics/Source/Sprite.cpp`
+- 変更対象クラス: `Xelqoria::Graphics::Sprite`
+- 影響する機能: Sprite の Material 参照管理
+
+## 前提
+
+- parent issue: issue-235
+- ブランチ運用ルール: `docs/agents/branch-rules.md`
+- parent issue ブランチ: `issue-235`
+- この child issue のブランチ: `issue-237`
+- PR の向き: `issue-237` から `issue-235`
+
+## 実装方針
+
+Sprite は std::shared_ptr<SpriteMaterial> を持ち、コンストラクタで default SpriteMaterial を生成する。SetMaterial(nullptr) は Material 未設定状態を作らないように default SpriteMaterial へ戻す。既存の Texture / Color / Outline API の委譲は issue-238 で扱う。
+
+## 作業手順
+
+1. 関連コードを確認する
+2. Sprite にコンストラクタと SetMaterial / GetMaterial を追加する
+3. Sprite が Material 未設定状態にならないようにする
+4. ビルドまたはテストを実行する
+5. `branch-rules.md` に従って PR を作成する
+
+## 検証方法
+
+- 実行するビルド: `Graphics/Xelqoria.Graphics.vcxproj` Debug x64
+- 実行するテスト: 可能なら Graphics テスト
+- 手動確認項目: Sprite / SpriteMaterial 自身に描画処理が追加されていないこと
+
+## 完了条件
+
+- Sprite が SpriteMaterial 参照を持つ
+- Sprite が生成時点で default SpriteMaterial を持つ
+- Sprite::SetMaterial() / Sprite::GetMaterial() が追加されている
+- SetMaterial(nullptr) により Sprite が Material を持たない通常状態にならない
+- レイヤー責務に違反していない
+- `branch-rules.md` に従った PR が作成されている


### PR DESCRIPTION
## 概要
- Sprite に default SpriteMaterial を生成するコンストラクタを追加
- Sprite::SetMaterial() / Sprite::GetMaterial() を追加
- SetMaterial(nullptr) は Material 未設定状態にせず default Material へ戻す

## Issue
- Parent: #235
- Child: #237

## 検証
- MSBuild: Graphics/Xelqoria.Graphics.vcxproj Debug x64 成功
- LayerDependencyChecker passed