### PR TITLE
Editor タブの active / inactive / hover 表示をテーマ対応する

### DIFF
--- a/Editor/Source/Application.cpp
+++ b/Editor/Source/Application.cpp
@@ -303,6 +303,11 @@ namespace Xelqoria::Editor
         m_window.SetDrawItemHandler(
             [this](Platform::NativeMessageParameter drawItemParameter)
             {
+                if (m_editorShell.HandleDrawItem(static_cast<LPARAM>(drawItemParameter)))
+                {
+                    return true;
+                }
+
                 return m_logOutputPanelController.HandleDrawItem(static_cast<LPARAM>(drawItemParameter));
             });
         m_window.SetCloseRequestHandler(

--- a/Editor/Source/EditorShell.cpp
+++ b/Editor/Source/EditorShell.cpp
@@ -22,6 +22,7 @@ namespace Xelqoria::Editor
     {
         constexpr UINT_PTR ParentWindowSubclassId = 1;
         constexpr UINT_PTR SpriteRefEditSubclassId = 1;
+        constexpr UINT_PTR EditorTabControlSubclassId = 2;
         constexpr const wchar_t* WorkspaceBackgroundWindowClassName = L"XelqoriaEditorWorkspaceBackground";
         constexpr const wchar_t* EditorPanelWindowClassName = L"XelqoriaEditorPanel";
         constexpr const wchar_t* DockPreviewWindowClassName = L"XelqoriaDockPreviewWindow";
@@ -75,6 +76,20 @@ namespace Xelqoria::Editor
             SelectObject(deviceContext, previousBrush);
             SelectObject(deviceContext, previousPen);
             DeleteObject(pen);
+        }
+
+        [[nodiscard]] int GetHoveredTabIndex(HWND tabControl)
+        {
+            POINT cursorPoint{};
+            if (FALSE == GetCursorPos(&cursorPoint))
+            {
+                return -1;
+            }
+
+            ScreenToClient(tabControl, &cursorPoint);
+            TCHITTESTINFO hitTestInfo{};
+            hitTestInfo.pt = cursorPoint;
+            return TabCtrl_HitTest(tabControl, &hitTestInfo);
         }
 
         LRESULT CALLBACK WorkspaceBackgroundWindowProc(HWND window, UINT message, WPARAM wParam, LPARAM lParam)
@@ -650,11 +665,15 @@ namespace Xelqoria::Editor
             return false;
         }
 
-        constexpr DWORD tabStyle = WS_CHILD | WS_VISIBLE | WS_CLIPSIBLINGS | TCS_TABS;
+        constexpr DWORD tabStyle = WS_CHILD | WS_VISIBLE | WS_CLIPSIBLINGS | TCS_TABS | TCS_OWNERDRAWFIXED;
         m_leftTopDockTab = CreateChildWindow(parentWindow, hInstance, WC_TABCONTROLW, L"", tabStyle);
         m_leftBottomDockTab = CreateChildWindow(parentWindow, hInstance, WC_TABCONTROLW, L"", tabStyle);
         m_centerDockTab = CreateChildWindow(parentWindow, hInstance, WC_TABCONTROLW, L"", tabStyle);
         m_rightDockTab = CreateChildWindow(parentWindow, hInstance, WC_TABCONTROLW, L"", tabStyle);
+        ConfigureEditorTabControl(m_leftTopDockTab);
+        ConfigureEditorTabControl(m_leftBottomDockTab);
+        ConfigureEditorTabControl(m_centerDockTab);
+        ConfigureEditorTabControl(m_rightDockTab);
         m_dockPreviewWindow = CreateChildWindow(
             parentWindow,
             hInstance,
@@ -1334,11 +1353,12 @@ namespace Xelqoria::Editor
             hInstance,
             WC_TABCONTROLW,
             L"",
-            WS_CHILD | WS_VISIBLE | WS_CLIPSIBLINGS | TCS_TABS);
+            WS_CHILD | WS_VISIBLE | WS_CLIPSIBLINGS | TCS_TABS | TCS_OWNERDRAWFIXED);
         if (nullptr == m_logOutputTabControl)
         {
             return false;
         }
