### PR TITLE
Inspector のセクション表示と入力欄の見た目をテーマ対応する

### DIFF
--- a/Editor/Source/EditorShell.cpp
+++ b/Editor/Source/EditorShell.cpp
@@ -693,7 +693,8 @@ namespace Xelqoria::Editor
         m_parentWindow = parentWindow;
         m_windowBackgroundBrush = CreateSolidBrush(ToColorRef(EditorThemes::XelqoriaDark.windowBackground));
         m_panelBackgroundBrush = CreateSolidBrush(ToColorRef(EditorThemes::XelqoriaDark.panelBackground));
-        if (nullptr == m_windowBackgroundBrush || nullptr == m_panelBackgroundBrush)
+        m_inputBackgroundBrush = CreateSolidBrush(ToColorRef(EditorThemes::XelqoriaDark.panelHeaderBackground));
+        if (nullptr == m_windowBackgroundBrush || nullptr == m_panelBackgroundBrush || nullptr == m_inputBackgroundBrush)
         {
             return false;
         }
@@ -817,6 +818,12 @@ namespace Xelqoria::Editor
         {
             DeleteObject(m_panelBackgroundBrush);
             m_panelBackgroundBrush = nullptr;
+        }
+
+        if (nullptr != m_inputBackgroundBrush)
+        {
+            DeleteObject(m_inputBackgroundBrush);
+            m_inputBackgroundBrush = nullptr;
         }
 
         if (m_ownsDefaultFont && nullptr != m_defaultFont)
@@ -1070,7 +1077,7 @@ namespace Xelqoria::Editor
             hInstance,
             L"Static",
             L"Transform",
-            WS_CHILD | WS_VISIBLE);
+            WS_CHILD | WS_VISIBLE | SS_OWNERDRAW);
         if (nullptr == m_transformSectionLabel)
         {
             return false;
@@ -1103,7 +1110,7 @@ namespace Xelqoria::Editor
             hInstance,
             L"Static",
             L"SpriteComponent",
-            WS_CHILD | WS_VISIBLE);
+            WS_CHILD | WS_VISIBLE | SS_OWNERDRAW);
         if (nullptr == m_spriteComponentSectionLabel)
         {
             return false;
@@ -1862,15 +1869,15 @@ namespace Xelqoria::Editor
         const int outerPadding = ScaleMetric(12);
         const int groupHeaderHeight = ScaleMetric(26);
         const int labelHeight = ScaleMetric(24);
-        const int rowHeight = ScaleMetric(24);
-        const int rowSpacing = ScaleMetric(8);
+        const int rowHeight = ScaleMetric(26);
+        const int rowSpacing = ScaleMetric(6);
         const int sectionSpacing = ScaleMetric(12);
-        const int labelWidth = ScaleMetric(72);
+        const int labelWidth = ScaleMetric(78);
         const int width = panelRect.right - panelRect.left;
         const int height = panelRect.bottom - panelRect.top;
         const int innerX = panelRect.left + outerPadding;
         const int innerWidth = (std::max)(0, width - outerPadding * 2);
-        const int editWidth = (std::max)(0, (innerWidth - labelWidth - ScaleMetric(24)) / 3);
+        const int editWidth = (std::max)(0, (innerWidth - labelWidth - ScaleMetric(16)) / 3);
         const int transformTop = panelRect.top + groupHeaderHeight + labelHeight + ScaleMetric(8);
         const int spriteSectionTop = transformTop + labelHeight + ScaleMetric(4) + 3 * (rowHeight + rowSpacing) + sectionSpacing;
         const int spriteRefTop = spriteSectionTop + labelHeight + ScaleMetric(4);
@@ -2842,6 +2849,11 @@ namespace Xelqoria::Editor
         }
 
         if (DrawEditorTabControl(*drawItem))
+        {
+            return true;
+        }
+
+        if (DrawInspectorSectionLabel(*drawItem))
         {
             return true;
         }
@@ -4374,6 +4386,45 @@ namespace Xelqoria::Editor
         return true;
     }
 
