### PR TITLE
#241 SpriteMaterial 導入に伴うテストとクラス図を更新する

### DIFF
--- a/Graphics/Source/Sprite.cpp
+++ b/Graphics/Source/Sprite.cpp
@@ -1,9 +1,32 @@
 #include "Sprite.h"
 
+#include "SpriteMaterial.h"
+
 #include <utility>
 
 namespace Xelqoria::Graphics
 {
+	Sprite::Sprite()
+		: m_material(std::make_shared<SpriteMaterial>())
+	{
+	}
+
+	void Sprite::SetMaterial(std::shared_ptr<SpriteMaterial> material)
+	{
+		if (material)
+		{
+			m_material = std::move(material);
+			return;
+		}
+
+		m_material = std::make_shared<SpriteMaterial>();
+	}
+
+	std::shared_ptr<SpriteMaterial> Sprite::GetMaterial() const
+	{
+		return m_material;
+	}
+
 	void Sprite::SetTexture(std::shared_ptr <Texture2D> texture)
 	{
 		m_texture = std::move(texture);

--- a/Graphics/Source/Sprite.cpp
+++ b/Graphics/Source/Sprite.cpp
@@ -29,22 +29,22 @@ namespace Xelqoria::Graphics
 
 	void Sprite::SetTexture(std::shared_ptr <Texture2D> texture)
 	{
-		m_texture = std::move(texture);
+		m_material->SetTexture(std::move(texture));
 	}
 
 	std::shared_ptr<Texture2D> Sprite::GetTexture() const
 	{
-		return m_texture;
+		return m_material->GetTexture();
 	}
 
 	void Sprite::SetTextureAssetId(Core::AssetId assetId)
 	{
-		m_textureAssetId = std::move(assetId);
+		m_material->SetTextureAssetId(std::move(assetId));
 	}
 
 	const Core::AssetId& Sprite::GetTextureAssetId() const
 	{
-		return m_textureAssetId;
+		return m_material->GetTextureAssetId();
 	}
 
 	void Sprite::SetPosition(const Xelqoria::Math::Vector2& position)
@@ -89,56 +89,56 @@ namespace Xelqoria::Graphics
 
 	void Sprite::SetColor(float red, float green, float blue, float alpha)
 	{
-		m_color = { red, green, blue, alpha };
+		m_material->SetColor(red, green, blue, alpha);
 	}
 
 	const std::array<float, 4>& Sprite::GetColor() const
 	{
-		return m_color;
+		return m_material->GetColor();
 	}
 
 	void Sprite::SetOutlineEnabled(bool enabled)
 	{
-		m_outlineEnabled = enabled;
+		m_material->SetOutlineEnabled(enabled);
 	}
 
 	bool Sprite::IsOutlineEnabled() const
 	{
-		return m_outlineEnabled;
+		return m_material->IsOutlineEnabled();
 	}
 
 	void Sprite::SetOutlineThickness(float thickness)
 	{
-		m_outlineThickness = thickness;
+		m_material->SetOutlineThickness(thickness);
 	}
 
 	float Sprite::GetOutlineThickness() const
 	{
-		return m_outlineThickness;
+		return m_material->GetOutlineThickness();
 	}
 
 	void Sprite::SetOutlineColor(float red, float green, float blue, float alpha)
 	{
-		m_outlineColor = { red, green, blue, alpha };
+		m_material->SetOutlineColor(red, green, blue, alpha);
 	}
 
 	const std::array<float, 4>& Sprite::GetOutlineColor() const
 	{
-		return m_outlineColor;
+		return m_material->GetOutlineColor();
 	}
 
 	SpriteDrawInput Sprite::ToDrawInput() const
 	{
 		return SpriteDrawInput{
-			m_texture,
-			m_textureAssetId,
+			m_material->GetTexture(),
+			m_material->GetTextureAssetId(),
 			m_position,
 			m_scale,
 			m_rotationDegrees,
-			m_color,
-			m_outlineEnabled,
-			m_outlineThickness,
-			m_outlineColor
+			m_material->GetColor(),
+			m_material->IsOutlineEnabled(),
+			m_material->GetOutlineThickness(),
+			m_material->GetOutlineColor()
 		};
 	}
 }

--- a/Graphics/Source/Sprite.h
+++ b/Graphics/Source/Sprite.h
@@ -9,6 +9,7 @@
 
 namespace Xelqoria::Graphics
 {
+	class SpriteMaterial;
 	class Texture2D;
 
 	/// <summary>
@@ -17,6 +18,23 @@ namespace Xelqoria::Graphics
 	class Sprite
 	{
 	public:
+		/// <summary>
+		/// default SpriteMaterial を持つスプライトを生成する。
+		/// </summary>
+		Sprite();
+
+		/// <summary>
+		/// スプライトに使用する Material を設定する。
+		/// </summary>
+		/// <param name="material">設定する Material。nullptr の場合は default Material に戻す。</param>
+		void SetMaterial(std::shared_ptr<SpriteMaterial> material);
+
+		/// <summary>
+		/// 現在設定されている Material を取得する。
+		/// </summary>
+		/// <returns>スプライトに紐づく Material。</returns>
+		std::shared_ptr<SpriteMaterial> GetMaterial() const;
+
 		/// <summary>
 		/// スプライトに使用するテクスチャを設定する。
 		/// </summary>
@@ -152,6 +170,7 @@ namespace Xelqoria::Graphics
 		[[nodiscard]] SpriteDrawInput ToDrawInput() const;
 
 	private:
+		std::shared_ptr<SpriteMaterial> m_material;
 		std::shared_ptr<Texture2D> m_texture;
 		Core::AssetId m_textureAssetId{};
 		Xelqoria::Math::Vector2 m_position{};

--- a/Graphics/Source/Sprite.h
+++ b/Graphics/Source/Sprite.h
@@ -171,14 +171,8 @@ namespace Xelqoria::Graphics
 
 	private:
 		std::shared_ptr<SpriteMaterial> m_material;
-		std::shared_ptr<Texture2D> m_texture;
-		Core::AssetId m_textureAssetId{};
 		Xelqoria::Math::Vector2 m_position{};
 		Xelqoria::Math::Vector2 m_scale{ 1.0f, 1.0f };
 		float m_rotationDegrees = 0.0f;
-		std::array<float, 4> m_color{ 1.0f, 1.0f, 1.0f, 1.0f };
-		bool m_outlineEnabled = false;
-		float m_outlineThickness = 1.0f;
-		std::array<float, 4> m_outlineColor{ 1.0f, 1.0f, 0.0f, 1.0f };
 	};
 }

--- a/docs/class_diagram/graphics-class-diagram.md
+++ b/docs/class_diagram/graphics-class-diagram.md
@@ -35,15 +35,39 @@ classDiagram
             +GetRHITexture()
         }
 
