### PR TITLE
LogOutput / Console のログ表示色をテーマ対応する

### DIFF
--- a/Editor/Source/LogOutputPanelController.cpp
+++ b/Editor/Source/LogOutputPanelController.cpp
@@ -1,9 +1,11 @@
 #include "LogOutputPanelController.h"
 
+#include <algorithm>
 #include <CommCtrl.h>
 #include <utility>
 
 #include "ButtonClickWin32Adapter.h"
+#include "EditorTheme.h"
 
 namespace Xelqoria::Editor
 {
@@ -22,6 +24,43 @@ namespace Xelqoria::Editor
             }
 
             return text.find(filter) != std::wstring::npos;
+        }
+
+        [[nodiscard]] BYTE ToColorByte(float value)
+        {
+            const float clampedValue = (std::max)(0.0f, (std::min)(1.0f, value));
+            return static_cast<BYTE>((clampedValue * 255.0f) + 0.5f);
+        }
+
+        [[nodiscard]] COLORREF ToColorRef(EditorColor color)
+        {
+            return RGB(ToColorByte(color.red), ToColorByte(color.green), ToColorByte(color.blue));
+        }
+
+        void FillRectWithThemeColor(HDC deviceContext, const RECT& rect, EditorColor color)
+        {
+            HBRUSH brush = CreateSolidBrush(ToColorRef(color));
+            FillRect(deviceContext, &rect, brush);
+            DeleteObject(brush);
+        }
+
+        [[nodiscard]] LogOutputSeverity InferSeverity(
+            const std::wstring& message,
+            bool isError)
+        {
+            if (isError)
+            {
+                return LogOutputSeverity::Error;
+            }
+
+            if (message.find(L"warning") != std::wstring::npos
+                || message.find(L"Warning") != std::wstring::npos
+                || message.find(L"警告") != std::wstring::npos)
+            {
+                return LogOutputSeverity::Warning;
+            }
+
+            return LogOutputSeverity::Normal;
         }
     }
 
@@ -44,7 +83,8 @@ namespace Xelqoria::Editor
             return;
         }
 
-        m_logs[index].push_back(LogOutputEntry{ std::move(message), isError });
+        const LogOutputSeverity severity = InferSeverity(message, isError);
+        m_logs[index].push_back(LogOutputEntry{ std::move(message), severity });
         if (GetActiveCategory() == category)
         {
             RefreshVisibleRows();
@@ -113,15 +153,20 @@ namespace Xelqoria::Editor
         }
 
         const bool isSelected = 0 != (drawItem->itemState & ODS_SELECTED);
-        const COLORREF backgroundColor = GetSysColor(isSelected ? COLOR_HIGHLIGHT : COLOR_WINDOW);
-        const COLORREF textColor =
-            0 != drawItem->itemData
-                ? RGB(190, 0, 0)
-                : GetSysColor(isSelected ? COLOR_HIGHLIGHTTEXT : COLOR_WINDOWTEXT);
+        const auto severity = static_cast<LogOutputSeverity>(drawItem->itemData);
+        const EditorColor backgroundColor =
+            isSelected ? EditorThemes::XelqoriaDark.selection : EditorThemes::XelqoriaDark.panelBackground;
+        EditorColor textColor = EditorThemes::XelqoriaDark.textPrimary;
+        if (LogOutputSeverity::Warning == severity)
+        {
+            textColor = EditorThemes::XelqoriaDark.warning;
+        }
+        else if (LogOutputSeverity::Error == severity)
+        {
+            textColor = EditorThemes::XelqoriaDark.error;
+        }
 
-        HBRUSH backgroundBrush = CreateSolidBrush(backgroundColor);
-        FillRect(drawItem->hDC, &drawItem->rcItem, backgroundBrush);
-        DeleteObject(backgroundBrush);
+        FillRectWithThemeColor(drawItem->hDC, drawItem->rcItem, backgroundColor);
 
         const LRESULT textLength = SendMessageW(
             drawItem->hwndItem,
@@ -139,8 +184,9 @@ namespace Xelqoria::Editor
             text.resize(static_cast<std::size_t>(textLength));
 
             RECT textRect = drawItem->rcItem;
-            textRect.left += 2;
-            const COLORREF previousTextColor = SetTextColor(drawItem->hDC, textColor);
+            textRect.left += 8;
+            textRect.right -= 8;
+            const COLORREF previousTextColor = SetTextColor(drawItem->hDC, ToColorRef(textColor));
             const int previousBackgroundMode = SetBkMode(drawItem->hDC, TRANSPARENT);
             DrawTextW(
                 drawItem->hDC,
@@ -154,7 +200,15 @@ namespace Xelqoria::Editor
 
         if (0 != (drawItem->itemState & ODS_FOCUS))
         {
-            DrawFocusRect(drawItem->hDC, &drawItem->rcItem);
+            RECT focusRect = drawItem->rcItem;
+            InflateRect(&focusRect, -1, -1);
+            HPEN focusPen = CreatePen(PS_SOLID, 1, ToColorRef(EditorThemes::XelqoriaDark.accent));
+            HGDIOBJ previousPen = SelectObject(drawItem->hDC, focusPen);
+            HGDIOBJ previousBrush = SelectObject(drawItem->hDC, GetStockObject(NULL_BRUSH));
+            Rectangle(drawItem->hDC, focusRect.left, focusRect.top, focusRect.right, focusRect.bottom);
+            SelectObject(drawItem->hDC, previousBrush);
+            SelectObject(drawItem->hDC, previousPen);
+            DeleteObject(focusPen);
         }
 
         return true;
@@ -182,7 +236,7 @@ namespace Xelqoria::Editor
                         m_listBox,
                         LB_SETITEMDATA,
                         static_cast<WPARAM>(itemIndex),
-                        static_cast<LPARAM>(log.isError ? 1 : 0));
+                        static_cast<LPARAM>(log.severity));
                 }
             }
         }