+        ConfigureEditorTabControl(m_logOutputTabControl);
 
         const std::array<const wchar_t*, 3> tabNames{ L"ゲームログ", L"ビルドログ", L"エディタログ" };
         for (std::size_t index = 0; index < tabNames.size(); ++index)
@@ -2756,6 +2776,17 @@ namespace Xelqoria::Editor
         return true;
     }
 
+    bool EditorShell::HandleDrawItem(LPARAM drawItemParameter) const
+    {
+        const DRAWITEMSTRUCT* drawItem = reinterpret_cast<const DRAWITEMSTRUCT*>(drawItemParameter);
+        if (nullptr == drawItem)
+        {
+            return false;
+        }
+
+        return DrawEditorTabControl(*drawItem);
+    }
+
     void EditorShell::ShowPanelControls(EditorPanelId panelId, bool visible) const
     {
         const int showCommand = visible ? SW_SHOW : SW_HIDE;
@@ -3676,10 +3707,11 @@ namespace Xelqoria::Editor
             reinterpret_cast<HINSTANCE>(GetWindowLongPtrW(parentWindow, GWLP_HINSTANCE)),
             WC_TABCONTROLW,
             L"",
-            WS_CHILD | WS_VISIBLE | WS_CLIPSIBLINGS | TCS_TABS);
+            WS_CHILD | WS_VISIBLE | WS_CLIPSIBLINGS | TCS_TABS | TCS_OWNERDRAWFIXED);
         if (nullptr != tabControl)
         {
             SendMessageW(tabControl, WM_SETFONT, reinterpret_cast<WPARAM>(m_defaultFont), TRUE);
+            ConfigureEditorTabControl(tabControl);
         }
         m_floatingPanelGroups.push_back(FloatingPanelGroup{
             floatingWindow,
@@ -4099,7 +4131,7 @@ namespace Xelqoria::Editor
             return nullptr;
         }
 
-        constexpr DWORD tabStyle = WS_CHILD | WS_VISIBLE | WS_CLIPSIBLINGS | TCS_TABS;
+        constexpr DWORD tabStyle = WS_CHILD | WS_VISIBLE | WS_CLIPSIBLINGS | TCS_TABS | TCS_OWNERDRAWFIXED;
         HWND tabControl = CreateChildWindow(
             parentWindow,
             reinterpret_cast<HINSTANCE>(GetWindowLongPtrW(parentWindow, GWLP_HINSTANCE)),
@@ -4112,6 +4144,7 @@ namespace Xelqoria::Editor
         }
 
         SendMessageW(tabControl, WM_SETFONT, reinterpret_cast<WPARAM>(m_defaultFont), TRUE);
+        ConfigureEditorTabControl(tabControl);
         ShowWindow(tabControl, SW_HIDE);
         m_dynamicDockTabs.push_back(tabControl);
         return tabControl;
@@ -4142,6 +4175,87 @@ namespace Xelqoria::Editor
             m_logOutputDockTab = tabControl;
         }
         return tabControl;