-        class Sprite {
+        class SpriteMaterial {
             -m_texture shared_ptr~Texture2D~
             -m_textureAssetId AssetId
-            -m_position Vector2
-            -m_scale Vector2
-            -m_rotationDegrees float
+            -m_color array~float, 4~
+            -m_outlineEnabled bool
+            -m_outlineThickness float
+            -m_outlineColor array~float, 4~
             +SetTexture(...)
             +GetTexture()
             +SetTextureAssetId(...)
+            +GetTextureAssetId()
+            +SetColor(...)
+            +GetColor()
+            +SetOutlineEnabled(...)
+            +IsOutlineEnabled()
+            +SetOutlineThickness(...)
+            +GetOutlineThickness()
+            +SetOutlineColor(...)
+            +GetOutlineColor()
+        }
+
+        class Sprite {
+            -m_material shared_ptr~SpriteMaterial~
+            -m_position Vector2
+            -m_scale Vector2
+            -m_rotationDegrees float
+            +SetMaterial(...)
+            +GetMaterial()
+            +SetTexture(...)
+            +GetTexture()
+            +SetTextureAssetId(...)
+            +GetTextureAssetId()
+            +ToDrawInput()
         }
 
         class SpriteRenderer {
@@ -69,8 +93,9 @@ classDiagram
     TextureAssetRegistry ..|> ITextureAssetResolver
     Texture2D --> ITexture : wraps
     Texture2D ..> IGraphicsContext : loads via
-    Sprite --> Texture2D : holds
-    Sprite --> AssetId : references
+    SpriteMaterial --> Texture2D : holds
+    SpriteMaterial --> AssetId : references
+    Sprite --> SpriteMaterial : references
     Sprite ..> Vector2 : uses
     Sprite *-- Vector2
     SpriteRenderer --> IGraphicsContext : uses

--- a/docs/plans/issue-237-sprite-material-reference.md
+++ b/docs/plans/issue-237-sprite-material-reference.md
@@ -1,0 +1,47 @@
+# ExecPlan: issue-237 Sprite に SpriteMaterial 参照を導入する
+
+## 目的
+
+Sprite に SpriteMaterial 参照を導入し、生成時点で default SpriteMaterial を持つ設計にする。
+
+## 対象範囲
+
+- 変更対象プロジェクト: Graphics
+- 変更対象ファイル: `Graphics/Source/Sprite.h`, `Graphics/Source/Sprite.cpp`
+- 変更対象クラス: `Xelqoria::Graphics::Sprite`
+- 影響する機能: Sprite の Material 参照管理
+
+## 前提
+
+- parent issue: issue-235
+- ブランチ運用ルール: `docs/agents/branch-rules.md`
+- parent issue ブランチ: `issue-235`
+- この child issue のブランチ: `issue-237`
+- PR の向き: `issue-237` から `issue-235`
+
+## 実装方針
+
+Sprite は std::shared_ptr<SpriteMaterial> を持ち、コンストラクタで default SpriteMaterial を生成する。SetMaterial(nullptr) は Material 未設定状態を作らないように default SpriteMaterial へ戻す。既存の Texture / Color / Outline API の委譲は issue-238 で扱う。
+
+## 作業手順
+
+1. 関連コードを確認する
+2. Sprite にコンストラクタと SetMaterial / GetMaterial を追加する
+3. Sprite が Material 未設定状態にならないようにする
+4. ビルドまたはテストを実行する
+5. `branch-rules.md` に従って PR を作成する
+
+## 検証方法
+
+- 実行するビルド: `Graphics/Xelqoria.Graphics.vcxproj` Debug x64
+- 実行するテスト: 可能なら Graphics テスト
+- 手動確認項目: Sprite / SpriteMaterial 自身に描画処理が追加されていないこと
+
+## 完了条件
+
+- Sprite が SpriteMaterial 参照を持つ
+- Sprite が生成時点で default SpriteMaterial を持つ
+- Sprite::SetMaterial() / Sprite::GetMaterial() が追加されている
+- SetMaterial(nullptr) により Sprite が Material を持たない通常状態にならない
+- レイヤー責務に違反していない
+- `branch-rules.md` に従った PR が作成されている

--- a/docs/plans/issue-238-sprite-api-delegates-material.md
+++ b/docs/plans/issue-238-sprite-api-delegates-material.md
@@ -1,0 +1,49 @@
+# ExecPlan: issue-238 Sprite の既存描画情報 API を SpriteMaterial へ委譲する
+
+## 目的
+
+Sprite の既存 Texture / Color / Outline 系 API を互換 API として残し、内部実装を SpriteMaterial へ委譲する。
+
+## 対象範囲
+
+- 変更対象プロジェクト: Graphics
+- 変更対象ファイル: `Graphics/Source/Sprite.h`, `Graphics/Source/Sprite.cpp`
+- 変更対象クラス: `Xelqoria::Graphics::Sprite`
+- 影響する機能: Sprite の既存描画情報 API
+
+## 前提
+
+- parent issue: issue-235
+- 先行 issue: issue-237
+- ブランチ運用ルール: `docs/agents/branch-rules.md`
+- parent issue ブランチ: `issue-235`
+- この child issue のブランチ: `issue-238`
+- PR の向き: `issue-238` から `issue-235`
+
+## 実装方針
+
+SetTexture / GetTexture / SetTextureAssetId / GetTextureAssetId / SetColor / GetColor / Outline 系 API を SpriteMaterial へ委譲する。Sprite 側の Texture / Color / Outline 直接保持メンバーは削除し、SpriteMaterial を主所有箇所にする。
+
+## 作業手順
+
+1. 関連コードを確認する
+2. 既存 API の実装を SpriteMaterial へ委譲する
+3. Sprite 側の描画情報保持メンバーを削除する
+4. 必要な接続を確認する
+5. ビルドまたはテストを実行する
+6. `branch-rules.md` に従って PR を作成する
+
+## 検証方法
+
+- 実行するビルド: `Graphics/Xelqoria.Graphics.vcxproj` Debug x64
+- 実行するテスト: 可能なら Graphics テスト
+- 手動確認項目: Sprite / SpriteMaterial 自身に描画処理が追加されていないこと
+
+## 完了条件
+
+- 既存 Texture 系 API が SpriteMaterial へ委譲されている
+- 既存 Color 系 API が SpriteMaterial へ委譲されている
+- 既存 Outline 系 API が SpriteMaterial へ委譲されている
+- Sprite が Texture / Color / Outline を主所有する構造になっていない
+- レイヤー責務に違反していない
+- `branch-rules.md` に従った PR が作成されている

--- a/docs/plans/issue-239-sprite-drawinput-renderer-material.md
+++ b/docs/plans/issue-239-sprite-drawinput-renderer-material.md
@@ -1,0 +1,47 @@
+# ExecPlan: issue-239 SpriteDrawInput と SpriteRenderer を SpriteMaterial 経由に対応させる
+
+## 目的
+
+Sprite::ToDrawInput() が SpriteMaterial の描画情報を反映し、SpriteRenderer::Draw(const Sprite&) が Material 経由の描画情報で描画できることを確認する。
+
+## 対象範囲
+
+- 変更対象プロジェクト: Graphics, tests/Graphics
+- 変更対象ファイル: `Graphics/Source/Sprite.cpp`, `tests/Graphics/Source/SpriteRenderMathTests.cpp`
+- 変更対象クラス: `Xelqoria::Graphics::Sprite`, `Xelqoria::Graphics::SpriteRenderer`
+- 影響する機能: Sprite から SpriteDrawInput への変換、SpriteRenderer の Sprite 描画経路
+
+## 前提
+
+- parent issue: issue-235
+- 先行 issue: issue-238
+- ブランチ運用ルール: `docs/agents/branch-rules.md`
+- parent issue ブランチ: `issue-235`
+- この child issue のブランチ: `issue-239`
+- PR の向き: `issue-239` から `issue-235`
+
+## 実装方針
+
+issue-238 で Sprite::ToDrawInput() は SpriteMaterial の値を参照する形へ接続済み。SpriteRenderer::Draw(const Sprite&) は既存どおり ToDrawInput() を通す。ここでは Material 由来の色・外枠・テクスチャが renderer の描画定数へ反映されるテストを追加して経路を確認する。
+
+## 作業手順
+
+1. 関連コードを確認する
+2. SpriteRenderer::Draw(const Sprite&) の経路を確認する
+3. Material 由来の描画情報が反映されるテストを追加する
+4. ビルドまたはテストを実行する
+5. `branch-rules.md` に従って PR を作成する
+
+## 検証方法
+
+- 実行するビルド: `tests/Graphics/Xelqoria.Tests.Graphics.vcxproj` Debug x64
+- 実行するテスト: 可能なら Graphics テスト実行
+- 手動確認項目: RHI に SpriteMaterial / Material / Sprite / Renderer などの高レベル概念が追加されていないこと
+
+## 完了条件
+
+- Sprite::ToDrawInput() が SpriteMaterial の Texture / TextureAssetId / Color / Outline 情報を反映している
+- Sprite::ToDrawInput() が Sprite の Position / Scale / Rotation を維持している
+- SpriteRenderer::Draw(const Sprite&) で SpriteMaterial 経由の描画情報が反映される
+- レイヤー責務に違反していない
+- `branch-rules.md` に従った PR が作成されている

--- a/docs/plans/issue-240-sprite-material-sharing.md
+++ b/docs/plans/issue-240-sprite-material-sharing.md
@@ -1,0 +1,47 @@
+# ExecPlan: issue-240 SpriteMaterial 共有と個別 Material 運用を確認する
+
+## 目的
+
+複数 Sprite が同一 SpriteMaterial を共有できること、および個別に見た目を変更したい場合は個別 SpriteMaterial を設定できることを確認する。
+
+## 対象範囲
+
+- 変更対象プロジェクト: tests/Graphics
+- 変更対象ファイル: `tests/Graphics/Source/SpriteRenderMathTests.cpp`
+- 変更対象クラス: `Xelqoria::Graphics::Sprite`, `Xelqoria::Graphics::SpriteMaterial`
+- 影響する機能: SpriteMaterial 共有と個別 Material 設定
+
+## 前提
+
+- parent issue: issue-235
+- 先行 issue: issue-239
+- ブランチ運用ルール: `docs/agents/branch-rules.md`
+- parent issue ブランチ: `issue-235`
+- この child issue のブランチ: `issue-240`
+- PR の向き: `issue-240` から `issue-235`
+
+## 実装方針
+
+Sprite::SetMaterial() に同じ std::shared_ptr<SpriteMaterial> を設定した複数 Sprite が、共有 Material の変更を ToDrawInput() に反映することをテストする。さらに個別 SpriteMaterial を設定した Sprite は共有 Material の後続変更から独立することを確認する。
+
+## 作業手順
+
+1. 関連コードを確認する
+2. Material 共有のテストを追加する
+3. 個別 Material 設定のテストを追加する
+4. ビルドまたはテストを実行する
+5. `branch-rules.md` に従って PR を作成する
+
+## 検証方法
+
+- 実行するビルド: `tests/Graphics/Xelqoria.Tests.Graphics.vcxproj` Debug x64
+- 実行するテスト: `./artifacts/x64/Debug/Xelqoria.Tests.Graphics.exe`
+- 手動確認項目: 共有 SpriteMaterial の暗黙コピーが行われていないこと
+
+## 完了条件
+
+- 複数 Sprite が同じ SpriteMaterial を共有できる
+- 共有 SpriteMaterial を変更すると、それを参照している Sprite の描画に反映される
+- 個別に見た目を変更したい場合、個別の SpriteMaterial を設定できる
+- 共有 SpriteMaterial の暗黙コピーが行われない
+- `branch-rules.md` に従った PR が作成されている

--- a/docs/plans/issue-241-sprite-material-tests-diagram.md
+++ b/docs/plans/issue-241-sprite-material-tests-diagram.md
@@ -1,0 +1,47 @@
+# ExecPlan: issue-241 SpriteMaterial 導入に伴うテストとクラス図を更新する
+
+## 目的
+
+SpriteMaterial 導入後の主要な挙動をテストで確認し、Graphics クラス図を更新する。
+
+## 対象範囲
+
+- 変更対象プロジェクト: tests/Graphics, docs
+- 変更対象ファイル: `tests/Graphics/Source/SpriteRenderMathTests.cpp`, `docs/class_diagram/graphics-class-diagram.md`
+- 変更対象クラス: `Xelqoria::Graphics::Sprite`, `Xelqoria::Graphics::SpriteMaterial`
+- 影響する機能: SpriteMaterial の保持情報、Sprite の default Material、Graphics クラス図
+
+## 前提
+
+- parent issue: issue-235
+- 先行 issue: issue-240
+- ブランチ運用ルール: `docs/agents/branch-rules.md`
+- parent issue ブランチ: `issue-235`
+- この child issue のブランチ: `issue-241`
+- PR の向き: `issue-241` から `issue-235`
+
+## 実装方針
+
+既存の Graphics テストへ SpriteMaterial 単体の保持情報、Sprite の default Material、SetMaterial(nullptr) の挙動確認を追加する。Graphics クラス図は SpriteMaterial と Sprite からの参照関係を反映し、Sprite が Texture / Color / Outline を直接主所有する表現を削除する。
+
+## 作業手順
+
+1. 関連コードとクラス図を確認する
+2. SpriteMaterial / Sprite の追加テストを実装する
+3. Graphics クラス図を更新する
+4. ビルドまたはテストを実行する
+5. `branch-rules.md` に従って PR を作成する
+
+## 検証方法
+
+- 実行するビルド: `tests/Graphics/Xelqoria.Tests.Graphics.vcxproj` Debug x64
+- 実行するテスト: `./artifacts/x64/Debug/Xelqoria.Tests.Graphics.exe`
+- 手動確認項目: Graphics 層に Direct3D 型が混入していないこと、RHI に高レベル描画概念が追加されていないこと
+
+## 完了条件
+
+- SpriteMaterial 導入に関する主要な挙動がテストで確認されている
+- Graphics クラス図が SpriteMaterial 導入後の公開型と依存関係を表している
+- 既存テストが通る
+- レイヤー責務に違反していない
+- `branch-rules.md` に従った PR が作成されている

--- a/tests/Graphics/Source/SpriteRenderMathTests.cpp
+++ b/tests/Graphics/Source/SpriteRenderMathTests.cpp
@@ -166,6 +166,51 @@ TEST(SpriteRenderMathTests, SpriteStoresRenderStateAndComputesQuadTransform)
     EXPECT_TRUE(IsEqual(emptyTransform.rotationSin, 0.0f));
 }
 
+TEST(SpriteRenderMathTests, SpriteMaterialStoresRenderState)
+{
+    auto renderTexture = std::make_shared<Xelqoria::Graphics::Texture2D>();
+    renderTexture->SetRHITexture(std::make_shared<FakeTexture>(32, 16));
+
+    Xelqoria::Graphics::SpriteMaterial material;
+    material.SetTexture(renderTexture);
+    material.SetTextureAssetId("textures/material");
+    material.SetColor(0.2f, 0.4f, 0.6f, 0.8f);
+    material.SetOutlineEnabled(true);
+    material.SetOutlineThickness(6.0f);
+    material.SetOutlineColor(0.1f, 0.3f, 0.5f, 0.7f);
+
+    EXPECT_EQ(material.GetTexture(), renderTexture);
+    EXPECT_EQ(material.GetTextureAssetId(), Xelqoria::Core::AssetId("textures/material"));
+    EXPECT_TRUE(IsEqual(material.GetColor()[0], 0.2f));
+    EXPECT_TRUE(IsEqual(material.GetColor()[3], 0.8f));
+    EXPECT_TRUE(material.IsOutlineEnabled());
+    EXPECT_TRUE(IsEqual(material.GetOutlineThickness(), 6.0f));
+    EXPECT_TRUE(IsEqual(material.GetOutlineColor()[0], 0.1f));
+    EXPECT_TRUE(IsEqual(material.GetOutlineColor()[3], 0.7f));
+}
+
+TEST(SpriteRenderMathTests, SpriteAlwaysHasMaterial)
+{
+    Xelqoria::Graphics::Sprite sprite;
+
+    const std::shared_ptr<Xelqoria::Graphics::SpriteMaterial> defaultMaterial = sprite.GetMaterial();
+    ASSERT_NE(defaultMaterial, nullptr);
+
+    auto customMaterial = std::make_shared<Xelqoria::Graphics::SpriteMaterial>();
+    customMaterial->SetColor(0.3f, 0.5f, 0.7f, 0.9f);
+    sprite.SetMaterial(customMaterial);
+
+    EXPECT_EQ(sprite.GetMaterial(), customMaterial);
+    EXPECT_TRUE(IsEqual(sprite.ToDrawInput().color[1], 0.5f));
+
+    sprite.SetMaterial(nullptr);
+
+    ASSERT_NE(sprite.GetMaterial(), nullptr);
+    EXPECT_NE(sprite.GetMaterial(), customMaterial);
+    EXPECT_TRUE(IsEqual(sprite.ToDrawInput().color[0], 1.0f));
+    EXPECT_TRUE(IsEqual(sprite.ToDrawInput().outlineThickness, 1.0f));
+}
+
 TEST(SpriteRenderMathTests, SpriteCreatesCommonDrawInput)
 {
     Xelqoria::Graphics::Sprite sprite;

--- a/tests/Graphics/Source/SpriteRenderMathTests.cpp
+++ b/tests/Graphics/Source/SpriteRenderMathTests.cpp
@@ -11,6 +11,7 @@
 #include "Sprite.h"
 #include "SpriteCulling.h"
 #include "SpriteDrawInput.h"
+#include "SpriteMaterial.h"
 #include "SpriteRenderMath.h"
 #include "SpriteRenderer.h"
 #include "TextureAssetRegistry.h"
@@ -266,6 +267,58 @@ TEST(SpriteRenderMathTests, SpriteRendererDrawsSpriteUsingMaterialState)
     EXPECT_TRUE(IsEqual(context.lastConstants[11], 0.4f));
     EXPECT_TRUE(IsEqual(context.lastConstants[12], 0.25f));
     EXPECT_TRUE(IsEqual(context.lastConstants[15], 0.8f));
+}
+
+TEST(SpriteRenderMathTests, SpritesShareMaterialStateWithoutImplicitCopy)
+{
+    auto sharedMaterial = std::make_shared<Xelqoria::Graphics::SpriteMaterial>();
+
+    Xelqoria::Graphics::Sprite firstSprite;
+    Xelqoria::Graphics::Sprite secondSprite;
+    firstSprite.SetMaterial(sharedMaterial);
+    secondSprite.SetMaterial(sharedMaterial);
+
+    sharedMaterial->SetColor(0.2f, 0.4f, 0.6f, 0.8f);
+    sharedMaterial->SetOutlineEnabled(true);
+    sharedMaterial->SetOutlineThickness(5.0f);
+
+    const Xelqoria::Graphics::SpriteDrawInput firstInput = firstSprite.ToDrawInput();
+    const Xelqoria::Graphics::SpriteDrawInput secondInput = secondSprite.ToDrawInput();
+
+    EXPECT_EQ(firstSprite.GetMaterial(), sharedMaterial);
+    EXPECT_EQ(secondSprite.GetMaterial(), sharedMaterial);
+    EXPECT_TRUE(IsEqual(firstInput.color[0], 0.2f));
+    EXPECT_TRUE(IsEqual(secondInput.color[2], 0.6f));
+    EXPECT_TRUE(firstInput.outlineEnabled);
+    EXPECT_TRUE(secondInput.outlineEnabled);
+    EXPECT_TRUE(IsEqual(firstInput.outlineThickness, 5.0f));
+    EXPECT_TRUE(IsEqual(secondInput.outlineThickness, 5.0f));
+}
+
+TEST(SpriteRenderMathTests, SpriteCanUseIndividualMaterialState)
+{
+    auto sharedMaterial = std::make_shared<Xelqoria::Graphics::SpriteMaterial>();
+    sharedMaterial->SetColor(0.2f, 0.4f, 0.6f, 0.8f);
+
+    auto individualMaterial = std::make_shared<Xelqoria::Graphics::SpriteMaterial>();
+    individualMaterial->SetColor(0.9f, 0.7f, 0.5f, 0.3f);
+
+    Xelqoria::Graphics::Sprite sharedSprite;
+    Xelqoria::Graphics::Sprite individualSprite;
+    sharedSprite.SetMaterial(sharedMaterial);
+    individualSprite.SetMaterial(individualMaterial);
+
+    sharedMaterial->SetColor(0.1f, 0.2f, 0.3f, 0.4f);
+
+    const Xelqoria::Graphics::SpriteDrawInput sharedInput = sharedSprite.ToDrawInput();
+    const Xelqoria::Graphics::SpriteDrawInput individualInput = individualSprite.ToDrawInput();
+
+    EXPECT_EQ(sharedSprite.GetMaterial(), sharedMaterial);
+    EXPECT_EQ(individualSprite.GetMaterial(), individualMaterial);
+    EXPECT_TRUE(IsEqual(sharedInput.color[0], 0.1f));
+    EXPECT_TRUE(IsEqual(sharedInput.color[3], 0.4f));
+    EXPECT_TRUE(IsEqual(individualInput.color[0], 0.9f));
+    EXPECT_TRUE(IsEqual(individualInput.color[3], 0.3f));
 }
 
 TEST(SpriteRenderMathTests, SpriteCullingRejectsSpritesOutsideViewport)

--- a/tests/Graphics/Source/SpriteRenderMathTests.cpp
+++ b/tests/Graphics/Source/SpriteRenderMathTests.cpp
@@ -231,6 +231,43 @@ TEST(SpriteRenderMathTests, SpriteRendererDrawsCommonDrawInput)
     EXPECT_TRUE(IsEqual(context.lastConstants[15], 0.8f));
 }
 
