### PR TITLE
#273 Assets ビューでプロジェクトルートの読込とファイル監視を実装する

### DIFF
--- a/Editor.UI/Source/EditorTheme.h
+++ b/Editor.UI/Source/EditorTheme.h
@@ -105,6 +105,21 @@ namespace Xelqoria::Editor
         /// エラーログなどに使う色。
         /// </summary>
         EditorColor error{};
+
+        /// <summary>
+        /// 標準パネルの角丸半径。96 DPI 基準の pixel 単位で扱う。
+        /// </summary>
+        int panelCornerRadius = 0;
+
+        /// <summary>
+        /// 標準コントロールの角丸半径。96 DPI 基準の pixel 単位で扱う。
+        /// </summary>
+        int controlCornerRadius = 0;
+
+        /// <summary>
+        /// パネル境界線の太さ。96 DPI 基準の pixel 単位で扱う。
+        /// </summary>
+        int panelBorderThickness = 1;
     };
 
     namespace EditorThemes
@@ -123,7 +138,10 @@ namespace Xelqoria::Editor
             EditorColor::FromRgb8(0x26, 0x36, 0x5F),
             EditorColor::FromRgb8(0x2A, 0x2F, 0x3A),
             EditorColor::FromRgb8(0xE6, 0xB4, 0x50),
-            EditorColor::FromRgb8(0xFF, 0x6B, 0x6B)
+            EditorColor::FromRgb8(0xFF, 0x6B, 0x6B),
+            8,
+            5,
+            1
         };
     }
 }

--- a/Editor/Source/Application.cpp
+++ b/Editor/Source/Application.cpp
@@ -1072,6 +1072,7 @@ namespace Xelqoria::Editor
         }
 
         m_assetsPanelController.UpdateDragState(inputSnapshot);
+        m_assetsPanelController.UpdateFileSystemWatch();
         m_inspectorPanelController.UpdateDropHighlight(m_assetsPanelController);
         m_materialPanelController.UpdateTextureDropHighlight(m_assetsPanelController);
         const bool canAddSpriteComponent = m_assetsPanelController.HasVisibleSpriteAssets();

--- a/Editor/Source/AssetsPanelController.cpp
+++ b/Editor/Source/AssetsPanelController.cpp
@@ -5,6 +5,7 @@
 #include <CommCtrl.h>
 #include <cstdio>
 #include <cwctype>
+#include <functional>
 #include <iterator>
 #include <objbase.h>
 #include <ShObjIdl.h>
@@ -479,6 +480,61 @@ namespace Xelqoria::Editor
             return result;
         }
 
+        void CombineHash(std::uint64_t& seed, std::uint64_t value)
+        {
+            seed ^= value + 0x9E3779B97F4A7C15ull + (seed << 6) + (seed >> 2);
+        }
+
+        [[nodiscard]] std::uint64_t BuildProjectTreeSignature(const std::filesystem::path& rootDirectory)
+        {
+            if (rootDirectory.empty())
+            {
+                return 0;
+            }
+
+            std::error_code errorCode;
+            if (false == std::filesystem::is_directory(rootDirectory, errorCode) || errorCode)
+            {
+                return 0;
+            }
+
+            std::uint64_t signature = 1469598103934665603ull;
+            std::size_t visitedCount = 0;
+            constexpr std::size_t MaxVisitedEntries = 4096;
+            const std::hash<std::wstring> pathHasher{};
+            for (std::filesystem::recursive_directory_iterator iterator(
+                    rootDirectory,
+                    std::filesystem::directory_options::skip_permission_denied,
+                    errorCode);
+                false == errorCode && iterator != std::filesystem::recursive_directory_iterator{};
+                iterator.increment(errorCode))
+            {
+                if (MaxVisitedEntries <= visitedCount)
+                {
+                    break;
+                }
+
+                const std::filesystem::directory_entry& entry = *iterator;
+                CombineHash(signature, static_cast<std::uint64_t>(pathHasher(entry.path().wstring())));
+                const auto writeTime = entry.last_write_time(errorCode);
+                if (false == static_cast<bool>(errorCode))
+                {
+                    CombineHash(signature, static_cast<std::uint64_t>(writeTime.time_since_epoch().count()));
+                }
+                errorCode.clear();
+
+                if (false == entry.is_directory(errorCode) && false == static_cast<bool>(errorCode))
+                {
+                    CombineHash(signature, static_cast<std::uint64_t>(entry.file_size(errorCode)));
+                }
+                errorCode.clear();
+                ++visitedCount;
+            }
+
+            CombineHash(signature, static_cast<std::uint64_t>(visitedCount));
+            return signature;
+        }
+
         /// <summary>
         /// Assets の右クリックメニューから実行されたコマンド ID を表す。
         /// </summary>
