### PR TITLE
EditorTheme と Xelqoria Dark テーマを追加する

### DIFF
--- a/Editor.UI/Source/EditorTheme.h
+++ b/Editor.UI/Source/EditorTheme.h
@@ -1,0 +1,129 @@
+#pragma once
+
+namespace Xelqoria::Editor
+{
+    /// <summary>
+    /// Editor UI で共有する OS 非依存の RGBA 色を表す。
+    /// </summary>
+    struct EditorColor
+    {
+        /// <summary>
+        /// 赤成分。0.0 から 1.0 の範囲で扱う。
+        /// </summary>
+        float red = 0.0f;
+
+        /// <summary>
+        /// 緑成分。0.0 から 1.0 の範囲で扱う。
+        /// </summary>
+        float green = 0.0f;
+
+        /// <summary>
+        /// 青成分。0.0 から 1.0 の範囲で扱う。
+        /// </summary>
+        float blue = 0.0f;
+
+        /// <summary>
+        /// 透明度。0.0 から 1.0 の範囲で扱う。
+        /// </summary>
+        float alpha = 1.0f;
+
+        /// <summary>
+        /// 8bit RGB 値から不透明な EditorColor を作成する。
+        /// </summary>
+        /// <param name="redValue">赤成分。0 から 255 の範囲で扱う。</param>
+        /// <param name="greenValue">緑成分。0 から 255 の範囲で扱う。</param>
+        /// <param name="blueValue">青成分。0 から 255 の範囲で扱う。</param>
+        /// <returns>正規化済み RGBA 色。</returns>
+        [[nodiscard]] static constexpr EditorColor FromRgb8(int redValue, int greenValue, int blueValue)
+        {
+            constexpr float MaxChannelValue = 255.0f;
+            return EditorColor{
+                static_cast<float>(redValue) / MaxChannelValue,
+                static_cast<float>(greenValue) / MaxChannelValue,
+                static_cast<float>(blueValue) / MaxChannelValue,
+                1.0f
+            };
+        }
+    };
+
+    /// <summary>
+    /// Editor UI の見た目に使う共通テーマ色を保持する。
+    /// </summary>
+    struct EditorTheme
+    {
+        /// <summary>
+        /// Editor Window 全体の背景色。
+        /// </summary>
+        EditorColor windowBackground{};
+
+        /// <summary>
+        /// パネル本文の背景色。
+        /// </summary>
+        EditorColor panelBackground{};
+
+        /// <summary>
+        /// パネルヘッダーの背景色。
+        /// </summary>
+        EditorColor panelHeaderBackground{};
+
+        /// <summary>
+        /// パネル境界線の色。
+        /// </summary>
+        EditorColor panelBorder{};
+
+        /// <summary>
+        /// 主要テキスト色。
+        /// </summary>
+        EditorColor textPrimary{};
+
+        /// <summary>
+        /// 補助テキスト色。
+        /// </summary>
+        EditorColor textSecondary{};
+
+        /// <summary>
+        /// 強調表示に使うアクセント色。
+        /// </summary>
+        EditorColor accent{};
+
+        /// <summary>
+        /// 選択状態の背景色。
+        /// </summary>
+        EditorColor selection{};
+
+        /// <summary>
+        /// hover 状態の背景色。
+        /// </summary>
+        EditorColor hover{};
+
+        /// <summary>
+        /// 警告ログなどに使う色。
+        /// </summary>
+        EditorColor warning{};
+
+        /// <summary>
+        /// エラーログなどに使う色。
+        /// </summary>
+        EditorColor error{};
+    };
+
+    namespace EditorThemes
+    {
+        /// <summary>
+        /// Xelqoria Editor の既定暗色テーマ。
+        /// </summary>
+        inline constexpr EditorTheme XelqoriaDark{
+            EditorColor::FromRgb8(0x18, 0x1A, 0x20),
+            EditorColor::FromRgb8(0x20, 0x23, 0x2B),
+            EditorColor::FromRgb8(0x2A, 0x2D, 0x36),
+            EditorColor::FromRgb8(0x3A, 0x3F, 0x4B),
+            EditorColor::FromRgb8(0xE6, 0xEA, 0xF2),
+            EditorColor::FromRgb8(0x9A, 0xA3, 0xB2),
+            EditorColor::FromRgb8(0x5B, 0x7C, 0xFF),
+            EditorColor::FromRgb8(0x26, 0x36, 0x5F),
+            EditorColor::FromRgb8(0x2A, 0x2F, 0x3A),
+            EditorColor::FromRgb8(0xE6, 0xB4, 0x50),
+            EditorColor::FromRgb8(0xFF, 0x6B, 0x6B)
+        };
+    }
+}