+    }
+
+    void EditorShell::ConfigureEditorTabControl(HWND tabControl) const
+    {
+        if (nullptr == tabControl)
+        {
+            return;
+        }
+
+        SendMessageW(tabControl, TCM_SETITEMSIZE, 0, MAKELPARAM(ScaleMetric(132), ScaleMetric(28)));
+        SetWindowSubclass(
+            tabControl,
+            EditorShell::EditorTabControlSubclassProc,
+            EditorTabControlSubclassId,
+            0);
+    }
+
+    bool EditorShell::DrawEditorTabControl(const DRAWITEMSTRUCT& drawItem) const
+    {
+        if (ODT_TAB != drawItem.CtlType || nullptr == drawItem.hwndItem || nullptr == drawItem.hDC)
+        {
+            return false;
+        }
+
+        const int tabIndex = static_cast<int>(drawItem.itemID);
+        if (tabIndex < 0)
+        {
+            return true;
+        }
+
+        const int activeTabIndex = TabCtrl_GetCurSel(drawItem.hwndItem);
+        const int hoveredTabIndex = GetHoveredTabIndex(drawItem.hwndItem);
+        const bool isActive = tabIndex == activeTabIndex;
+        const bool isHovered = tabIndex == hoveredTabIndex;
+
+        EditorColor backgroundColor = EditorThemes::XelqoriaDark.panelBackground;
+        EditorColor textColor = EditorThemes::XelqoriaDark.textSecondary;
+        if (isHovered)
+        {
+            backgroundColor = EditorThemes::XelqoriaDark.hover;
+            textColor = EditorThemes::XelqoriaDark.textPrimary;
+        }
+        if (isActive)
+        {
+            backgroundColor = EditorThemes::XelqoriaDark.panelHeaderBackground;
+            textColor = EditorThemes::XelqoriaDark.textPrimary;
+        }
+
+        RECT tabRect = drawItem.rcItem;
+        FillRectWithThemeColor(drawItem.hDC, tabRect, backgroundColor);
+        DrawRectBorder(drawItem.hDC, tabRect, EditorThemes::XelqoriaDark.panelBorder);
+
+        if (isActive)
+        {
+            RECT accentRect = tabRect;
+            accentRect.top = (std::max)(accentRect.top, accentRect.bottom - ScaleMetric(3));
+            FillRectWithThemeColor(drawItem.hDC, accentRect, EditorThemes::XelqoriaDark.accent);
+        }
+
+        wchar_t tabText[128]{};
+        TCITEMW item{};
+        item.mask = TCIF_TEXT;
+        item.pszText = tabText;
+        item.cchTextMax = static_cast<int>(std::size(tabText));
+        TabCtrl_GetItem(drawItem.hwndItem, tabIndex, &item);
+
+        SetBkMode(drawItem.hDC, TRANSPARENT);
+        SetTextColor(drawItem.hDC, ToColorRef(textColor));
+
+        RECT textRect = tabRect;
+        textRect.left += ScaleMetric(10);
+        textRect.right -= ScaleMetric(10);
+        textRect.bottom -= ScaleMetric(2);
+        DrawTextW(
+            drawItem.hDC,
+            tabText,
+            -1,
+            &textRect,
+            DT_LEFT | DT_SINGLELINE | DT_VCENTER | DT_END_ELLIPSIS);
+
+        return true;
     }
 
     std::wstring EditorShell::GetDockTabLayoutKey(HWND tabControl) const
@@ -4729,6 +4843,14 @@ namespace Xelqoria::Editor
                 }
             }
 
+            if (WM_DRAWITEM == message)
+            {
+                if (windowData->shell->HandleDrawItem(lParam))
+                {
+                    return TRUE;
+                }
+            }
+
             if (WM_MOVING == message)
             {
                 windowData->shell->BeginFloatingWindowDockDrag(windowData->shell->GetActiveFloatingPanel(window));
@@ -4754,6 +4876,38 @@ namespace Xelqoria::Editor
         }
 
         return DefWindowProcW(window, message, wParam, lParam);