@@ -548,6 +604,8 @@ namespace Xelqoria::Editor
             m_createMaterialTargetDirectory.clear();
             m_assignScriptRequested = false;
             m_assignScriptSpriteAssetPath.clear();
+            m_lastWatchTick = 0;
+            m_projectTreeSignature = 0;
             EndDragImage();
             RefreshListView();
             RefreshSummaryLabel();
@@ -565,9 +623,11 @@ namespace Xelqoria::Editor
             m_lastClickedIndex = -1;
             m_openMaterialRequested = false;
             m_openMaterialAssetId = {};
+            m_lastWatchTick = 0;
         }
 
         ReloadEditorIconImages(m_assetsRootDirectory);
+        m_projectTreeSignature = BuildProjectTreeSignature(m_assetsRootDirectory);
         RebuildVisibleEntries();
         RefreshListView();
         RefreshSummaryLabel();
@@ -793,6 +853,44 @@ namespace Xelqoria::Editor
         {
             (void)TryOpenEntry(static_cast<std::size_t>(hitIndex));
         }
+    }
+
+    void AssetsPanelController::UpdateFileSystemWatch()
+    {
+        if (m_assetsRootDirectory.empty())
+        {
+            return;
+        }
+
+        const ULONGLONG currentTick = GetTickCount64();
+        constexpr ULONGLONG WatchIntervalMilliseconds = 800;
+        if (0 != m_lastWatchTick && currentTick - m_lastWatchTick < WatchIntervalMilliseconds)
+        {
+            return;
+        }
+
+        m_lastWatchTick = currentTick;
+        const std::uint64_t nextSignature = BuildProjectTreeSignature(m_assetsRootDirectory);
+        if (nextSignature == m_projectTreeSignature)
+        {
+            return;
+        }
+
+        m_projectTreeSignature = nextSignature;
+        if (false == m_selectedFilePath.empty() && false == std::filesystem::exists(m_selectedFilePath))
+        {
+            m_selectedFilePath.clear();
+            m_selectedSpriteAssetId = {};
+        }
+
+        if (false == std::filesystem::is_directory(m_currentDirectory))
+        {
+            m_currentDirectory = m_assetsRootDirectory;
+        }
+
+        RebuildVisibleEntries();
+        RefreshListView();
+        RefreshSummaryLabel();
     }
 
     void AssetsPanelController::CompleteReleasedDrag()

--- a/Editor/Source/AssetsPanelController.h
+++ b/Editor/Source/AssetsPanelController.h
@@ -105,6 +105,11 @@ namespace Xelqoria::Editor
         void UpdateDragState(const Core::InputSnapshot& inputSnapshot);
 
         /// <summary>
+        /// プロジェクトルート全体のファイル変更を監視し、必要に応じて表示を更新する。
+        /// </summary>
+        void UpdateFileSystemWatch();
+
+        /// <summary>
         /// ドラッグ解放を SceneView 側で処理した後に状態を確定する。
         /// </summary>
         void CompleteReleasedDrag();
@@ -479,6 +484,8 @@ namespace Xelqoria::Editor
         bool m_assignScriptRequested = false;
         std::filesystem::path m_assignScriptSpriteAssetPath{};
         bool m_listViewInitialized = false;
+        ULONGLONG m_lastWatchTick = 0;
+        std::uint64_t m_projectTreeSignature = 0;
         HIMAGELIST m_dragImageList = nullptr;
         bool m_isDragImageVisible = false;
         HWND m_dragPreviewWindow = nullptr;

--- a/Editor/Source/EditorShell.cpp
+++ b/Editor/Source/EditorShell.cpp
@@ -80,6 +80,28 @@ namespace Xelqoria::Editor
             DeleteObject(pen);
         }
 
