### PR TITLE
#270 Editor 全体のダークテーマ基盤と共通 UI 描画を実装する

### DIFF
--- a/Editor.UI/Source/EditorTheme.h
+++ b/Editor.UI/Source/EditorTheme.h
@@ -105,6 +105,21 @@ namespace Xelqoria::Editor
         /// エラーログなどに使う色。
         /// </summary>
         EditorColor error{};
+
+        /// <summary>
+        /// 標準パネルの角丸半径。96 DPI 基準の pixel 単位で扱う。
+        /// </summary>
+        int panelCornerRadius = 0;
+
+        /// <summary>
+        /// 標準コントロールの角丸半径。96 DPI 基準の pixel 単位で扱う。
+        /// </summary>
+        int controlCornerRadius = 0;
+
+        /// <summary>
+        /// パネル境界線の太さ。96 DPI 基準の pixel 単位で扱う。
+        /// </summary>
+        int panelBorderThickness = 1;
     };
 
     namespace EditorThemes
@@ -123,7 +138,10 @@ namespace Xelqoria::Editor
             EditorColor::FromRgb8(0x26, 0x36, 0x5F),
             EditorColor::FromRgb8(0x2A, 0x2F, 0x3A),
             EditorColor::FromRgb8(0xE6, 0xB4, 0x50),
-            EditorColor::FromRgb8(0xFF, 0x6B, 0x6B)
+            EditorColor::FromRgb8(0xFF, 0x6B, 0x6B),
+            8,
+            5,
+            1
         };
     }
 }

--- a/Editor/Source/EditorShell.cpp
+++ b/Editor/Source/EditorShell.cpp
@@ -80,6 +80,28 @@ namespace Xelqoria::Editor
             DeleteObject(pen);
         }
 
+        void FillRoundRectWithThemeColor(HDC deviceContext, const RECT& rect, EditorColor color, int radius)
+        {
+            HBRUSH brush = CreateSolidBrush(ToColorRef(color));
+            HGDIOBJ previousBrush = SelectObject(deviceContext, brush);
+            HGDIOBJ previousPen = SelectObject(deviceContext, GetStockObject(NULL_PEN));
+            RoundRect(deviceContext, rect.left, rect.top, rect.right, rect.bottom, radius, radius);
+            SelectObject(deviceContext, previousPen);
+            SelectObject(deviceContext, previousBrush);
+            DeleteObject(brush);
+        }
+
+        void DrawRoundRectBorder(HDC deviceContext, const RECT& rect, EditorColor color, int radius)
+        {
+            HPEN pen = CreatePen(PS_SOLID, 1, ToColorRef(color));
+            HGDIOBJ previousPen = SelectObject(deviceContext, pen);
+            HGDIOBJ previousBrush = SelectObject(deviceContext, GetStockObject(NULL_BRUSH));
+            RoundRect(deviceContext, rect.left, rect.top, rect.right, rect.bottom, radius, radius);
+            SelectObject(deviceContext, previousBrush);
+            SelectObject(deviceContext, previousPen);
+            DeleteObject(pen);
+        }
+
         [[nodiscard]] int GetHoveredTabIndex(HWND tabControl)
         {
             POINT cursorPoint{};
@@ -179,9 +201,14 @@ namespace Xelqoria::Editor
                 RECT headerRect = clientRect;
                 headerRect.bottom = headerRect.top + headerHeight;
 
-                FillRectWithThemeColor(deviceContext, clientRect, EditorThemes::XelqoriaDark.panelBackground);
+                const int panelRadius = EditorThemes::XelqoriaDark.panelCornerRadius;
+                FillRoundRectWithThemeColor(
+                    deviceContext,
+                    clientRect,
+                    EditorThemes::XelqoriaDark.panelBackground,
+                    panelRadius);
                 FillRectWithThemeColor(deviceContext, headerRect, EditorThemes::XelqoriaDark.panelHeaderBackground);
-                DrawRectBorder(deviceContext, clientRect, EditorThemes::XelqoriaDark.panelBorder);
+                DrawRoundRectBorder(deviceContext, clientRect, EditorThemes::XelqoriaDark.panelBorder, panelRadius);
 
                 wchar_t title[64]{};
                 GetWindowTextW(window, title, static_cast<int>(std::size(title)));

--- a/docs/plans/issue-270-editor-dark-theme-base.md
+++ b/docs/plans/issue-270-editor-dark-theme-base.md
@@ -1,0 +1,47 @@
+# ExecPlan: issue-270 Editor 全体のダークテーマ基盤と共通 UI 描画を実装する
+
+## 目的
+
+Xelqoria Editor の標準 Win32 コントロールを独自ダークテーマで描画するための共通テーマ定義と共通描画基盤を整える。
+
+## 対象範囲
+
+- 変更対象プロジェクト: `Editor.UI`, `Editor`
+- 変更対象ファイル: `Editor.UI/Source/EditorTheme.h`, `Editor/Source/EditorShell.cpp`
+- 変更対象クラス: `EditorTheme`, `EditorShell`
+- 影響する機能: Editor パネル、タブ、リスト、入力欄、テーマ色
+
+## 前提
+
+- parent issue: #269
+- ブランチ運用ルール: `docs/agents/branch-rules.md`
+- parent issue ブランチ: `issue-269`
+- この child issue のブランチ: `issue-270`
+- PR の向き: `issue-270` -> `issue-269`
+
+## 実装方針
+
+OS 非依存のテーマ値は `Editor.UI` に置き、Win32 の描画処理は `Editor` の `EditorShell` に閉じる。既存の Owner Draw / Custom Draw / Subclass 化を活かし、テーマ値に角丸と境界線の共通寸法を追加する。
+
+## 作業手順
+
+1. 既存テーマ定義と EditorShell の描画経路を確認する
+2. `EditorTheme` に角丸と境界線の共通寸法を追加する
+3. パネル描画をテーマ定義に基づく角丸描画へ寄せる
+4. ビルドまたはレイヤー依存チェックを実行する
+5. PR を作成する
+
+## 検証方法
+
+- 実行するビルド: `dotnet build tools/LayerDependencyChecker/LayerDependencyChecker.csproj -c Debug`
+- 実行するテスト: LayerDependencyChecker
+- 手動確認項目: パネル背景、ヘッダー、境界線、選択、hover、入力欄が暗色テーマとして表示される
+
+## 完了条件
+
+- 共通 UI テーマの色、境界線、角丸、アクセントが定義されている
+- 対象標準コントロールが独自ダークテーマで描画される
+- hover / 押下 / 無効 / 選択状態が視覚的に区別できる
+- Graphics に Direct3D 型を漏らしていない
+- RHI に描画概念を持ち込んでいない
+- `issue-270` から `issue-269` への PR が作成されている


### PR DESCRIPTION
## 概要
- parent issue: #269
- child issue: #270
- `EditorTheme` に角丸と境界線の共通寸法を追加
- EditorShell のパネル描画をテーマ定義に基づく角丸描画へ更新
- child issue 用 ExecPlan を追加

## 検証
- `dotnet build tools/LayerDependencyChecker/LayerDependencyChecker.csproj -c Debug`
- `tools\LayerDependencyChecker\bin\Debug\net8.0\LayerDependencyChecker.exe D:\github\Xelqoria`