--- a/Editor/Source/LogOutputPanelController.h
+++ b/Editor/Source/LogOutputPanelController.h
@@ -23,6 +23,16 @@ namespace Xelqoria::Editor
     };
 
     /// <summary>
+    /// LogOutput の表示 severity を表す。
+    /// </summary>
+    enum class LogOutputSeverity
+    {
+        Normal = 0,
+        Warning = 1,
+        Error = 2
+    };
+
+    /// <summary>
     /// LogOutput パネルの表示と操作を管理する。
     /// </summary>
     class LogOutputPanelController
@@ -68,7 +78,7 @@ namespace Xelqoria::Editor
         struct LogOutputEntry
         {
             std::wstring message{};
-            bool isError = false;
+            LogOutputSeverity severity = LogOutputSeverity::Normal;
         };
 
         /// <summary>

--- a/docs/plans/issue-259-log-output-theme.md
+++ b/docs/plans/issue-259-log-output-theme.md
@@ -1,0 +1,52 @@
+# ExecPlan: issue-259 LogOutput / Console のログ表示色をテーマ対応する
+
+## 目的
+
+LogOutput / Console の背景色と通常 / 警告 / エラーログ表示を `Xelqoria Dark` に合わせる。
+
+## 対象範囲
+
+- 変更対象プロジェクト: `Editor`
+- 変更対象ファイル: `Editor/Source/LogOutputPanelController.h`, `Editor/Source/LogOutputPanelController.cpp`
+- 変更対象クラス: `Xelqoria::Editor::LogOutputPanelController`
+- 影響する機能: LogOutput ListBox の owner draw 表示
+
+## 前提
+
+- parent issue: #253
+- ブランチ運用ルール: `docs/agents/branch-rules.md`
+- parent issue ブランチ: `issue-253`
+- この child issue のブランチ: `issue-259`
+- PR の向き: `issue-259` -> `issue-253`
+
+## 実装方針
+
+既存のログ追加 API とフィルタ、コピー、タブ切り替え動作は維持する。
+
+ListBox の owner draw で `EditorThemes::XelqoriaDark` を参照し、通常ログは `TextPrimary`、警告ログは `Warning`、エラーログは `Error`、選択行は `Selection` を使って描画する。
+
+## 作業手順
+
+1. 既存 LogOutput の owner draw 経路を確認する
+2. ログ行に通常 / 警告 / エラーの内部 severity を持たせる
+3. ListBox 行描画を `Xelqoria Dark` の背景色・テキスト色へ変更する
+4. ビルドとレイヤー依存チェックを実行する
+5. `branch-rules.md` に従って PR を作成する
+
+## 検証方法
+
+- 実行するビルド: `Xelqoria.Editor.vcxproj` Debug x64
+- 実行するテスト: `LayerDependencyChecker`
+- 手動確認項目: Console / LogOutput の通常 / 警告 / エラー行と選択行がテーマ色で表示される
+
+## 完了条件
+
+- Console / LogOutput の背景色がテーマに沿っている
+- 通常ログのテキスト色がテーマに沿っている
+- 警告ログのテキスト色が `Warning` に沿っている
+- エラーログのテキスト色が `Error` に沿っている
+- 選択行がテーマに沿っている
+- 既存のログ出力仕様を変更していない
+- ビルドが通る
+- レイヤー責務に違反していない
+- `issue-259` から `issue-253` への PR が作成されている


### PR DESCRIPTION
## 概要
- #253 の子 Issue #259 に対応
- LogOutput 行に Normal / Warning / Error の severity を持たせ、`Xelqoria Dark` のテーマ色で owner draw
- 通常ログは `TextPrimary`、警告ログは `Warning`、エラーログは `Error`、選択行は `Selection` を使用
- child issue 用 ExecPlan を追加

## Issue
- Parent: #253
- Child: #259

## 検証
- PASS: `dotnet build tools\LayerDependencyChecker\LayerDependencyChecker.csproj -c Debug`
- PASS: `tools\LayerDependencyChecker\bin\Debug\net8.0\LayerDependencyChecker.exe D:\github\Xelqoria`
- PASS: `git diff --check`
- PASS: `MSBuild.exe Editor\Xelqoria.Editor.vcxproj /p:Configuration=Debug /p:Platform=x64 /m`

Closes #259