+        void FillRoundRectWithThemeColor(HDC deviceContext, const RECT& rect, EditorColor color, int radius)
+        {
+            HBRUSH brush = CreateSolidBrush(ToColorRef(color));
+            HGDIOBJ previousBrush = SelectObject(deviceContext, brush);
+            HGDIOBJ previousPen = SelectObject(deviceContext, GetStockObject(NULL_PEN));
+            RoundRect(deviceContext, rect.left, rect.top, rect.right, rect.bottom, radius, radius);
+            SelectObject(deviceContext, previousPen);
+            SelectObject(deviceContext, previousBrush);
+            DeleteObject(brush);
+        }
+
+        void DrawRoundRectBorder(HDC deviceContext, const RECT& rect, EditorColor color, int radius)
+        {
+            HPEN pen = CreatePen(PS_SOLID, 1, ToColorRef(color));
+            HGDIOBJ previousPen = SelectObject(deviceContext, pen);
+            HGDIOBJ previousBrush = SelectObject(deviceContext, GetStockObject(NULL_BRUSH));
+            RoundRect(deviceContext, rect.left, rect.top, rect.right, rect.bottom, radius, radius);
+            SelectObject(deviceContext, previousBrush);
+            SelectObject(deviceContext, previousPen);
+            DeleteObject(pen);
+        }
+
         [[nodiscard]] int GetHoveredTabIndex(HWND tabControl)
         {
             POINT cursorPoint{};
@@ -179,9 +201,14 @@ namespace Xelqoria::Editor
                 RECT headerRect = clientRect;
                 headerRect.bottom = headerRect.top + headerHeight;
 
-                FillRectWithThemeColor(deviceContext, clientRect, EditorThemes::XelqoriaDark.panelBackground);
+                const int panelRadius = EditorThemes::XelqoriaDark.panelCornerRadius;
+                FillRoundRectWithThemeColor(
+                    deviceContext,
+                    clientRect,
+                    EditorThemes::XelqoriaDark.panelBackground,
+                    panelRadius);
                 FillRectWithThemeColor(deviceContext, headerRect, EditorThemes::XelqoriaDark.panelHeaderBackground);
-                DrawRectBorder(deviceContext, clientRect, EditorThemes::XelqoriaDark.panelBorder);
+                DrawRoundRectBorder(deviceContext, clientRect, EditorThemes::XelqoriaDark.panelBorder, panelRadius);
 
                 wchar_t title[64]{};
                 GetWindowTextW(window, title, static_cast<int>(std::size(title)));

--- a/Editor/Source/EditorShell.cpp
+++ b/Editor/Source/EditorShell.cpp
@@ -26,6 +26,7 @@ namespace Xelqoria::Editor
         constexpr UINT_PTR EditorRowControlSubclassId = 3;
         constexpr int EditorRowHeight = 22;
         constexpr const wchar_t* WorkspaceBackgroundWindowClassName = L"XelqoriaEditorWorkspaceBackground";
+        constexpr const wchar_t* EditorChromeWindowClassName = L"XelqoriaEditorChrome";
         constexpr const wchar_t* EditorPanelWindowClassName = L"XelqoriaEditorPanel";
         constexpr const wchar_t* DockPreviewWindowClassName = L"XelqoriaDockPreviewWindow";
         constexpr const wchar_t* DockGuideWindowClassName = L"XelqoriaDockGuideWindow";
@@ -175,6 +176,47 @@ namespace Xelqoria::Editor
                 RECT clientRect{};
                 GetClientRect(window, &clientRect);
                 FillRectWithThemeColor(deviceContext, clientRect, EditorThemes::XelqoriaDark.windowBackground);
+                EndPaint(window, &paintStruct);
+                return 0;
+            }
+
+            if (WM_ERASEBKGND == message)
+            {
+                return 1;
+            }
+
+            return DefWindowProcW(window, message, wParam, lParam);
+        }
+
+        LRESULT CALLBACK EditorChromeWindowProc(HWND window, UINT message, WPARAM wParam, LPARAM lParam)
+        {
+            if (WM_PAINT == message)
+            {
+                PAINTSTRUCT paintStruct{};
+                HDC deviceContext = BeginPaint(window, &paintStruct);
+                RECT clientRect{};
+                GetClientRect(window, &clientRect);
+                FillRectWithThemeColor(deviceContext, clientRect, EditorThemes::XelqoriaDark.panelHeaderBackground);
+
+                HPEN borderPen = CreatePen(PS_SOLID, 1, ToColorRef(EditorThemes::XelqoriaDark.panelBorder));
+                HGDIOBJ previousPen = SelectObject(deviceContext, borderPen);
+                MoveToEx(deviceContext, clientRect.left, clientRect.bottom - 1, nullptr);
+                LineTo(deviceContext, clientRect.right, clientRect.bottom - 1);
+                SelectObject(deviceContext, previousPen);
+                DeleteObject(borderPen);
+
+                wchar_t text[128]{};
+                GetWindowTextW(window, text, static_cast<int>(std::size(text)));
+                if (L'\0' != text[0])
+                {
+                    SetBkMode(deviceContext, TRANSPARENT);
+                    SetTextColor(deviceContext, ToColorRef(EditorThemes::XelqoriaDark.textPrimary));
+                    RECT textRect = clientRect;
+                    textRect.left += 12;
+                    textRect.right -= 12;
+                    DrawTextW(deviceContext, text, -1, &textRect, DT_LEFT | DT_SINGLELINE | DT_VCENTER | DT_END_ELLIPSIS);
+                }
+
                 EndPaint(window, &paintStruct);
                 return 0;
             }
@@ -500,6 +542,22 @@ namespace Xelqoria::Editor
             return 0 != RegisterClassW(&windowClass);
         }
 