+    bool EditorShell::DrawInspectorSectionLabel(const DRAWITEMSTRUCT& drawItem) const
+    {
+        if (ODT_STATIC != drawItem.CtlType
+            || nullptr == drawItem.hwndItem
+            || nullptr == drawItem.hDC
+            || (drawItem.hwndItem != m_transformSectionLabel
+                && drawItem.hwndItem != m_spriteComponentSectionLabel))
+        {
+            return false;
+        }
+
+        RECT sectionRect = drawItem.rcItem;
+        FillRectWithThemeColor(drawItem.hDC, sectionRect, EditorThemes::XelqoriaDark.panelHeaderBackground);
+        DrawRectBorder(drawItem.hDC, sectionRect, EditorThemes::XelqoriaDark.panelBorder);
+
+        RECT accentRect = sectionRect;
+        const LONG accentWidth = static_cast<LONG>(ScaleMetric(4));
+        accentRect.right = (std::min)(accentRect.right, accentRect.left + accentWidth);
+        FillRectWithThemeColor(drawItem.hDC, accentRect, EditorThemes::XelqoriaDark.accent);
+
+        wchar_t sectionText[128]{};
+        GetWindowTextW(drawItem.hwndItem, sectionText, static_cast<int>(std::size(sectionText)));
+
+        SetBkMode(drawItem.hDC, TRANSPARENT);
+        SetTextColor(drawItem.hDC, ToColorRef(EditorThemes::XelqoriaDark.textPrimary));
+
+        RECT textRect = sectionRect;
+        textRect.left += ScaleMetric(12);
+        textRect.right -= ScaleMetric(8);
+        DrawTextW(
+            drawItem.hDC,
+            sectionText,
+            -1,
+            &textRect,
+            DT_LEFT | DT_SINGLELINE | DT_VCENTER | DT_END_ELLIPSIS);
+
+        return true;
+    }
+
     std::optional<LRESULT> EditorShell::DrawAssetsListViewItem(LPARAM customDrawParameter) const
     {
         const NMLVCUSTOMDRAW* customDraw = reinterpret_cast<const NMLVCUSTOMDRAW*>(customDrawParameter);
@@ -5171,13 +5222,64 @@ namespace Xelqoria::Editor
                 return std::nullopt;
             }
 
+            HWND control = reinterpret_cast<HWND>(lParam);
+            if (WM_CTLCOLOREDIT == message && IsInspectorInputControl(control) && nullptr != m_inputBackgroundBrush)
+            {
+                SetBkMode(deviceContext, OPAQUE);
+                SetBkColor(deviceContext, ToColorRef(EditorThemes::XelqoriaDark.panelHeaderBackground));
+                SetTextColor(
+                    deviceContext,
+                    ToColorRef(IsWindowEnabled(control) ? EditorThemes::XelqoriaDark.textPrimary : EditorThemes::XelqoriaDark.textSecondary));
+                return reinterpret_cast<LRESULT>(m_inputBackgroundBrush);
+            }
+
             SetBkMode(deviceContext, TRANSPARENT);
             SetBkColor(deviceContext, ToColorRef(EditorThemes::XelqoriaDark.panelBackground));
-            SetTextColor(deviceContext, ToColorRef(EditorThemes::XelqoriaDark.textPrimary));
+            SetTextColor(
+                deviceContext,
+                ToColorRef(IsInspectorSecondaryLabel(control) ? EditorThemes::XelqoriaDark.textSecondary : EditorThemes::XelqoriaDark.textPrimary));
             return reinterpret_cast<LRESULT>(m_panelBackgroundBrush);
         }
 
         return std::nullopt;
+    }
+
+    bool EditorShell::IsInspectorInputControl(HWND window) const
+    {
+        if (nullptr == window)
+        {
+            return false;
+        }
+
+        for (HWND transformEdit : m_transformEditControls)
+        {
+            if (window == transformEdit)
+            {
+                return true;
+            }
+        }
+
+        return window == m_spriteRefEdit || window == m_scriptAssetEdit;
+    }
+
+    bool EditorShell::IsInspectorSecondaryLabel(HWND window) const
+    {
+        if (nullptr == window)
+        {
+            return false;
+        }
+
+        for (HWND transformLabel : m_transformLabels)
+        {
+            if (window == transformLabel)
+            {
+                return true;
+            }
+        }
+
+        return window == m_inspectorSummaryLabel
+            || window == m_spriteRefLabel
+            || window == m_scriptAssetLabel;
     }
 
     HWND EditorShell::GetHierarchyListBox() const

--- a/Editor/Source/EditorShell.h
+++ b/Editor/Source/EditorShell.h
@@ -774,6 +774,13 @@ namespace Xelqoria::Editor
         bool DrawHierarchyListBoxItem(const DRAWITEMSTRUCT& drawItem) const;
 
         /// <summary>
+        /// Inspector セクション見出しの owner draw 描画を行う。
+        /// </summary>
+        /// <param name="drawItem">描画情報。</param>
+        /// <returns>描画を処理した場合は true。</returns>
+        bool DrawInspectorSectionLabel(const DRAWITEMSTRUCT& drawItem) const;
+
+        /// <summary>
         /// Assets ListView の custom draw 色をテーマに沿って設定する。
         /// </summary>
         /// <param name="customDrawParameter">NMLVCUSTOMDRAW の LPARAM。</param>