+TEST(SpriteRenderMathTests, SpriteRendererDrawsSpriteUsingMaterialState)
+{
+    auto rhiTexture = std::make_shared<FakeTexture>(64, 32);
+    auto renderTexture = std::make_shared<Xelqoria::Graphics::Texture2D>();
+    renderTexture->SetRHITexture(rhiTexture);
+
+    Xelqoria::Graphics::Sprite sprite;
+    sprite.SetTexture(renderTexture);
+    sprite.SetPosition(160.0f, -90.0f);
+    sprite.SetScale(2.0f, 0.5f);
+    sprite.SetRotationDegrees(90.0f);
+    sprite.SetColor(0.25f, 0.5f, 0.75f, 0.8f);
+    sprite.SetOutlineEnabled(true);
+    sprite.SetOutlineThickness(4.0f);
+    sprite.SetOutlineColor(0.1f, 0.2f, 0.3f, 0.4f);
+
+    FakeGraphicsContext context{};
+    Xelqoria::Graphics::SpriteRenderer spriteRenderer(context);
+
+    spriteRenderer.Begin();
+    spriteRenderer.Draw(sprite);
+    spriteRenderer.End();
+
+    EXPECT_EQ(context.drawCount, 1u);
+    EXPECT_EQ(context.lastVertexCount, 6u);
+    EXPECT_EQ(context.lastStartVertexLocation, 0u);
+    EXPECT_EQ(context.lastBoundTexture, nullptr);
+    EXPECT_EQ(context.lastConstants.size(), Xelqoria::Graphics::QuadRenderConstantFloatCount);
+    EXPECT_TRUE(IsEqual(context.lastConstants[0], 0.2f));
+    EXPECT_TRUE(IsEqual(context.lastConstants[6], 1.0f));
+    EXPECT_TRUE(IsEqual(context.lastConstants[7], 4.0f));
+    EXPECT_TRUE(IsEqual(context.lastConstants[8], 0.1f));
+    EXPECT_TRUE(IsEqual(context.lastConstants[11], 0.4f));
+    EXPECT_TRUE(IsEqual(context.lastConstants[12], 0.25f));
+    EXPECT_TRUE(IsEqual(context.lastConstants[15], 0.8f));
+}
+
 TEST(SpriteRenderMathTests, SpriteCullingRejectsSpritesOutsideViewport)
 {
     auto renderTexture = std::make_shared<Xelqoria::Graphics::Texture2D>();


### PR DESCRIPTION
## 概要
- issue-240 をローカル merge した上で最終テストとクラス図を更新
- SpriteMaterial 単体の保持情報テストを追加
- Sprite が default Material を持ち、SetMaterial(nullptr) でも Material 未設定にならないことを確認
- Graphics クラス図へ SpriteMaterial と Sprite からの参照関係を反映

## Issue
- Parent: #235
- Child: #241
- Depends on: #240 / PR #247

## 検証
- MSBuild: tests/Graphics/Xelqoria.Tests.Graphics.vcxproj Debug x64 成功
- ./artifacts/x64/Debug/Xelqoria.Tests.Graphics.exe 成功（12 tests）
- LayerDependencyChecker passed
- RHI に SpriteMaterial / Material / Sprite / Renderer 概念を追加していないことを rg で確認