### PR TITLE
#238 Sprite の既存描画情報 API を SpriteMaterial へ委譲する

### DIFF
--- a/Graphics/Source/Sprite.cpp
+++ b/Graphics/Source/Sprite.cpp
@@ -1,9 +1,32 @@
 #include "Sprite.h"
 
+#include "SpriteMaterial.h"
+
 #include <utility>
 
 namespace Xelqoria::Graphics
 {
+	Sprite::Sprite()
+		: m_material(std::make_shared<SpriteMaterial>())
+	{
+	}
+
+	void Sprite::SetMaterial(std::shared_ptr<SpriteMaterial> material)
+	{
+		if (material)
+		{
+			m_material = std::move(material);
+			return;
+		}
+
+		m_material = std::make_shared<SpriteMaterial>();
+	}
+
+	std::shared_ptr<SpriteMaterial> Sprite::GetMaterial() const
+	{
+		return m_material;
+	}
+
 	void Sprite::SetTexture(std::shared_ptr <Texture2D> texture)
 	{
 		m_texture = std::move(texture);

--- a/Graphics/Source/Sprite.cpp
+++ b/Graphics/Source/Sprite.cpp
@@ -29,22 +29,22 @@ namespace Xelqoria::Graphics
 
 	void Sprite::SetTexture(std::shared_ptr <Texture2D> texture)
 	{
-		m_texture = std::move(texture);
+		m_material->SetTexture(std::move(texture));
 	}
 
 	std::shared_ptr<Texture2D> Sprite::GetTexture() const
 	{
-		return m_texture;
+		return m_material->GetTexture();
 	}
 
 	void Sprite::SetTextureAssetId(Core::AssetId assetId)
 	{
-		m_textureAssetId = std::move(assetId);
+		m_material->SetTextureAssetId(std::move(assetId));
 	}
 
 	const Core::AssetId& Sprite::GetTextureAssetId() const
 	{
-		return m_textureAssetId;
+		return m_material->GetTextureAssetId();
 	}
 
 	void Sprite::SetPosition(const Xelqoria::Math::Vector2& position)
@@ -89,56 +89,56 @@ namespace Xelqoria::Graphics
 
 	void Sprite::SetColor(float red, float green, float blue, float alpha)
 	{
-		m_color = { red, green, blue, alpha };
+		m_material->SetColor(red, green, blue, alpha);
 	}
 
 	const std::array<float, 4>& Sprite::GetColor() const
 	{
-		return m_color;
+		return m_material->GetColor();
 	}
 
 	void Sprite::SetOutlineEnabled(bool enabled)
 	{
-		m_outlineEnabled = enabled;
+		m_material->SetOutlineEnabled(enabled);
 	}
 
 	bool Sprite::IsOutlineEnabled() const
 	{
-		return m_outlineEnabled;
+		return m_material->IsOutlineEnabled();
 	}
 
 	void Sprite::SetOutlineThickness(float thickness)
 	{
-		m_outlineThickness = thickness;
+		m_material->SetOutlineThickness(thickness);
 	}
 
 	float Sprite::GetOutlineThickness() const
 	{
-		return m_outlineThickness;
+		return m_material->GetOutlineThickness();
 	}
 
 	void Sprite::SetOutlineColor(float red, float green, float blue, float alpha)
 	{
-		m_outlineColor = { red, green, blue, alpha };
+		m_material->SetOutlineColor(red, green, blue, alpha);
 	}
 
 	const std::array<float, 4>& Sprite::GetOutlineColor() const
 	{
-		return m_outlineColor;
+		return m_material->GetOutlineColor();
 	}
 
 	SpriteDrawInput Sprite::ToDrawInput() const
 	{
 		return SpriteDrawInput{
-			m_texture,
-			m_textureAssetId,
+			m_material->GetTexture(),
+			m_material->GetTextureAssetId(),
 			m_position,
 			m_scale,
 			m_rotationDegrees,
-			m_color,
-			m_outlineEnabled,
-			m_outlineThickness,
-			m_outlineColor
+			m_material->GetColor(),
+			m_material->IsOutlineEnabled(),
+			m_material->GetOutlineThickness(),
+			m_material->GetOutlineColor()
 		};
 	}
 }

--- a/Graphics/Source/Sprite.h
+++ b/Graphics/Source/Sprite.h
@@ -9,6 +9,7 @@
 
 namespace Xelqoria::Graphics
 {
+	class SpriteMaterial;
 	class Texture2D;
 
 	/// <summary>
@@ -17,6 +18,23 @@ namespace Xelqoria::Graphics
 	class Sprite
 	{
 	public:
+		/// <summary>
+		/// default SpriteMaterial を持つスプライトを生成する。
+		/// </summary>
+		Sprite();
+
+		/// <summary>
+		/// スプライトに使用する Material を設定する。
+		/// </summary>
+		/// <param name="material">設定する Material。nullptr の場合は default Material に戻す。</param>
+		void SetMaterial(std::shared_ptr<SpriteMaterial> material);
+
+		/// <summary>
+		/// 現在設定されている Material を取得する。
+		/// </summary>
+		/// <returns>スプライトに紐づく Material。</returns>
+		std::shared_ptr<SpriteMaterial> GetMaterial() const;
+
 		/// <summary>
 		/// スプライトに使用するテクスチャを設定する。
 		/// </summary>
@@ -152,6 +170,7 @@ namespace Xelqoria::Graphics
 		[[nodiscard]] SpriteDrawInput ToDrawInput() const;
 
 	private:
+		std::shared_ptr<SpriteMaterial> m_material;
 		std::shared_ptr<Texture2D> m_texture;
 		Core::AssetId m_textureAssetId{};
 		Xelqoria::Math::Vector2 m_position{};

--- a/Graphics/Source/Sprite.h
+++ b/Graphics/Source/Sprite.h
@@ -171,14 +171,8 @@ namespace Xelqoria::Graphics
 
 	private:
 		std::shared_ptr<SpriteMaterial> m_material;
-		std::shared_ptr<Texture2D> m_texture;
-		Core::AssetId m_textureAssetId{};
 		Xelqoria::Math::Vector2 m_position{};
 		Xelqoria::Math::Vector2 m_scale{ 1.0f, 1.0f };
 		float m_rotationDegrees = 0.0f;
-		std::array<float, 4> m_color{ 1.0f, 1.0f, 1.0f, 1.0f };
-		bool m_outlineEnabled = false;
-		float m_outlineThickness = 1.0f;
-		std::array<float, 4> m_outlineColor{ 1.0f, 1.0f, 0.0f, 1.0f };
 	};
 }

--- a/docs/plans/issue-237-sprite-material-reference.md
+++ b/docs/plans/issue-237-sprite-material-reference.md
@@ -1,0 +1,47 @@
+# ExecPlan: issue-237 Sprite に SpriteMaterial 参照を導入する
+
+## 目的
+
+Sprite に SpriteMaterial 参照を導入し、生成時点で default SpriteMaterial を持つ設計にする。
+
+## 対象範囲
+
+- 変更対象プロジェクト: Graphics
+- 変更対象ファイル: `Graphics/Source/Sprite.h`, `Graphics/Source/Sprite.cpp`
+- 変更対象クラス: `Xelqoria::Graphics::Sprite`
+- 影響する機能: Sprite の Material 参照管理
+
+## 前提
+
+- parent issue: issue-235
+- ブランチ運用ルール: `docs/agents/branch-rules.md`
+- parent issue ブランチ: `issue-235`
+- この child issue のブランチ: `issue-237`
+- PR の向き: `issue-237` から `issue-235`
+
+## 実装方針
+
+Sprite は std::shared_ptr<SpriteMaterial> を持ち、コンストラクタで default SpriteMaterial を生成する。SetMaterial(nullptr) は Material 未設定状態を作らないように default SpriteMaterial へ戻す。既存の Texture / Color / Outline API の委譲は issue-238 で扱う。
+
+## 作業手順
+
+1. 関連コードを確認する
+2. Sprite にコンストラクタと SetMaterial / GetMaterial を追加する
+3. Sprite が Material 未設定状態にならないようにする
+4. ビルドまたはテストを実行する
+5. `branch-rules.md` に従って PR を作成する
+
+## 検証方法
+
+- 実行するビルド: `Graphics/Xelqoria.Graphics.vcxproj` Debug x64
+- 実行するテスト: 可能なら Graphics テスト
+- 手動確認項目: Sprite / SpriteMaterial 自身に描画処理が追加されていないこと
+
+## 完了条件
+
+- Sprite が SpriteMaterial 参照を持つ
+- Sprite が生成時点で default SpriteMaterial を持つ
+- Sprite::SetMaterial() / Sprite::GetMaterial() が追加されている
+- SetMaterial(nullptr) により Sprite が Material を持たない通常状態にならない
+- レイヤー責務に違反していない
+- `branch-rules.md` に従った PR が作成されている

--- a/docs/plans/issue-238-sprite-api-delegates-material.md
+++ b/docs/plans/issue-238-sprite-api-delegates-material.md
@@ -1,0 +1,49 @@
+# ExecPlan: issue-238 Sprite の既存描画情報 API を SpriteMaterial へ委譲する
+
+## 目的
+
+Sprite の既存 Texture / Color / Outline 系 API を互換 API として残し、内部実装を SpriteMaterial へ委譲する。
+
+## 対象範囲
+
+- 変更対象プロジェクト: Graphics
+- 変更対象ファイル: `Graphics/Source/Sprite.h`, `Graphics/Source/Sprite.cpp`
+- 変更対象クラス: `Xelqoria::Graphics::Sprite`
+- 影響する機能: Sprite の既存描画情報 API
+
+## 前提
+
+- parent issue: issue-235
+- 先行 issue: issue-237
+- ブランチ運用ルール: `docs/agents/branch-rules.md`
+- parent issue ブランチ: `issue-235`
+- この child issue のブランチ: `issue-238`
+- PR の向き: `issue-238` から `issue-235`
+
+## 実装方針
+
+SetTexture / GetTexture / SetTextureAssetId / GetTextureAssetId / SetColor / GetColor / Outline 系 API を SpriteMaterial へ委譲する。Sprite 側の Texture / Color / Outline 直接保持メンバーは削除し、SpriteMaterial を主所有箇所にする。
+
+## 作業手順
+
+1. 関連コードを確認する
+2. 既存 API の実装を SpriteMaterial へ委譲する
+3. Sprite 側の描画情報保持メンバーを削除する
+4. 必要な接続を確認する
+5. ビルドまたはテストを実行する
+6. `branch-rules.md` に従って PR を作成する
+
+## 検証方法
+
+- 実行するビルド: `Graphics/Xelqoria.Graphics.vcxproj` Debug x64
+- 実行するテスト: 可能なら Graphics テスト
+- 手動確認項目: Sprite / SpriteMaterial 自身に描画処理が追加されていないこと
+
+## 完了条件
+
+- 既存 Texture 系 API が SpriteMaterial へ委譲されている
+- 既存 Color 系 API が SpriteMaterial へ委譲されている
+- 既存 Outline 系 API が SpriteMaterial へ委譲されている
+- Sprite が Texture / Color / Outline を主所有する構造になっていない
+- レイヤー責務に違反していない
+- `branch-rules.md` に従った PR が作成されている


### PR DESCRIPTION
## 概要
- issue-237 をローカル merge した上で既存 API 委譲を実装
- Texture / TextureAssetId / Color / Outline 系 API を SpriteMaterial に委譲
- Sprite 側の Texture / Color / Outline 直接保持メンバーを削除
- ToDrawInput の既存接続は Material 値を使う形で維持

## Issue
- Parent: #235
- Child: #238
- Depends on: #237 / PR #244

## 検証
- MSBuild: Graphics/Xelqoria.Graphics.vcxproj Debug x64 成功
- LayerDependencyChecker passed