### PR TITLE
Hierarchy / Assets の選択状態・hover 表示をテーマ対応する

### DIFF
--- a/Editor/Source/EditorShell.cpp
+++ b/Editor/Source/EditorShell.cpp
@@ -23,6 +23,8 @@ namespace Xelqoria::Editor
         constexpr UINT_PTR ParentWindowSubclassId = 1;
         constexpr UINT_PTR SpriteRefEditSubclassId = 1;
         constexpr UINT_PTR EditorTabControlSubclassId = 2;
+        constexpr UINT_PTR EditorRowControlSubclassId = 3;
+        constexpr int EditorRowHeight = 22;
         constexpr const wchar_t* WorkspaceBackgroundWindowClassName = L"XelqoriaEditorWorkspaceBackground";
         constexpr const wchar_t* EditorPanelWindowClassName = L"XelqoriaEditorPanel";
         constexpr const wchar_t* DockPreviewWindowClassName = L"XelqoriaDockPreviewWindow";
@@ -90,6 +92,56 @@ namespace Xelqoria::Editor
             TCHITTESTINFO hitTestInfo{};
             hitTestInfo.pt = cursorPoint;
             return TabCtrl_HitTest(tabControl, &hitTestInfo);
+        }
+
+        [[nodiscard]] int GetHoveredListBoxIndex(HWND listBox)
+        {
+            POINT cursorPoint{};
+            if (FALSE == GetCursorPos(&cursorPoint))
+            {
+                return -1;
+            }
+
+            ScreenToClient(listBox, &cursorPoint);
+            RECT clientRect{};
+            GetClientRect(listBox, &clientRect);
+            if (FALSE == PtInRect(&clientRect, cursorPoint))
+            {
+                return -1;
+            }
+
+            const LRESULT hitResult = SendMessageW(
+                listBox,
+                LB_ITEMFROMPOINT,
+                0,
+                MAKELPARAM(cursorPoint.x, cursorPoint.y));
+            if (0 != HIWORD(hitResult))
+            {
+                return -1;
+            }
+
+            return LOWORD(hitResult);
+        }
+
+        [[nodiscard]] int GetHoveredListViewIndex(HWND listView)
+        {
+            POINT cursorPoint{};
+            if (FALSE == GetCursorPos(&cursorPoint))
+            {
+                return -1;
+            }
+
+            ScreenToClient(listView, &cursorPoint);
+            RECT clientRect{};
+            GetClientRect(listView, &clientRect);
+            if (FALSE == PtInRect(&clientRect, cursorPoint))
+            {
+                return -1;
+            }
+
+            LVHITTESTINFO hitTestInfo{};
+            hitTestInfo.pt = cursorPoint;
+            return ListView_HitTest(listView, &hitTestInfo);
         }
 
         LRESULT CALLBACK WorkspaceBackgroundWindowProc(HWND window, UINT message, WPARAM wParam, LPARAM lParam)
@@ -902,11 +954,14 @@ namespace Xelqoria::Editor
             hInstance,
             L"ListBox",
             L"",
-            WS_CHILD | WS_VISIBLE | WS_VSCROLL | LBS_NOTIFY | LBS_NOINTEGRALHEIGHT | WS_BORDER);
+            WS_CHILD | WS_VISIBLE | WS_VSCROLL | LBS_NOTIFY | LBS_OWNERDRAWFIXED | LBS_HASSTRINGS | LBS_NOINTEGRALHEIGHT | WS_BORDER);
         if (nullptr == m_hierarchyListBox)
         {
             return false;
         }
+
+        SendMessageW(m_hierarchyListBox, LB_SETITEMHEIGHT, 0, static_cast<LPARAM>(ScaleMetric(EditorRowHeight)));
+        SetWindowSubclass(m_hierarchyListBox, EditorRowControlSubclassProc, EditorRowControlSubclassId, 0);
 
         m_hierarchyNameEdit = CreateChildWindow(
             parentWindow,
@@ -980,10 +1035,11 @@ namespace Xelqoria::Editor
         {
             ListView_SetExtendedListViewStyle(
                 m_assetsListView,
-                LVS_EX_FULLROWSELECT | LVS_EX_GRIDLINES | LVS_EX_DOUBLEBUFFER);
+                LVS_EX_FULLROWSELECT | LVS_EX_DOUBLEBUFFER);
             ListView_SetBkColor(m_assetsListView, ToColorRef(EditorThemes::XelqoriaDark.panelBackground));
             ListView_SetTextBkColor(m_assetsListView, ToColorRef(EditorThemes::XelqoriaDark.panelBackground));
             ListView_SetTextColor(m_assetsListView, ToColorRef(EditorThemes::XelqoriaDark.textPrimary));
+            SetWindowSubclass(m_assetsListView, EditorRowControlSubclassProc, EditorRowControlSubclassId, 0);
         }
 
         return nullptr != m_assetsListView;