--- a/Editor.UI/Xelqoria.Editor.UI.vcxproj
+++ b/Editor.UI/Xelqoria.Editor.UI.vcxproj
@@ -23,6 +23,7 @@
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="Source\ButtonClickInput.h" />
+    <ClInclude Include="Source\EditorTheme.h" />
     <ClInclude Include="Source\SceneViewSurface.h" />
   </ItemGroup>
   <ItemGroup>

--- a/Editor.UI/Xelqoria.Editor.UI.vcxproj.filters
+++ b/Editor.UI/Xelqoria.Editor.UI.vcxproj.filters
@@ -14,6 +14,9 @@
     <ClInclude Include="Source\ButtonClickInput.h">
       <Filter>Source</Filter>
     </ClInclude>
+    <ClInclude Include="Source\EditorTheme.h">
+      <Filter>Source</Filter>
+    </ClInclude>
     <ClInclude Include="Source\SceneViewSurface.h">
       <Filter>Source</Filter>
     </ClInclude>

--- a/docs/plans/issue-254-editor-theme.md
+++ b/docs/plans/issue-254-editor-theme.md
@@ -1,0 +1,50 @@
+# ExecPlan: issue-254 EditorTheme と Xelqoria Dark テーマを追加する
+
+## 目的
+
+Editor UI の見た目を一元管理する `EditorTheme` を `Editor.UI` に追加し、デフォルトテーマとして Xelqoria Dark を提供する。
+
+## 対象範囲
+
+- 変更対象プロジェクト: `Editor.UI`
+- 変更対象ファイル: `Editor.UI/Source/EditorTheme.h`, `Editor.UI/Xelqoria.Editor.UI.vcxproj`, `Editor.UI/Xelqoria.Editor.UI.vcxproj.filters`
+- 変更対象クラス: `EditorColor`, `EditorTheme`
+- 影響する機能: 後続 Editor View テーマ適用の共通土台
+
+## 前提
+
+- parent issue: #253
+- ブランチ運用ルール: `docs/agents/branch-rules.md`
+- parent issue ブランチ: `issue-253`
+- この child issue のブランチ: `issue-254`
+- PR の向き: `issue-254` -> `issue-253`
+
+## 実装方針
+
+Editor.UI の責務に収まる OS 非依存のテーマ定義を追加する。Win32、Direct3D、Backends には依存せず、色はコード固定の RGBA 値として表す。
+
+## 作業手順
+
+1. 関連コードと Editor.UI プロジェクト構成を確認する
+2. 既存の色表現型の有無を確認する
+3. `EditorTheme` と Xelqoria Dark のデフォルト定義を追加する
+4. Visual Studio プロジェクトにヘッダーを追加する
+5. ビルドまたは関連検証を実行する
+6. `branch-rules.md` に従って PR を作成する
+
+## 検証方法
+
+- 実行するビルド: `dotnet build tools/LayerDependencyChecker/LayerDependencyChecker.csproj -c Debug`
+- 実行するビルド: `msbuild Xelqoria.slnx /t:Xelqoria.Editor.UI /p:Configuration=Debug /p:Platform=x64`（環境に MSBuild がある場合）
+- 代替確認: `tools/LayerDependencyChecker/bin/Debug/net8.0/LayerDependencyChecker.exe D:\github\Xelqoria`
+- 実行するテスト: なし
+- 手動確認項目: `Editor.UI` が Backends / Direct3D / Platform.Win32 に依存していないこと
+
+## 完了条件
+
+- `Editor.UI` に `EditorTheme` 相当のテーマ定義が存在する
+- デフォルトテーマとして Xelqoria Dark が存在する
+- `EditorTheme` が対象色を一元管理できる
+- `Editor.UI` が Backends / Direct3D / Platform.Win32 に依存していない
+- Core に描画処理を追加していない
+- PR が `issue-253` 向けに作成されている


### PR DESCRIPTION
## 概要
- Editor.UI に OS 非依存の `EditorColor` / `EditorTheme` を追加
- デフォルトテーマ `EditorThemes::XelqoriaDark` をコード固定で追加
- `Editor.UI` の vcxproj / filters と child issue 用 ExecPlan を更新

## Issue
- Parent: #253
- Child: #254

## 検証
- PASS: `dotnet build tools\LayerDependencyChecker\LayerDependencyChecker.csproj -c Debug`
- PASS: `tools\LayerDependencyChecker\bin\Debug\net8.0\LayerDependencyChecker.exe D:\github\Xelqoria`
- 未実行: `msbuild Xelqoria.slnx /t:Xelqoria.Editor.UI /p:Configuration=Debug /p:Platform=x64`
  - この環境では `msbuild` と Visual C++ targets (`$(VCTargetsPath)\Microsoft.Cpp.Default.props`) が見つからないため。