@@ -934,6 +941,20 @@ namespace Xelqoria::Editor
         /// <returns>処理結果。未処理の場合は空。</returns>
         [[nodiscard]] std::optional<LRESULT> HandleThemeMessage(UINT message, WPARAM wParam, LPARAM lParam) const;
 
+        /// <summary>
+        /// Inspector 入力欄かを判定する。
+        /// </summary>
+        /// <param name="window">判定対象 HWND。</param>
+        /// <returns>Inspector 入力欄の場合は true。</returns>
+        [[nodiscard]] bool IsInspectorInputControl(HWND window) const;
+
+        /// <summary>
+        /// Inspector 補助ラベルかを判定する。
+        /// </summary>
+        /// <param name="window">判定対象 HWND。</param>
+        /// <returns>Inspector 補助ラベルの場合は true。</returns>
+        [[nodiscard]] bool IsInspectorSecondaryLabel(HWND window) const;
+
     private:
         /// <summary>
         /// 共通設定を適用した子ウィンドウを生成する。
@@ -1006,6 +1027,7 @@ namespace Xelqoria::Editor
         HFONT m_defaultFont = nullptr;
         HBRUSH m_windowBackgroundBrush = nullptr;
         HBRUSH m_panelBackgroundBrush = nullptr;
+        HBRUSH m_inputBackgroundBrush = nullptr;
         UINT m_currentDpi = 96;
         bool m_ownsDefaultFont = false;
         HWND m_parentWindow = nullptr;

--- a/docs/plans/issue-258-inspector-theme.md
+++ b/docs/plans/issue-258-inspector-theme.md
@@ -1,0 +1,54 @@
+# ExecPlan: issue-258 Inspector のセクション表示と入力欄の見た目をテーマ対応する
+
+## 目的
+
+Inspector のセクション表示と入力欄の見た目を `Xelqoria Dark` に合わせ、白背景の標準コントロール感を減らす。
+
+## 対象範囲
+
+- 変更対象プロジェクト: `Editor`
+- 変更対象ファイル: `Editor/Source/EditorShell.cpp`, `Editor/Source/EditorShell.h`
+- 変更対象クラス: `Xelqoria::Editor::EditorShell`
+- 影響する機能: Inspector の Transform / SpriteComponent セクション、Inspector 入力欄
+
+## 前提
+
+- parent issue: #253
+- ブランチ運用ルール: `docs/agents/branch-rules.md`
+- parent issue ブランチ: `issue-253`
+- この child issue のブランチ: `issue-258`
+- PR の向き: `issue-258` -> `issue-253`
+
+## 実装方針
+
+入力処理や編集対象データ構造は変更しない。
+
+Transform / SpriteComponent のセクション見出しは既存 Static を owner draw 化し、テーマのヘッダー色、境界線、アクセント色で描画する。
+
+Inspector の Edit コントロールは親ウィンドウの `WM_CTLCOLOREDIT` で判定し、テーマの暗色入力背景とテキスト色を適用する。
+
+## 作業手順
+
+1. Inspector の生成・レイアウト・色適用経路を確認する
+2. セクション見出しを owner draw 化する
+3. Inspector 入力欄だけ暗色入力背景を適用する
+4. ラベル幅、行高、余白を調整する
+5. ビルドとレイヤー依存チェックを実行する
+6. `branch-rules.md` に従って PR を作成する
+
+## 検証方法
+
+- 実行するビルド: `Xelqoria.Editor.vcxproj` Debug x64
+- 実行するテスト: `LayerDependencyChecker`
+- 手動確認項目: Inspector のセクション、ラベル、入力欄がテーマ色で表示され、既存編集操作が維持される
+
+## 完了条件
+
+- Inspector のセクション表示がテーマに沿って整理されている
+- 入力欄の背景が白背景の標準 UI のように浮いていない
+- ラベルと値の余白が揃っている
+- 数値入力欄のサイズが揃っている
+- 入力処理や編集対象データ構造を変更していない
+- ビルドが通る
+- レイヤー責務に違反していない
+- `issue-258` から `issue-253` への PR が作成されている


### PR DESCRIPTION
## 概要
- #253 の子 Issue #258 に対応
- Inspector の Transform / SpriteComponent セクション見出しを owner draw 化し、テーマのヘッダー色・境界線・アクセントで描画
- Inspector の入力欄だけ暗色入力背景とテキスト色を適用
- ラベル幅、行高、余白を調整し、Transform 数値入力欄のサイズを揃える
- child issue 用 ExecPlan を追加

## 検証
- `MSBuild.exe Editor\Xelqoria.Editor.vcxproj /p:Configuration=Debug /p:Platform=x64 /m`
- `git diff --check`
- `tools\LayerDependencyChecker\bin\Debug\net8.0\LayerDependencyChecker.exe D:\github\Xelqoria`

Closes #258