@@ -2785,7 +2841,12 @@ namespace Xelqoria::Editor
             return false;
         }
 
-        return DrawEditorTabControl(*drawItem);
+        if (DrawEditorTabControl(*drawItem))
+        {
+            return true;
+        }
+
+        return DrawHierarchyListBoxItem(*drawItem);
     }
 
     void EditorShell::ShowPanelControls(EditorPanelId panelId, bool visible) const
@@ -4259,6 +4320,101 @@ namespace Xelqoria::Editor
         return true;
     }
 
+    bool EditorShell::DrawHierarchyListBoxItem(const DRAWITEMSTRUCT& drawItem) const
+    {
+        if (ODT_LISTBOX != drawItem.CtlType
+            || drawItem.hwndItem != m_hierarchyListBox
+            || nullptr == drawItem.hDC)
+        {
+            return false;
+        }
+
+        if (static_cast<UINT>(-1) == drawItem.itemID)
+        {
+            FillRectWithThemeColor(drawItem.hDC, drawItem.rcItem, EditorThemes::XelqoriaDark.panelBackground);
+            return true;
+        }
+
+        const bool isSelected = 0 != (drawItem.itemState & ODS_SELECTED);
+        const bool isHovered = static_cast<int>(drawItem.itemID) == GetHoveredListBoxIndex(drawItem.hwndItem);
+
+        EditorColor backgroundColor = EditorThemes::XelqoriaDark.panelBackground;
+        EditorColor textColor = EditorThemes::XelqoriaDark.textPrimary;
+        if (isHovered)
+        {
+            backgroundColor = EditorThemes::XelqoriaDark.hover;
+        }
+        if (isSelected)
+        {
+            backgroundColor = EditorThemes::XelqoriaDark.selection;
+        }
+
+        FillRectWithThemeColor(drawItem.hDC, drawItem.rcItem, backgroundColor);
+
+        wchar_t itemText[256]{};
+        SendMessageW(
+            drawItem.hwndItem,
+            LB_GETTEXT,
+            drawItem.itemID,
+            reinterpret_cast<LPARAM>(itemText));
+
+        SetBkMode(drawItem.hDC, TRANSPARENT);
+        SetTextColor(drawItem.hDC, ToColorRef(textColor));
+
+        RECT textRect = drawItem.rcItem;
+        textRect.left += ScaleMetric(8);
+        textRect.right -= ScaleMetric(8);
+        DrawTextW(
+            drawItem.hDC,
+            itemText,
+            -1,
+            &textRect,
+            DT_LEFT | DT_SINGLELINE | DT_VCENTER | DT_END_ELLIPSIS);
+
+        return true;
+    }
+
+    std::optional<LRESULT> EditorShell::DrawAssetsListViewItem(LPARAM customDrawParameter) const
+    {
+        const NMLVCUSTOMDRAW* customDraw = reinterpret_cast<const NMLVCUSTOMDRAW*>(customDrawParameter);
+        if (nullptr == customDraw
+            || customDraw->nmcd.hdr.hwndFrom != m_assetsListView
+            || customDraw->nmcd.hdr.code != NM_CUSTOMDRAW)
+        {
+            return std::nullopt;
+        }
+
+        if (CDDS_PREPAINT == customDraw->nmcd.dwDrawStage)
+        {
+            return CDRF_NOTIFYITEMDRAW;
+        }
+
+        if (CDDS_ITEMPREPAINT != customDraw->nmcd.dwDrawStage)
+        {
+            return CDRF_DODEFAULT;
+        }
+
+        NMLVCUSTOMDRAW* mutableCustomDraw = const_cast<NMLVCUSTOMDRAW*>(customDraw);
+        const int itemIndex = static_cast<int>(customDraw->nmcd.dwItemSpec);
+        const bool isSelected = 0 != (customDraw->nmcd.uItemState & CDIS_SELECTED);
+        const bool isHovered = itemIndex == GetHoveredListViewIndex(m_assetsListView);
+
+        EditorColor backgroundColor = EditorThemes::XelqoriaDark.panelBackground;
+        EditorColor textColor = EditorThemes::XelqoriaDark.textPrimary;
+        if (isHovered)
+        {
+            backgroundColor = EditorThemes::XelqoriaDark.hover;
+        }
+        if (isSelected)
+        {
+            backgroundColor = EditorThemes::XelqoriaDark.selection;
+        }
+
+        mutableCustomDraw->clrText = ToColorRef(textColor);
+        mutableCustomDraw->clrTextBk = ToColorRef(backgroundColor);
+        return CDRF_DODEFAULT;
+    }
+
     std::wstring EditorShell::GetDockTabLayoutKey(HWND tabControl) const
     {
         if (tabControl == m_leftTopDockTab)
@@ -4697,6 +4853,11 @@ namespace Xelqoria::Editor
             }
         }
 