+        bool RegisterEditorChromeWindowClass(HINSTANCE hInstance)
+        {
+            WNDCLASSW existingClass{};
+            if (GetClassInfoW(hInstance, EditorChromeWindowClassName, &existingClass))
+            {
+                return true;
+            }
+
+            WNDCLASSW windowClass{};
+            windowClass.lpfnWndProc = EditorChromeWindowProc;
+            windowClass.hInstance = hInstance;
+            windowClass.hCursor = LoadCursor(nullptr, IDC_ARROW);
+            windowClass.lpszClassName = EditorChromeWindowClassName;
+            return 0 != RegisterClassW(&windowClass);
+        }
+
         bool RegisterEditorPanelWindowClass(HINSTANCE hInstance)
         {
             WNDCLASSW existingClass{};
@@ -688,6 +746,11 @@ namespace Xelqoria::Editor
             return false;
         }
 
+        if (false == RegisterEditorChromeWindowClass(hInstance))
+        {
+            return false;
+        }
+
         if (false == RegisterEditorPanelWindowClass(hInstance))
         {
             return false;
@@ -742,6 +805,30 @@ namespace Xelqoria::Editor
             L"",
             WS_CHILD | WS_VISIBLE | WS_CLIPSIBLINGS);
         if (nullptr == m_workspaceBackground)
+        {
+            return false;
+        }
+
+        m_topBar = CreateChildWindow(
+            parentWindow,
+            hInstance,
+            EditorChromeWindowClassName,
+            L"Xelqoria Editor",
+            WS_CHILD | WS_VISIBLE | WS_CLIPSIBLINGS);
+        m_statusBar = CreateChildWindow(
+            parentWindow,
+            hInstance,
+            EditorChromeWindowClassName,
+            L"Ready  |  Fixed Layout  |  Xelqoria Dark",
+            WS_CHILD | WS_VISIBLE | WS_CLIPSIBLINGS);
+        m_topBarProjectButton = CreateChildWindow(parentWindow, hInstance, L"Button", L"Project", WS_CHILD | WS_VISIBLE | BS_PUSHBUTTON);
+        m_topBarPlayButton = CreateChildWindow(parentWindow, hInstance, L"Button", L"Play", WS_CHILD | WS_VISIBLE | BS_PUSHBUTTON);
+        m_topBarLayoutButton = CreateChildWindow(parentWindow, hInstance, L"Button", L"Layout", WS_CHILD | WS_VISIBLE | BS_PUSHBUTTON);
+        if (nullptr == m_topBar
+            || nullptr == m_statusBar
+            || nullptr == m_topBarProjectButton
+            || nullptr == m_topBarPlayButton
+            || nullptr == m_topBarLayoutButton)
         {
             return false;
         }
@@ -856,7 +943,7 @@ namespace Xelqoria::Editor
         if (m_ownsDefaultFont && nullptr != m_defaultFont)
         {
             HFONT stockFont = static_cast<HFONT>(GetStockObject(DEFAULT_GUI_FONT));
-            const std::array<HWND, 82> controls = CollectControls();
+            const std::array<HWND, 87> controls = CollectControls();
             for (HWND control : controls)
             {
                 if (nullptr != control)
@@ -895,12 +982,22 @@ namespace Xelqoria::Editor
         }
 
         const int outerPadding = ScaleMetric(12);
+        const int topBarHeight = ScaleMetric(42);
+        const int statusBarHeight = ScaleMetric(24);
+        const int topButtonWidth = ScaleMetric(84);
+        const int topButtonHeight = ScaleMetric(26);
+        const int topButtonGap = ScaleMetric(8);
         MoveChildWindowNoRedraw(m_workspaceBackground, 0, 0, clientWidth, clientHeight);
+        MoveChildWindowNoRedraw(m_topBar, 0, 0, clientWidth, topBarHeight);
+        MoveChildWindowNoRedraw(m_topBarProjectButton, clientWidth - outerPadding - (topButtonWidth + topButtonGap) * 3, ScaleMetric(8), topButtonWidth, topButtonHeight);
+        MoveChildWindowNoRedraw(m_topBarPlayButton, clientWidth - outerPadding - (topButtonWidth + topButtonGap) * 2, ScaleMetric(8), topButtonWidth, topButtonHeight);
+        MoveChildWindowNoRedraw(m_topBarLayoutButton, clientWidth - outerPadding - topButtonWidth, ScaleMetric(8), topButtonWidth, topButtonHeight);
+        MoveChildWindowNoRedraw(m_statusBar, 0, clientHeight - statusBarHeight, clientWidth, statusBarHeight);
         const RECT rootRect{
             outerPadding,
-            outerPadding,
+            topBarHeight + outerPadding,
             clientWidth - outerPadding,
-            clientHeight - outerPadding
+            clientHeight - statusBarHeight - outerPadding
         };
         LayoutDockNode(m_rootDockNodeId, rootRect);
         HideDockGuideWindows();
@@ -4921,7 +5018,7 @@ namespace Xelqoria::Editor
             m_ownsDefaultFont = false;
         }
 