+    }
+
+    LRESULT CALLBACK EditorShell::EditorTabControlSubclassProc(
+        HWND window,
+        UINT message,
+        WPARAM wParam,
+        LPARAM lParam,
+        UINT_PTR subclassId,
+        DWORD_PTR referenceData)
+    {
+        (void)subclassId;
+        (void)referenceData;
+
+        if (WM_MOUSEMOVE == message)
+        {
+            TRACKMOUSEEVENT trackMouseEvent{};
+            trackMouseEvent.cbSize = sizeof(trackMouseEvent);
+            trackMouseEvent.dwFlags = TME_LEAVE;
+            trackMouseEvent.hwndTrack = window;
+            TrackMouseEvent(&trackMouseEvent);
+            InvalidateRect(window, nullptr, FALSE);
+        }
+        else if (WM_MOUSELEAVE == message)
+        {
+            InvalidateRect(window, nullptr, FALSE);
+        }
+        else if (WM_NCDESTROY == message)
+        {
+            RemoveWindowSubclass(window, EditorShell::EditorTabControlSubclassProc, EditorTabControlSubclassId);
+        }
+
+        return DefSubclassProc(window, message, wParam, lParam);
     }
 
     LRESULT CALLBACK EditorShell::ParentWindowSubclassProc(

--- a/Editor/Source/EditorShell.cpp
+++ b/Editor/Source/EditorShell.cpp
@@ -122,7 +122,8 @@ namespace Xelqoria::Editor
                 RECT clientRect{};
                 GetClientRect(window, &clientRect);
 
-                const int headerHeight = (std::min)(26, (std::max)(0, clientRect.bottom - clientRect.top));
+                const int clientHeight = static_cast<int>(clientRect.bottom - clientRect.top);
+                const int headerHeight = (std::min)(26, (std::max)(0, clientHeight));
                 RECT headerRect = clientRect;
                 headerRect.bottom = headerRect.top + headerHeight;
 

--- a/Editor/Source/EditorShell.h
+++ b/Editor/Source/EditorShell.h
@@ -330,6 +330,13 @@ namespace Xelqoria::Editor
         bool HandleNotify(LPARAM notifyParameter);
 
         /// <summary>
+        /// EditorShell が所有する owner draw control の描画を処理する。
+        /// </summary>
+        /// <param name="drawItemParameter">WM_DRAWITEM の LPARAM。</param>
+        /// <returns>描画を処理した場合は true。</returns>
+        bool HandleDrawItem(LPARAM drawItemParameter) const;
+
+        /// <summary>
         /// 現在開いているプロジェクト画面レイアウトを初期状態へ戻す。
         /// </summary>
         void ResetDockLayout();
@@ -747,6 +754,19 @@ namespace Xelqoria::Editor
         [[nodiscard]] HWND CreateDockTabControlForLayoutKey(const std::wstring& layoutKey);
 
         /// <summary>
+        /// Editor 用 TabControl の共通外観設定を適用する。
+        /// </summary>
+        /// <param name="tabControl">設定対象 TabControl。</param>
+        void ConfigureEditorTabControl(HWND tabControl) const;
+
+        /// <summary>
+        /// Editor 用 TabControl の owner draw 描画を行う。
+        /// </summary>
+        /// <param name="drawItem">描画情報。</param>
+        /// <returns>描画を処理した場合は true。</returns>
+        bool DrawEditorTabControl(const DRAWITEMSTRUCT& drawItem) const;
+
+        /// <summary>
         /// Dock leaf の TabControl を保存用識別子へ変換する。
         /// </summary>
         [[nodiscard]] std::wstring GetDockTabLayoutKey(HWND tabControl) const;
@@ -857,6 +877,17 @@ namespace Xelqoria::Editor
         /// フローティングビュー用 window procedure。
         /// </summary>
         static LRESULT CALLBACK FloatingPanelWindowProc(HWND window, UINT message, WPARAM wParam, LPARAM lParam);
+
+        /// <summary>
+        /// Editor 用 TabControl の hover 再描画を処理する。
+        /// </summary>
+        static LRESULT CALLBACK EditorTabControlSubclassProc(
+            HWND window,
+            UINT message,
+            WPARAM wParam,
+            LPARAM lParam,
+            UINT_PTR subclassId,
+            DWORD_PTR referenceData);
 
         /// <summary>
         /// Editor 親ウィンドウのテーマ背景と標準コントロール色を処理する。

--- a/docs/plans/issue-256-editor-tab-theme.md
+++ b/docs/plans/issue-256-editor-tab-theme.md
@@ -1,0 +1,52 @@
+# ExecPlan: issue-256 Editor タブの active / inactive / hover 表示をテーマ対応する
+
+## 目的
+
+Editor のタブ表示を Xelqoria Dark テーマに合わせ、active / inactive / hover を視覚的に区別できるようにする。
+
+## 対象範囲
+
+- 変更対象プロジェクト: `Editor`
+- 変更対象ファイル: `Editor/Source/Application.cpp`, `Editor/Source/EditorShell.h`, `Editor/Source/EditorShell.cpp`
+- 変更対象クラス: `Application`, `EditorShell`
+- 影響する機能: Dock / Floating / Console の TabControl 外観
+
+## 前提
+
+- parent issue: #253
+- 前提 child issue: #254, #255
+- ブランチ運用ルール: `docs/agents/branch-rules.md`
+- parent issue ブランチ: `issue-253`
+- この child issue のブランチ: `issue-256`
+- PR の向き: `issue-256` -> `issue-253`
+
+## 実装方針
+
+既存の Docking データ構造やタブ切り替え処理は維持する。TabControl を owner draw にし、`EditorThemes::XelqoriaDark` の `PanelBackground` / `PanelHeaderBackground` / `Hover` / `Accent` / `TextPrimary` / `TextSecondary` を使って active / inactive / hover を描き分ける。
+
+hover 表示は TabControl のサブクラスでマウス移動時に再描画を促すだけに留め、ドラッグやタブ切り替えの挙動は変更しない。
+
+## 作業手順
+
+1. TabControl の生成箇所と通知処理を確認する
+2. Dock / Floating / Console の TabControl を owner draw にする
+3. `EditorShell` に owner draw 描画処理を追加する
+4. `Application` から `EditorShell` の draw handler を呼ぶ
+5. 依存チェックと可能なビルドを実行する
+
+## 検証方法
+
+- 実行するビルド: `dotnet build tools/LayerDependencyChecker/LayerDependencyChecker.csproj -c Debug`
+- 実行する依存チェック: `tools/LayerDependencyChecker/bin/Debug/net8.0/LayerDependencyChecker.exe D:\github\Xelqoria`
+- 実行する静的確認: `git diff --check`
+- 実行するビルド: `msbuild Xelqoria.slnx /t:Xelqoria.Editor /p:Configuration=Debug /p:Platform=x64`（環境に MSBuild がある場合）
+- 実行するテスト: なし
+
+## 完了条件
+
+- タブの active 状態が視覚的に分かる
+- タブの inactive 状態が active と区別できる
+- タブの hover 状態が active / inactive と区別できる
+- タブ表示が `EditorTheme` の色を参照している
+- 既存の Docking 操作やタブ切り替え挙動を変更していない
+- PR が `issue-253` 向けに作成されている


### PR DESCRIPTION
## 概要
- Dock / Floating / Console の TabControl を owner draw 化
- `EditorThemes::XelqoriaDark` の色で active / inactive / hover を描き分け
- active タブに Accent 色の下線を追加
- TabControl サブクラスで hover 再描画を促す処理を追加
- `Application` の draw item handler から `EditorShell` の owner draw 処理を先に呼ぶように変更
- child issue 用 ExecPlan を追加

## Issue
- Parent: #253
- Child: #256

## 検証
- PASS: `dotnet build tools\LayerDependencyChecker\LayerDependencyChecker.csproj -c Debug`
- PASS: `tools\LayerDependencyChecker\bin\Debug\net8.0\LayerDependencyChecker.exe D:\github\Xelqoria`
- PASS: `git diff --check`
- 未実行: `msbuild Xelqoria.slnx /t:Xelqoria.Editor /p:Configuration=Debug /p:Platform=x64`
  - この環境では `msbuild` と Visual C++ targets (`$(VCTargetsPath)\Microsoft.Cpp.Default.props`) が見つからないため。