+        if (nullptr != m_hierarchyListBox)
+        {
+            SendMessageW(m_hierarchyListBox, LB_SETITEMHEIGHT, 0, static_cast<LPARAM>(ScaleMetric(EditorRowHeight)));
+        }
+
         if (ownedPreviousFont && nullptr != previousFont)
         {
             DeleteObject(previousFont);
@@ -4829,6 +4990,13 @@ namespace Xelqoria::Editor
 
             if (WM_NOTIFY == message)
             {
+                const std::optional<LRESULT> themeResult =
+                    windowData->shell->HandleThemeMessage(message, wParam, lParam);
+                if (true == themeResult.has_value())
+                {
+                    return *themeResult;
+                }
+
                 NMHDR* notifyHeader = reinterpret_cast<NMHDR*>(lParam);
                 const int groupIndex = windowData->shell->FindFloatingPanelGroupIndex(window);
                 if (nullptr != notifyHeader
@@ -4911,6 +5079,38 @@ namespace Xelqoria::Editor
         return DefSubclassProc(window, message, wParam, lParam);
     }
 
+    LRESULT CALLBACK EditorShell::EditorRowControlSubclassProc(
+        HWND window,
+        UINT message,
+        WPARAM wParam,
+        LPARAM lParam,
+        UINT_PTR subclassId,
+        DWORD_PTR referenceData)
+    {
+        (void)subclassId;
+        (void)referenceData;
+
+        if (WM_MOUSEMOVE == message)
+        {
+            TRACKMOUSEEVENT trackMouseEvent{};
+            trackMouseEvent.cbSize = sizeof(trackMouseEvent);
+            trackMouseEvent.dwFlags = TME_LEAVE;
+            trackMouseEvent.hwndTrack = window;
+            TrackMouseEvent(&trackMouseEvent);
+            InvalidateRect(window, nullptr, FALSE);
+        }
+        else if (WM_MOUSELEAVE == message)
+        {
+            InvalidateRect(window, nullptr, FALSE);
+        }
+        else if (WM_NCDESTROY == message)
+        {
+            RemoveWindowSubclass(window, EditorShell::EditorRowControlSubclassProc, EditorRowControlSubclassId);
+        }
+
+        return DefSubclassProc(window, message, wParam, lParam);
+    }
+
     LRESULT CALLBACK EditorShell::ParentWindowSubclassProc(
         HWND window,
         UINT message,
@@ -4936,6 +5136,17 @@ namespace Xelqoria::Editor
 
     std::optional<LRESULT> EditorShell::HandleThemeMessage(UINT message, WPARAM wParam, LPARAM lParam) const
     {
+        if (WM_NOTIFY == message)
+        {
+            const NMHDR* notifyHeader = reinterpret_cast<const NMHDR*>(lParam);
+            if (nullptr != notifyHeader
+                && notifyHeader->hwndFrom == m_assetsListView
+                && notifyHeader->code == NM_CUSTOMDRAW)
+            {
+                return DrawAssetsListViewItem(lParam);
+            }
+        }
+
         if (WM_ERASEBKGND == message)
         {
             HDC deviceContext = reinterpret_cast<HDC>(wParam);

--- a/Editor/Source/EditorShell.h
+++ b/Editor/Source/EditorShell.h
@@ -767,6 +767,20 @@ namespace Xelqoria::Editor
         bool DrawEditorTabControl(const DRAWITEMSTRUCT& drawItem) const;
 
         /// <summary>
+        /// Hierarchy ListBox の owner draw 描画を行う。
+        /// </summary>
+        /// <param name="drawItem">描画情報。</param>
+        /// <returns>描画を処理した場合は true。</returns>
+        bool DrawHierarchyListBoxItem(const DRAWITEMSTRUCT& drawItem) const;
+
+        /// <summary>
+        /// Assets ListView の custom draw 色をテーマに沿って設定する。
+        /// </summary>
+        /// <param name="customDrawParameter">NMLVCUSTOMDRAW の LPARAM。</param>
+        /// <returns>custom draw の戻り値。対象外の場合は空。</returns>
+        [[nodiscard]] std::optional<LRESULT> DrawAssetsListViewItem(LPARAM customDrawParameter) const;
+
+        /// <summary>
         /// Dock leaf の TabControl を保存用識別子へ変換する。
         /// </summary>
         [[nodiscard]] std::wstring GetDockTabLayoutKey(HWND tabControl) const;
@@ -882,6 +896,17 @@ namespace Xelqoria::Editor
         /// Editor 用 TabControl の hover 再描画を処理する。
         /// </summary>
         static LRESULT CALLBACK EditorTabControlSubclassProc(
+            HWND window,
+            UINT message,
+            WPARAM wParam,
+            LPARAM lParam,
+            UINT_PTR subclassId,
+            DWORD_PTR referenceData);
+
+        /// <summary>
+        /// 行表示コントロールの hover 再描画を処理する。
+        /// </summary>
+        static LRESULT CALLBACK EditorRowControlSubclassProc(
             HWND window,
             UINT message,
             WPARAM wParam,

--- a/docs/plans/issue-257-hierarchy-assets-row-theme.md
+++ b/docs/plans/issue-257-hierarchy-assets-row-theme.md
@@ -1,0 +1,53 @@
+# ExecPlan: issue-257 Hierarchy / Assets の選択状態・hover 表示をテーマ対応する
+
+## 目的
+
+Hierarchy / Assets の行表示、選択状態、hover 表示を `Xelqoria Dark` の共通テーマに沿って統一する。
+
+## 対象範囲
+
+- 変更対象プロジェクト: `Editor`
+- 変更対象ファイル: `Editor/Source/EditorShell.cpp`, `Editor/Source/EditorShell.h`
+- 変更対象クラス: `Xelqoria::Editor::EditorShell`
+- 影響する機能: Hierarchy ListBox、Assets ListView の行描画
+
+## 前提
+
+- parent issue: #253
+- ブランチ運用ルール: `docs/agents/branch-rules.md`
+- parent issue ブランチ: `issue-253`
+- この child issue のブランチ: `issue-257`
+- PR の向き: `issue-257` -> `issue-253`
+
+## 実装方針
+
+Win32 標準コントロールの既存操作は維持し、描画色のみ `EditorTheme` に寄せる。
+
+Hierarchy は ListBox を owner draw 化し、selected は `selection`、hover は `hover`、通常行は `panelBackground` で描画する。
+
+Assets は ListView の `NM_CUSTOMDRAW` を親ウィンドウ側で処理し、selected / hover / 通常行の背景色とテキスト色をテーマに合わせる。
+
+## 作業手順
+
+1. Hierarchy ListBox と Assets ListView の生成・通知経路を確認する
+2. Hierarchy ListBox を owner draw fixed に変更する
+3. 行表示コントロールの hover 再描画用 subclass を追加する
+4. Assets ListView の custom draw で行色を設定する
+5. ビルドとレイヤー依存チェックを実行する
+6. `branch-rules.md` に従って PR を作成する
+
+## 検証方法
+
+- 実行するビルド: `Xelqoria.Editor.vcxproj` Debug x64
+- 実行するテスト: `LayerDependencyChecker`
+- 手動確認項目: Hierarchy / Assets の selected と hover がテーマ色で区別できる
+
+## 完了条件
+
+- Hierarchy の Entity 行の hover / selected 表示がテーマに沿っている
+- Assets のアセット行の hover / selected 表示がテーマに沿っている
+- hover と selected が視覚的に区別できる
+- アイコン描画や Entity / Asset 操作仕様を変更していない
+- ビルドが通る
+- レイヤー責務に違反していない
+- `issue-257` から `issue-253` への PR が作成されている


### PR DESCRIPTION
## 概要
- #253 の子 Issue #257 に対応
- Hierarchy ListBox を owner draw 化し、通常 / hover / selected 行を `Xelqoria Dark` のテーマ色で描画
- Assets ListView の custom draw で通常 / hover / selected 行の背景色とテキスト色をテーマ化
- 行表示コントロールの hover 再描画用 subclass を追加
- child issue 用 ExecPlan を追加

## 検証
- `MSBuild.exe Editor\Xelqoria.Editor.vcxproj /p:Configuration=Debug /p:Platform=x64 /m`
- `git diff --check`
- `tools\LayerDependencyChecker\bin\Debug\net8.0\LayerDependencyChecker.exe D:\github\Xelqoria`

Closes #257