-        const std::array<HWND, 82> controls = CollectControls();
+        const std::array<HWND, 87> controls = CollectControls();
 
         for (HWND control : controls)
         {
@@ -4944,10 +5041,15 @@ namespace Xelqoria::Editor
         return true;
     }
 
-    std::array<HWND, 82> EditorShell::CollectControls() const
+    std::array<HWND, 87> EditorShell::CollectControls() const
     {
         return {
             m_workspaceBackground,
+            m_topBar,
+            m_topBarProjectButton,
+            m_topBarPlayButton,
+            m_topBarLayoutButton,
+            m_statusBar,
             m_leftTopDockTab,
             m_leftBottomDockTab,
             m_centerDockTab,

--- a/Editor/Source/EditorShell.cpp
+++ b/Editor/Source/EditorShell.cpp
@@ -1671,17 +1671,17 @@ namespace Xelqoria::Editor
     {
         m_dockNodes.clear();
 
-        DockNode hierarchyNode{};
-        hierarchyNode.kind = DockNodeKind::Leaf;
-        hierarchyNode.panels = { EditorPanelId::Hierarchy };
-        hierarchyNode.tabControl = m_leftTopDockTab;
-        const DockNodeId hierarchyNodeId = AddDockNode(std::move(hierarchyNode));
-
         DockNode assetsNode{};
         assetsNode.kind = DockNodeKind::Leaf;
         assetsNode.panels = { EditorPanelId::Assets };
-        assetsNode.tabControl = m_leftBottomDockTab;
+        assetsNode.tabControl = m_leftTopDockTab;
         const DockNodeId assetsNodeId = AddDockNode(std::move(assetsNode));
+
+        DockNode hierarchyNode{};
+        hierarchyNode.kind = DockNodeKind::Leaf;
+        hierarchyNode.panels = { EditorPanelId::Hierarchy };
+        hierarchyNode.tabControl = m_leftBottomDockTab;
+        const DockNodeId hierarchyNodeId = AddDockNode(std::move(hierarchyNode));
 
         DockNode sceneViewNode{};
         sceneViewNode.kind = DockNodeKind::Leaf;
@@ -1705,9 +1705,9 @@ namespace Xelqoria::Editor
         DockNode leftColumnNode{};
         leftColumnNode.kind = DockNodeKind::Split;
         leftColumnNode.splitOrientation = DockSplitOrientation::Vertical;
-        leftColumnNode.splitRatio = 0.32f;
-        leftColumnNode.firstChild = hierarchyNodeId;
-        leftColumnNode.secondChild = assetsNodeId;
+        leftColumnNode.splitRatio = 0.46f;
+        leftColumnNode.firstChild = assetsNodeId;
+        leftColumnNode.secondChild = hierarchyNodeId;
         const DockNodeId leftColumnNodeId = AddDockNode(leftColumnNode);
 
         DockNode centerColumnNode{};
@@ -1729,7 +1729,7 @@ namespace Xelqoria::Editor
         DockNode rootNode{};
         rootNode.kind = DockNodeKind::Split;
         rootNode.splitOrientation = DockSplitOrientation::Horizontal;
-        rootNode.splitRatio = 0.12f;
+        rootNode.splitRatio = 0.22f;
         rootNode.firstChild = leftColumnNodeId;
         rootNode.secondChild = centerRightNodeId;
         m_rootDockNodeId = AddDockNode(rootNode);
@@ -2435,6 +2435,20 @@ namespace Xelqoria::Editor
         {
             return false;
         }
+
+        if (inputSnapshot.WasKeyPressed('R') && inputSnapshot.IsKeyDown(VK_CONTROL))
+        {
+            ResetDockLayout();
+            return true;
+        }
+
+        m_dragKind = DockDragKind::None;
+        m_dragPanelId.reset();
+        m_pendingDockDragPanelId.reset();
+        m_hasDockPreview = false;
+        HideDockGuideWindows();
+        ShowWindow(m_dockPreviewWindow, SW_HIDE);
+        return false;
 
         bool changed = false;
         const POINT cursorScreenPoint = ToWin32Point(inputSnapshot.GetCursorScreenPoint());
@@ -4315,6 +4329,13 @@ namespace Xelqoria::Editor
                 item.mask = TCIF_TEXT;
                 item.pszText = const_cast<LPWSTR>(GetPanelTitle(dockNode.panels[index]));
                 TabCtrl_InsertItem(dockNode.tabControl, static_cast<int>(index), &item);
+                if (EditorPanelId::SceneView == dockNode.panels[index])
+                {
+                    TCITEMW gameItem{};
+                    gameItem.mask = TCIF_TEXT;
+                    gameItem.pszText = const_cast<LPWSTR>(L"Game");
+                    TabCtrl_InsertItem(dockNode.tabControl, static_cast<int>(index + 1), &gameItem);
+                }
             }
 
             dockNode.activeTabIndex = (std::max)(0, (std::min)(dockNode.activeTabIndex, static_cast<int>(dockNode.panels.size()) - 1));
@@ -4720,7 +4741,7 @@ namespace Xelqoria::Editor
         case EditorPanelId::Assets:
             return L"Assets";
         case EditorPanelId::SceneView:
-            return L"SceneView";
+            return L"Scene";
         case EditorPanelId::Inspector:
             return L"Inspector";
         case EditorPanelId::Material:

--- a/Editor/Source/EditorShell.h
+++ b/Editor/Source/EditorShell.h
@@ -885,7 +885,7 @@ namespace Xelqoria::Editor
         /// EditorShell が管理する child window 群を列挙する。
         /// </summary>
         /// <returns>管理対象 child window の一覧。</returns>
-        [[nodiscard]] std::array<HWND, 82> CollectControls() const;
+        [[nodiscard]] std::array<HWND, 87> CollectControls() const;
 
         /// <summary>
         /// 指定値を現在 DPI に合わせて拡大縮小する。
@@ -1047,6 +1047,11 @@ namespace Xelqoria::Editor
         HWND m_logOutputFloatingWindow = nullptr;
         std::vector<FloatingPanelGroup> m_floatingPanelGroups{};
         HWND m_workspaceBackground = nullptr;
+        HWND m_topBar = nullptr;
+        HWND m_topBarProjectButton = nullptr;
+        HWND m_topBarPlayButton = nullptr;
+        HWND m_topBarLayoutButton = nullptr;
+        HWND m_statusBar = nullptr;
         HWND m_hierarchyPanel = nullptr;
         HWND m_assetsPanel = nullptr;
         HWND m_inspectorPanel = nullptr;

--- a/docs/plans/issue-270-editor-dark-theme-base.md
+++ b/docs/plans/issue-270-editor-dark-theme-base.md
@@ -1,0 +1,47 @@
+# ExecPlan: issue-270 Editor 全体のダークテーマ基盤と共通 UI 描画を実装する
+
+## 目的
+
+Xelqoria Editor の標準 Win32 コントロールを独自ダークテーマで描画するための共通テーマ定義と共通描画基盤を整える。
+
+## 対象範囲
+
+- 変更対象プロジェクト: `Editor.UI`, `Editor`
+- 変更対象ファイル: `Editor.UI/Source/EditorTheme.h`, `Editor/Source/EditorShell.cpp`
+- 変更対象クラス: `EditorTheme`, `EditorShell`
+- 影響する機能: Editor パネル、タブ、リスト、入力欄、テーマ色
+
+## 前提
+
+- parent issue: #269
+- ブランチ運用ルール: `docs/agents/branch-rules.md`
+- parent issue ブランチ: `issue-269`
+- この child issue のブランチ: `issue-270`
+- PR の向き: `issue-270` -> `issue-269`
+
+## 実装方針
+
+OS 非依存のテーマ値は `Editor.UI` に置き、Win32 の描画処理は `Editor` の `EditorShell` に閉じる。既存の Owner Draw / Custom Draw / Subclass 化を活かし、テーマ値に角丸と境界線の共通寸法を追加する。
+
+## 作業手順
+
+1. 既存テーマ定義と EditorShell の描画経路を確認する
+2. `EditorTheme` に角丸と境界線の共通寸法を追加する
+3. パネル描画をテーマ定義に基づく角丸描画へ寄せる
+4. ビルドまたはレイヤー依存チェックを実行する
+5. PR を作成する
+
+## 検証方法
+
+- 実行するビルド: `dotnet build tools/LayerDependencyChecker/LayerDependencyChecker.csproj -c Debug`
+- 実行するテスト: LayerDependencyChecker
+- 手動確認項目: パネル背景、ヘッダー、境界線、選択、hover、入力欄が暗色テーマとして表示される
+
+## 完了条件
+
+- 共通 UI テーマの色、境界線、角丸、アクセントが定義されている
+- 対象標準コントロールが独自ダークテーマで描画される
+- hover / 押下 / 無効 / 選択状態が視覚的に区別できる
+- Graphics に Direct3D 型を漏らしていない
+- RHI に描画概念を持ち込んでいない
+- `issue-270` から `issue-269` への PR が作成されている

--- a/docs/plans/issue-271-top-status-bar.md
+++ b/docs/plans/issue-271-top-status-bar.md
@@ -1,0 +1,49 @@
+# ExecPlan: issue-271 TopBar / StatusBar を画像ベースで実装する
+
+## 目的
+
+Editor メイン画面の上部と最下部に、Xelqoria Dark テーマに合わせた TopBar / StatusBar を固定表示する。
+
+## 対象範囲
+
+- 変更対象プロジェクト: `Editor`
+- 変更対象ファイル: `Editor/Source/EditorShell.h`, `Editor/Source/EditorShell.cpp`
+- 変更対象クラス: `EditorShell`
+- 影響する機能: Editor メイン画面の上部操作領域、最下部状態表示、固定レイアウトの使用可能領域
+
+## 前提
+
+- parent issue: #269
+- 先行 issue: #270
+- ブランチ運用ルール: `docs/agents/branch-rules.md`
+- parent issue ブランチ: `issue-269`
+- この child issue のブランチ: `issue-271`
+- PR の向き: `issue-271` -> `issue-269`
+
+## 実装方針
+
+`issue-270` のテーマ基盤をローカルマージして利用する。TopBar / StatusBar は Editor の OS ネイティブ UI シェルに閉じ、`Editor.UI` や Runtime 側へ Win32 実装を持ち込まない。
+
+## 作業手順
+
+1. `issue-270` をこのブランチへローカルマージする
+2. TopBar / StatusBar 用の独自描画 child window を追加する
+3. TopBar に主要操作ボタンを配置する
+4. StatusBar を最下部に固定し、既存パネル領域から除外する
+5. ビルドまたはレイヤー依存チェックを実行する
+6. PR を作成する
+
+## 検証方法
+
+- 実行するビルド: `dotnet build tools/LayerDependencyChecker/LayerDependencyChecker.csproj -c Debug`
+- 実行するテスト: LayerDependencyChecker
+- 手動確認項目: TopBar が上部、StatusBar が最下部に固定表示され、各パネルと重ならない
+
+## 完了条件
+
+- TopBar がメイン画面上部に固定表示される
+- StatusBar がメイン画面最下部に固定表示される
+- ボタン、メニュー、状態表示がダークテーマで描画される
+- hover / 押下 / 無効状態が視覚的に区別できる
+- 既存のレイヤー責務を破壊していない
+- `issue-271` から `issue-269` への PR が作成されている

--- a/docs/plans/issue-272-fixed-editor-layout.md
+++ b/docs/plans/issue-272-fixed-editor-layout.md
@@ -1,0 +1,52 @@
+# ExecPlan: issue-272 固定レイアウトで Assets / Hierarchy / Scene / Inspector / Console を配置する
+
+## 目的
+
+Editor メイン画面に Assets / Hierarchy / Scene / Inspector / Console / StatusBar を固定レイアウトで配置する。
+
+## 対象範囲
+
+- 変更対象プロジェクト: `Editor`
+- 変更対象ファイル: `Editor/Source/EditorShell.cpp`
+- 変更対象クラス: `EditorShell`
+- 影響する機能: Editor メイン画面の初期配置、Dock 操作、Scene / Game タブ表示
+
+## 前提
+
+- parent issue: #269
+- 先行 issue: #270, #271
+- ブランチ運用ルール: `docs/agents/branch-rules.md`
+- parent issue ブランチ: `issue-269`
+- この child issue のブランチ: `issue-272`
+- PR の向き: `issue-272` -> `issue-269`
+
+## 実装方針
+
+`issue-271` までの TopBar / StatusBar を前提に、既存 Dock tree の初期状態を固定レイアウトとして扱う。Assets を左上、Hierarchy を左下、Scene / Game を中央、Inspector を右、Console を下に配置し、今回スコープ外のパネルドラッグ操作は無効化する。
+
+## 作業手順
+
+1. `issue-271` をこのブランチへローカルマージする
+2. 初期 Dock tree を固定レイアウト順へ変更する
+3. SceneView のタブ表示を Scene / Game に見えるよう調整する
+4. パネルドラッグによる Dock 操作を無効化する
+5. ビルドまたはレイヤー依存チェックを実行する
+6. PR を作成する
+
+## 検証方法
+
+- 実行するビルド: `dotnet build tools/LayerDependencyChecker/LayerDependencyChecker.csproj -c Debug`
+- 実行するテスト: LayerDependencyChecker
+- 手動確認項目: Assets 左上、Hierarchy 左下、Scene / Game 中央、Inspector 右、Console 下、StatusBar 最下部に表示される
+
+## 完了条件
+
+- Assets が左上に表示される
+- Hierarchy が左下に表示される
+- Scene / Game が中央に表示される
+- Inspector が右に表示される
+- Console が下に表示される
+- StatusBar が最下部に表示される
+- 各パネルにヘッダーと薄い境界線がある
+- 既存のレイヤー責務を破壊していない
+- `issue-272` から `issue-269` への PR が作成されている

--- a/docs/plans/issue-273-assets-root-watch.md
+++ b/docs/plans/issue-273-assets-root-watch.md
@@ -1,0 +1,52 @@
+# ExecPlan: issue-273 Assets ビューでプロジェクトルートの読込とファイル監視を実装する
+
+## 目的
+
+Assets ビューでプロジェクトルート全体を読み取り、ファイル変更を監視して UI に反映する。
+
+## 対象範囲
+
+- 変更対象プロジェクト: `Editor`
+- 変更対象ファイル: `Editor/Source/AssetsPanelController.h`, `Editor/Source/AssetsPanelController.cpp`, `Editor/Source/Application.cpp`
+- 変更対象クラス: `AssetsPanelController`, `Application`
+- 影響する機能: Assets ビューのプロジェクトルート表示、変更監視、選択維持
+
+## 前提
+
+- parent issue: #269
+- 先行 issue: #270, #271, #272
+- ブランチ運用ルール: `docs/agents/branch-rules.md`
+- parent issue ブランチ: `issue-269`
+- この child issue のブランチ: `issue-273`
+- PR の向き: `issue-273` -> `issue-269`
+
+## 実装方針
+
+`issue-272` の固定レイアウトを前提に、既存の詳細 ListView 表示を活かす。プロジェクトルート全体は軽量なシグネチャポーリングで監視し、変更があった場合のみ現在表示中フォルダを再構築する。大量変更時の固まりを避けるため、走査数に上限を設ける。
+
+## 作業手順
+
+1. `issue-272` をこのブランチへローカルマージする
+2. プロジェクトルート全体の変更シグネチャを計算する
+3. 一定間隔でシグネチャを比較し、変更時のみ ListView を更新する
+4. 選択中ファイルが削除された場合は選択解除する
+5. 現在フォルダが削除された場合はプロジェクトルートへ戻す
+6. ビルドまたはレイヤー依存チェックを実行する
+7. PR を作成する
+
+## 検証方法
+
+- 実行するビルド: `dotnet build tools/LayerDependencyChecker/LayerDependencyChecker.csproj -c Debug`
+- 実行するテスト: LayerDependencyChecker
+- 手動確認項目: プロジェクトルート配下の追加 / 削除 / 更新 / 名前変更が Assets 表示へ反映される
+
+## 完了条件
+
+- プロジェクトルート全体のファイル変更を監視する
+- 名前、更新日時、種類、サイズが表示される
+- ファイル追加、削除、更新、名前変更が Assets ビューに反映される
+- フォルダ追加、削除、名前変更が Assets ビューに反映される
+- 大量変更時に UI が固まりにくいよう監視走査を制限する
+- 選択中ファイル削除時に選択が解除される
+- 既存のレイヤー責務を破壊していない
+- `issue-273` から `issue-269` への PR が作成されている


### PR DESCRIPTION
## 概要
- parent issue: #269
- child issue: #273
- 先行実装 #270, #271, #272 をローカルマージ
- プロジェクトルート全体の変更シグネチャを定期ポーリング
- 変更検出時のみ Assets ListView を再構築
- 選択中ファイル削除時の選択解除と、現在フォルダ削除時のルート復帰を追加
- 大量変更時に固まりにくいよう監視走査数に上限を設定
- child issue 用 ExecPlan を追加

## 検証
- `dotnet build tools/LayerDependencyChecker/LayerDependencyChecker.csproj -c Debug`
- `tools\LayerDependencyChecker\bin\Debug\net8.0\LayerDependencyChecker.exe D:\github\Xelqoria`

## 補足
- このブランチは固定レイアウト前提として `issue-272` までをローカルマージしています。