### PR TITLE
Xelqoria Editor 初期画面をリデザインする

### DIFF
--- a/Editor/Source/Application.cpp
+++ b/Editor/Source/Application.cpp
@@ -285,6 +285,8 @@ namespace Xelqoria::Editor
             });
 
         InitializeProjectMenu();
+        SetMenu(GetMainWindowHandle(), nullptr);
+        DrawMenuBar(GetMainWindowHandle());
         m_window.SetCommandHandler(
             [this](unsigned commandId)
             {
@@ -303,6 +305,12 @@ namespace Xelqoria::Editor
         m_window.SetDrawItemHandler(
             [this](Platform::NativeMessageParameter drawItemParameter)
             {
+                if (false == m_editorInitialized
+                    && m_startupScreenController.HandleDrawItem(static_cast<LPARAM>(drawItemParameter)))
+                {
+                    return true;
+                }
+
                 if (m_editorShell.HandleDrawItem(static_cast<LPARAM>(drawItemParameter)))
                 {
                     return true;
@@ -336,6 +344,12 @@ namespace Xelqoria::Editor
         if (m_editorInitialized)
         {
             return true;
+        }
+
+        if (nullptr != m_menuBar && nullptr == GetMenu(GetMainWindowHandle()))
+        {
+            SetMenu(GetMainWindowHandle(), m_menuBar);
+            DrawMenuBar(GetMainWindowHandle());
         }
 
         constexpr RHI::GraphicsAPI api = RHI::GraphicsAPI::D3D11;
@@ -410,10 +424,10 @@ namespace Xelqoria::Editor
         AppendMenuW(m_viewMenu, MF_STRING, ViewMenuMaterialCommandId, L"Material");
         AppendMenuW(m_viewMenu, MF_STRING, ViewMenuLogOutputCommandId, L"LogOutput");
 
-        HMENU menuBar = CreateMenu();
-        AppendMenuW(menuBar, MF_POPUP, reinterpret_cast<UINT_PTR>(m_projectMenu), L"プロジェクト");
-        AppendMenuW(menuBar, MF_POPUP, reinterpret_cast<UINT_PTR>(m_viewMenu), L"表示");
-        SetMenu(GetMainWindowHandle(), menuBar);
+        m_menuBar = CreateMenu();
+        AppendMenuW(m_menuBar, MF_POPUP, reinterpret_cast<UINT_PTR>(m_projectMenu), L"プロジェクト");
+        AppendMenuW(m_menuBar, MF_POPUP, reinterpret_cast<UINT_PTR>(m_viewMenu), L"表示");
+        SetMenu(GetMainWindowHandle(), m_menuBar);
     }
 
     void Application::HandleProjectMenuCommand(unsigned commandId)

--- a/Editor/Source/Application.h
+++ b/Editor/Source/Application.h
@@ -301,6 +301,7 @@ namespace Xelqoria::Editor
         bool m_running = true;
         bool m_editorInitialized = false;
         bool m_projectDirty = false;
+        HMENU m_menuBar = nullptr;
         HMENU m_projectMenu = nullptr;
         HMENU m_viewMenu = nullptr;
         Platform::Win32::Win32FileDialog m_fileDialog{};

--- a/Editor/Source/StartupScreenController.cpp
+++ b/Editor/Source/StartupScreenController.cpp
@@ -1,12 +1,17 @@
 #include "StartupScreenController.h"
 
+#include <Windows.h>
+
 #include <algorithm>
 #include <array>
+#include <chrono>
 #include <cwchar>
+#include <ctime>
+#include <iomanip>
+#include <sstream>
 #include <string>
-#include <Windows.h>
-#include <filesystem>
-#include <optional>
+#include <system_error>
+
 #include "EditorProject.h"
 #include <InputSystem.h>
 
@@ -19,14 +24,32 @@ namespace Xelqoria::Editor
         constexpr int BrowseFolderButtonId = 4303;
         constexpr int CreateConfirmButtonId = 4304;
         constexpr int CreateCancelButtonId = 4305;
+        constexpr int ProjectTabButtonId = 4306;
+        constexpr int ViewTabButtonId = 4307;
+        constexpr int MinimizeButtonId = 4308;
+        constexpr int MaximizeButtonId = 4309;
+        constexpr int CloseButtonId = 4310;
+        constexpr int RecentProjectsListBoxId = 4311;
+        constexpr int AllProjectsListBoxId = 4312;
         constexpr const wchar_t* CreateProjectWindowClassName = L"XelqoriaCreateProjectWindow";
+        constexpr const wchar_t* ParentControllerPropertyName = L"XelqoriaStartupScreenController";
+        constexpr COLORREF BackgroundColor = RGB(4, 7, 20);
+        constexpr COLORREF HeaderColor = RGB(7, 10, 25);
+        constexpr COLORREF PanelColor = RGB(15, 16, 44);
+        constexpr COLORREF PanelHoverColor = RGB(25, 24, 68);
+        constexpr COLORREF TextColor = RGB(238, 241, 255);
+        constexpr COLORREF MutedTextColor = RGB(170, 178, 216);
+        constexpr COLORREF AccentColor = RGB(160, 82, 255);
+        constexpr COLORREF AccentBlueColor = RGB(44, 113, 255);
+        constexpr COLORREF BorderColor = RGB(91, 75, 210);
+        constexpr COLORREF EditColor = RGB(13, 15, 38);
 
         [[nodiscard]] POINT ToWin32Point(Platform::Point point)
         {
             return POINT{ static_cast<LONG>(point.x), static_cast<LONG>(point.y) };
         }
 
-        UINT GetWindowDpi(HWND window)
+        [[nodiscard]] UINT GetWindowDpi(HWND window)
         {
             HMODULE user32 = GetModuleHandleW(L"user32.dll");
             if (nullptr != user32)
@@ -55,8 +78,31 @@ namespace Xelqoria::Editor
             return dpi > 0 ? static_cast<UINT>(dpi) : 96u;
         }
 
+        [[nodiscard]] StartupScreenController* GetControllerFromWindow(HWND window)
+        {
+            return reinterpret_cast<StartupScreenController*>(
+                GetPropW(window, ParentControllerPropertyName));
+        }
+
+        LRESULT CALLBACK StartupParentWindowProc(HWND window, UINT message, WPARAM wParam, LPARAM lParam)
+        {
+            StartupScreenController* controller = GetControllerFromWindow(window);
+            if (nullptr != controller)
+            {
+                return controller->HandleParentWindowMessage(window, message, wParam, lParam);
+            }
+
+            return DefWindowProcW(window, message, wParam, lParam);
+        }
+
         LRESULT CALLBACK CreateProjectWindowProc(HWND window, UINT message, WPARAM wParam, LPARAM lParam)
         {
+            StartupScreenController* controller = GetControllerFromWindow(window);
+            if (nullptr != controller)
+            {
+                return controller->HandleCreateProjectWindowMessage(window, message, wParam, lParam);
+            }
+
             if (message == WM_CLOSE)
             {
                 ShowWindow(window, SW_HIDE);
@@ -66,12 +112,7 @@ namespace Xelqoria::Editor
             return DefWindowProcW(window, message, wParam, lParam);
         }
 
-        [[nodiscard]] std::wstring BuildRecentProjectLabel(const EditorProjectInfo& project)
-        {
-            return project.name + L" - " + project.projectFilePath.parent_path().wstring();
-        }
-
-        bool RegisterCreateProjectWindowClass(HINSTANCE hInstance)
+        [[nodiscard]] bool RegisterCreateProjectWindowClass(HINSTANCE hInstance)
         {
             WNDCLASSW windowClass{};
             if (GetClassInfoW(hInstance, CreateProjectWindowClassName, &windowClass))
@@ -81,26 +122,114 @@ namespace Xelqoria::Editor
 
             windowClass.lpfnWndProc = CreateProjectWindowProc;
             windowClass.hInstance = hInstance;
-            windowClass.hCursor = nullptr;
-            windowClass.hbrBackground = reinterpret_cast<HBRUSH>(COLOR_BTNFACE + 1);
+            windowClass.hCursor = LoadCursor(nullptr, IDC_ARROW);
+            windowClass.hbrBackground = nullptr;
             windowClass.lpszClassName = CreateProjectWindowClassName;
             return 0 != RegisterClassW(&windowClass);
+        }
+
+        [[nodiscard]] std::wstring BuildRecentProjectLabel(const EditorProjectInfo& project)
+        {
+            return project.name + L" - " + project.projectFilePath.parent_path().wstring();
+        }
+
+        [[nodiscard]] std::wstring FormatProjectFileTime(const std::filesystem::path& projectFilePath)
+        {
+            std::error_code errorCode;
+            const std::filesystem::file_time_type fileTime = std::filesystem::last_write_time(projectFilePath, errorCode);
+            if (errorCode)
+            {
+                return L"-";
+            }
+
+            const auto systemTime =
+                std::chrono::time_point_cast<std::chrono::system_clock::duration>(
+                    fileTime - std::filesystem::file_time_type::clock::now() + std::chrono::system_clock::now());
+            const std::time_t timeValue = std::chrono::system_clock::to_time_t(systemTime);
+            std::tm localTime{};
+            if (0 != localtime_s(&localTime, &timeValue))
+            {
+                return L"-";
+            }
+
+            std::wstringstream stream{};
+            stream << std::put_time(&localTime, L"%Y-%m-%d %H:%M");
+            return stream.str();
+        }
+
+        [[nodiscard]] std::wstring BuildAllProjectLabel(const EditorProjectInfo& project)
+        {
+            return project.name
+                + L"    "
+                + project.projectFilePath.parent_path().wstring()
+                + L"    "
+                + FormatProjectFileTime(project.projectFilePath);
+        }
+
+        [[nodiscard]] bool IsExistingValidProject(const EditorProjectInfo& project)
+        {
+            EditorProject validator{};
+            return validator.Open(project.projectFilePath);
+        }
+
+        [[nodiscard]] std::filesystem::file_time_type GetSortableProjectTime(const EditorProjectInfo& project)
+        {
+            std::error_code errorCode;
+            const std::filesystem::file_time_type fileTime = std::filesystem::last_write_time(project.projectFilePath, errorCode);
+            return errorCode ? (std::filesystem::file_time_type::min)() : fileTime;
+        }
+
+        void SelectPenAndBrush(HDC deviceContext, HPEN pen, HBRUSH brush)
+        {
+            SelectObject(deviceContext, pen);
+            SelectObject(deviceContext, brush);
         }
     }
 
     bool StartupScreenController::Initialize(HWND parentWindow, HINSTANCE hInstance, Platform::IFileDialog& fileDialog)
     {
         m_fileDialog = &fileDialog;
+        m_hidden = false;
+        EnsureThemeResources();
+        SubclassParentWindow(parentWindow);
         (void)RefreshDpiResources(parentWindow);
-        m_createButton = CreateChildWindow(parentWindow, hInstance, L"Button", L"プロジェクト作成", WS_CHILD | WS_VISIBLE | BS_PUSHBUTTON);
-        m_openButton = CreateChildWindow(parentWindow, hInstance, L"Button", L"プロジェクトを開く", WS_CHILD | WS_VISIBLE | BS_PUSHBUTTON);
+
+        m_projectTabButton = CreateChildWindow(parentWindow, hInstance, L"Button", L"プロジェクト", WS_CHILD | WS_VISIBLE | BS_OWNERDRAW);
+        m_viewTabButton = CreateChildWindow(parentWindow, hInstance, L"Button", L"表示", WS_CHILD | WS_VISIBLE | BS_OWNERDRAW);
+        m_minimizeButton = CreateChildWindow(parentWindow, hInstance, L"Button", L"ー", WS_CHILD | WS_VISIBLE | BS_OWNERDRAW);
+        m_maximizeButton = CreateChildWindow(parentWindow, hInstance, L"Button", L"□", WS_CHILD | WS_VISIBLE | BS_OWNERDRAW);
+        m_closeButton = CreateChildWindow(parentWindow, hInstance, L"Button", L"×", WS_CHILD | WS_VISIBLE | BS_OWNERDRAW);
+        m_createButton = CreateChildWindow(parentWindow, hInstance, L"Button", L"プロジェクト作成", WS_CHILD | WS_VISIBLE | BS_OWNERDRAW);
+        m_openButton = CreateChildWindow(parentWindow, hInstance, L"Button", L"プロジェクトを開く", WS_CHILD | WS_VISIBLE | BS_OWNERDRAW);
         m_recentLabel = CreateChildWindow(parentWindow, hInstance, L"Static", L"最近使ったプロジェクト一覧", WS_CHILD | WS_VISIBLE);
         m_recentListBox = CreateChildWindow(
             parentWindow,
             hInstance,
             L"ListBox",
             L"",
-            WS_CHILD | WS_VISIBLE | WS_VSCROLL | LBS_NOTIFY | LBS_NOINTEGRALHEIGHT | WS_BORDER);
+            WS_CHILD | WS_VISIBLE | WS_VSCROLL | LBS_NOTIFY | LBS_NOINTEGRALHEIGHT | LBS_OWNERDRAWFIXED | LBS_HASSTRINGS);
+        m_allProjectsLabel = CreateChildWindow(parentWindow, hInstance, L"Static", L"作成済みプロジェクト", WS_CHILD);
+        m_allProjectsListBox = CreateChildWindow(
+            parentWindow,
+            hInstance,
+            L"ListBox",
+            L"",
+            WS_CHILD | WS_VSCROLL | LBS_NOTIFY | LBS_NOINTEGRALHEIGHT | LBS_OWNERDRAWFIXED | LBS_HASSTRINGS);
+
+        if (nullptr == m_projectTabButton
+            || nullptr == m_viewTabButton
+            || nullptr == m_minimizeButton
+            || nullptr == m_maximizeButton
+            || nullptr == m_closeButton
+            || nullptr == m_createButton
+            || nullptr == m_openButton
+            || nullptr == m_recentLabel
+            || nullptr == m_recentListBox
+            || nullptr == m_allProjectsLabel
+            || nullptr == m_allProjectsListBox)
+        {
+            return false;
+        }
 
         if (false == RegisterCreateProjectWindowClass(hInstance))
         {
@@ -114,8 +243,8 @@ namespace Xelqoria::Editor
             WS_OVERLAPPED | WS_CAPTION | WS_SYSMENU | WS_CLIPCHILDREN,
             CW_USEDEFAULT,
             CW_USEDEFAULT,
-            ScaleMetric(560),
-            ScaleMetric(180),
+            ScaleMetric(640),
+            ScaleMetric(260),
             parentWindow,
             nullptr,
             hInstance,
@@ -126,44 +255,62 @@ namespace Xelqoria::Editor
             return false;
         }
 
-        if (nullptr == (m_nameLabel = CreateChildWindow(m_createProjectWindow, hInstance, L"Static", L"プロジェクト名", WS_CHILD | WS_VISIBLE))) {
-            return false;
-        }
-        if (nullptr == (m_projectNameEdit = CreateChildWindow(m_createProjectWindow, hInstance, L"Edit", L"NewProject", WS_CHILD | WS_VISIBLE | WS_BORDER | ES_AUTOHSCROLL))) {
-            return false;
-        }
-        if (nullptr == (m_folderLabel = CreateChildWindow(m_createProjectWindow, hInstance, L"Static", L"保存先フォルダ", WS_CHILD | WS_VISIBLE))) {
-            return false;
-        }
-        if (nullptr == (m_projectFolderEdit = CreateChildWindow(m_createProjectWindow, hInstance, L"Edit", L".", WS_CHILD | WS_VISIBLE | WS_BORDER | ES_AUTOHSCROLL))) {
-            return false;
-        }
-        if (nullptr == (m_browseFolderButton = CreateChildWindow(m_createProjectWindow, hInstance, L"Button", L"参照", WS_CHILD | WS_VISIBLE | BS_PUSHBUTTON))) {
-            return false;
-        }
-        if (nullptr == (m_createConfirmButton = CreateChildWindow(m_createProjectWindow, hInstance, L"Button", L"作成", WS_CHILD | WS_VISIBLE | BS_DEFPUSHBUTTON))) {
-            return false;
-        }
-        if (nullptr == (m_createCancelButton = CreateChildWindow(m_createProjectWindow, hInstance, L"Button", L"キャンセル", WS_CHILD | WS_VISIBLE | BS_PUSHBUTTON))) {
+        SetPropW(m_createProjectWindow, ParentControllerPropertyName, this);
+
+        m_nameLabel = CreateChildWindow(m_createProjectWindow, hInstance, L"Static", L"プロジェクト名", WS_CHILD | WS_VISIBLE);
+        m_projectNameEdit = CreateChildWindow(m_createProjectWindow, hInstance, L"Edit", L"NewProject", WS_CHILD | WS_VISIBLE | WS_BORDER | ES_AUTOHSCROLL);
+        m_folderLabel = CreateChildWindow(m_createProjectWindow, hInstance, L"Static", L"保存先フォルダ", WS_CHILD | WS_VISIBLE);
+        m_projectFolderEdit = CreateChildWindow(m_createProjectWindow, hInstance, L"Edit", L".", WS_CHILD | WS_VISIBLE | WS_BORDER | ES_AUTOHSCROLL);
+        m_browseFolderButton = CreateChildWindow(m_createProjectWindow, hInstance, L"Button", L"参照", WS_CHILD | WS_VISIBLE | BS_OWNERDRAW);
+        m_createConfirmButton = CreateChildWindow(m_createProjectWindow, hInstance, L"Button", L"作成", WS_CHILD | WS_VISIBLE | BS_OWNERDRAW);
+        m_createCancelButton = CreateChildWindow(m_createProjectWindow, hInstance, L"Button", L"キャンセル", WS_CHILD | WS_VISIBLE | BS_OWNERDRAW);
+
+        if (nullptr == m_nameLabel
+            || nullptr == m_projectNameEdit
+            || nullptr == m_folderLabel
+            || nullptr == m_projectFolderEdit
+            || nullptr == m_browseFolderButton
+            || nullptr == m_createConfirmButton
+            || nullptr == m_createCancelButton)
+        {
             return false;
         }
 
+        SetWindowLongPtrW(m_projectTabButton, GWLP_ID, ProjectTabButtonId);
+        SetWindowLongPtrW(m_viewTabButton, GWLP_ID, ViewTabButtonId);
+        SetWindowLongPtrW(m_minimizeButton, GWLP_ID, MinimizeButtonId);
+        SetWindowLongPtrW(m_maximizeButton, GWLP_ID, MaximizeButtonId);
+        SetWindowLongPtrW(m_closeButton, GWLP_ID, CloseButtonId);
         SetWindowLongPtrW(m_createButton, GWLP_ID, CreateProjectButtonId);
         SetWindowLongPtrW(m_openButton, GWLP_ID, OpenProjectButtonId);
+        SetWindowLongPtrW(m_recentListBox, GWLP_ID, RecentProjectsListBoxId);
+        SetWindowLongPtrW(m_allProjectsListBox, GWLP_ID, AllProjectsListBoxId);
         SetWindowLongPtrW(m_browseFolderButton, GWLP_ID, BrowseFolderButtonId);
         SetWindowLongPtrW(m_createConfirmButton, GWLP_ID, CreateConfirmButtonId);
         SetWindowLongPtrW(m_createCancelButton, GWLP_ID, CreateCancelButtonId);
+
+        SendMessageW(m_recentListBox, LB_SETITEMHEIGHT, 0, ScaleMetric(44));
+        SendMessageW(m_allProjectsListBox, LB_SETITEMHEIGHT, 0, ScaleMetric(44));
         UpdateCreateProjectWindowLayout();
         RefreshRecentProjects();
+        RefreshAllProjects();
+        SetActiveTab(StartupTab::Projects);
         return true;
     }
 
     StartupScreenController::~StartupScreenController()
     {
+        DestroyThemeResources();
+
         if (m_ownsDefaultFont && nullptr != m_defaultFont)
         {
             HFONT stockFont = static_cast<HFONT>(GetStockObject(DEFAULT_GUI_FONT));
-            const std::array<HWND, 12> controls{
+            const std::array<HWND, 19> controls{
+                m_projectTabButton,
+                m_viewTabButton,
+                m_minimizeButton,
+                m_maximizeButton,
+                m_closeButton,
                 m_nameLabel,
                 m_projectNameEdit,
                 m_folderLabel,
@@ -175,7 +322,9 @@ namespace Xelqoria::Editor
                 m_createButton,
                 m_openButton,
                 m_recentLabel,
-                m_recentListBox
+                m_recentListBox,
+                m_allProjectsLabel,
+                m_allProjectsListBox
             };
             for (HWND control : controls)
             {
@@ -208,22 +357,84 @@ namespace Xelqoria::Editor
             return;
         }
 
-        const int panelWidth = ScaleMetric(520);
-        const int panelLeft = (std::max)(ScaleMetric(24), (clientWidth - panelWidth) / 2);
-        const int top = (std::max)(ScaleMetric(24), (clientHeight - ScaleMetric(264)) / 2);
+        const int headerHeight = ScaleMetric(48);
+        const int tabHeight = ScaleMetric(52);
+        const int margin = ScaleMetric(28);
+        const int contentTop = headerHeight + tabHeight + ScaleMetric(28);
+        const int contentWidth = (std::min)(ScaleMetric(1360), (std::max)(ScaleMetric(420), clientWidth - margin * 2));
+        const int contentLeft = (std::max)(margin, (clientWidth - contentWidth) / 2);
+        const int cardGap = ScaleMetric(40);
+        const int cardHeight = ScaleMetric(118);
+        const int cardWidth = (contentWidth - cardGap) / 2;
+        const bool twoColumns = cardWidth >= ScaleMetric(320);
+        const int actualCardWidth = twoColumns ? cardWidth : contentWidth;
+        const int secondCardLeft = twoColumns ? contentLeft + actualCardWidth + cardGap : contentLeft;
+        const int secondCardTop = twoColumns ? contentTop : contentTop + cardHeight + ScaleMetric(16);
+        const int listTop = (twoColumns ? contentTop + cardHeight : secondCardTop + cardHeight) + ScaleMetric(36);
+        const int listHeight = (std::max)(ScaleMetric(180), clientHeight - listTop - ScaleMetric(54));
 
-        MoveWindow(m_createButton, panelLeft, top, ScaleMetric(250), ScaleMetric(32), TRUE);
-        MoveWindow(m_openButton, panelLeft + ScaleMetric(270), top, ScaleMetric(250), ScaleMetric(32), TRUE);
-        MoveWindow(m_recentLabel, panelLeft, top + ScaleMetric(56), panelWidth, ScaleMetric(24), TRUE);
-        MoveWindow(m_recentListBox, panelLeft, top + ScaleMetric(84), panelWidth, ScaleMetric(180), TRUE);
+        MoveWindow(m_projectTabButton, ScaleMetric(16), headerHeight, ScaleMetric(130), tabHeight, TRUE);
+        MoveWindow(m_viewTabButton, ScaleMetric(154), headerHeight, ScaleMetric(90), tabHeight, TRUE);
+        MoveWindow(m_minimizeButton, clientWidth - ScaleMetric(156), ScaleMetric(8), ScaleMetric(42), ScaleMetric(32), TRUE);
+        MoveWindow(m_maximizeButton, clientWidth - ScaleMetric(108), ScaleMetric(8), ScaleMetric(42), ScaleMetric(32), TRUE);
+        MoveWindow(m_closeButton, clientWidth - ScaleMetric(60), ScaleMetric(8), ScaleMetric(42), ScaleMetric(32), TRUE);
+        MoveWindow(m_createButton, contentLeft, contentTop, actualCardWidth, cardHeight, TRUE);
+        MoveWindow(m_openButton, secondCardLeft, secondCardTop, actualCardWidth, cardHeight, TRUE);
+        MoveWindow(m_recentLabel, contentLeft + ScaleMetric(20), listTop - ScaleMetric(38), contentWidth, ScaleMetric(28), TRUE);
+        MoveWindow(m_recentListBox, contentLeft, listTop, contentWidth, listHeight, TRUE);
+        MoveWindow(m_allProjectsLabel, contentLeft + ScaleMetric(20), contentTop, contentWidth, ScaleMetric(28), TRUE);
+        MoveWindow(m_allProjectsListBox, contentLeft, contentTop + ScaleMetric(42), contentWidth, (std::max)(ScaleMetric(260), clientHeight - contentTop - ScaleMetric(88)), TRUE);
+
         m_layoutInitialized = true;
         m_lastLayoutClientWidth = clientWidth;
         m_lastLayoutClientHeight = clientHeight;
         m_lastLayoutDpi = m_currentDpi;
+        SetActiveTab(m_activeTab);
+        InvalidateRect(parentWindow, nullptr, TRUE);
+    }
+
+    bool StartupScreenController::HandleDrawItem(LPARAM drawItemParameter)
+    {
+        const DRAWITEMSTRUCT* drawItem = reinterpret_cast<DRAWITEMSTRUCT*>(drawItemParameter);
+        if (nullptr == drawItem)
+        {
+            return false;
+        }
+
+        switch (drawItem->CtlID)
+        {
+        case CreateProjectButtonId:
+        case OpenProjectButtonId:
+        case BrowseFolderButtonId:
+        case CreateConfirmButtonId:
+        case CreateCancelButtonId:
+        case MinimizeButtonId:
+        case MaximizeButtonId:
+        case CloseButtonId:
+            DrawThemedButton(*drawItem);
+            return true;
+        case ProjectTabButtonId:
+            DrawTabButton(*drawItem, StartupTab::Projects);
+            return true;
+        case ViewTabButtonId:
+            DrawTabButton(*drawItem, StartupTab::View);
+            return true;
+        case RecentProjectsListBoxId:
+        case AllProjectsListBoxId:
+            DrawProjectListItem(*drawItem);
+            return true;
+        default:
+            return false;
+        }
     }
 
     void StartupScreenController::Update(const Core::InputSnapshot& inputSnapshot)
     {
+        if (m_hidden)
+        {
+            return;
+        }
+
         const bool isLeftMouseDown = inputSnapshot.IsMouseButtonDown(Core::MouseButton::Left);
         if (false == m_wasLeftMouseDown || isLeftMouseDown)
         {
@@ -235,6 +446,38 @@ namespace Xelqoria::Editor
 
         const POINT cursorPosition = ToWin32Point(inputSnapshot.GetCursorScreenPoint());
         const HWND clickedWindow = WindowFromPoint(cursorPosition);
+        if (clickedWindow == m_projectTabButton)
+        {
+            SetActiveTab(StartupTab::Projects);
+            return;
+        }
+
+        if (clickedWindow == m_viewTabButton)
+        {
+            RefreshAllProjects();
+            SetActiveTab(StartupTab::View);
+            return;
+        }
+
+        if (clickedWindow == m_minimizeButton)
+        {
+            ShowWindow(m_parentWindow, SW_MINIMIZE);
+            return;
+        }
+
+        if (clickedWindow == m_maximizeButton)
+        {
+            const bool isMaximized = IsZoomed(m_parentWindow);
+            ShowWindow(m_parentWindow, isMaximized ? SW_RESTORE : SW_MAXIMIZE);
+            return;
+        }
+
+        if (clickedWindow == m_closeButton)
+        {
+            PostMessageW(m_parentWindow, WM_CLOSE, 0, 0);
+            return;
+        }
+
         if (clickedWindow == m_createButton)
         {
             ShowCreateProjectWindow();
@@ -273,14 +516,22 @@ namespace Xelqoria::Editor
             return;
         }
 
-        if (clickedWindow == m_recentListBox && HandleRecentProjectDoubleClick(cursorPosition))
+        if (clickedWindow == m_recentListBox
+            && HandleProjectListDoubleClick(m_recentListBox, m_recentProjects, cursorPosition))
+        {
+            return;
+        }
+
+        if (clickedWindow == m_allProjectsListBox
+            && HandleProjectListDoubleClick(m_allProjectsListBox, m_allProjects, cursorPosition))
         {
             return;
         }
 
         if (clickedWindow == m_openButton)
         {
-            const std::optional<EditorProjectInfo> selectedProject = GetSelectedRecentProject();
+            const std::optional<EditorProjectInfo> selectedProject =
+                StartupTab::View == m_activeTab ? GetSelectedAllProject() : GetSelectedRecentProject();
             if (selectedProject.has_value())
             {
                 m_openProjectFilePath = selectedProject->projectFilePath;
@@ -312,11 +563,19 @@ namespace Xelqoria::Editor
 
     void StartupScreenController::Hide()
     {
-        std::array<HWND, 4> controls{
+        m_hidden = true;
+        std::array<HWND, 11> controls{
+            m_projectTabButton,
+            m_viewTabButton,
+            m_minimizeButton,
+            m_maximizeButton,
+            m_closeButton,
             m_createButton,
             m_openButton,
             m_recentLabel,
-            m_recentListBox
+            m_recentListBox,
+            m_allProjectsLabel,
+            m_allProjectsListBox
         };
 
         for (HWND control : controls)
@@ -325,26 +584,38 @@ namespace Xelqoria::Editor
         }
 
         HideCreateProjectWindow();
+        if (nullptr != m_parentWindow)
+        {
+            RedrawWindow(m_parentWindow, nullptr, nullptr, RDW_INVALIDATE | RDW_ERASE | RDW_UPDATENOW | RDW_ALLCHILDREN);
+        }
     }
 
     void StartupScreenController::Destroy()
     {
-        HWND parentWindow = nullptr;
-        if (nullptr != m_createButton)
-        {
-            parentWindow = GetParent(m_createButton);
-        }
+        HWND parentWindow = m_parentWindow;
 
-        std::array<HWND*, 4> startupControls{
+        std::array<HWND*, 11> startupControls{
+            &m_projectTabButton,
+            &m_viewTabButton,
+            &m_minimizeButton,
+            &m_maximizeButton,
+            &m_closeButton,
             &m_createButton,
             &m_openButton,
             &m_recentLabel,
-            &m_recentListBox
+            &m_recentListBox,
+            &m_allProjectsLabel,
+            &m_allProjectsListBox
         };
 
         for (HWND* control : startupControls)
         {
             DestroyWindowHandle(*control);
+        }
+
+        if (nullptr != m_createProjectWindow)
+        {
+            RemovePropW(m_createProjectWindow, ParentControllerPropertyName);
         }
 
         DestroyWindowHandle(m_createProjectWindow);
@@ -357,6 +628,7 @@ namespace Xelqoria::Editor
         m_createCancelButton = nullptr;
         m_createRequested = false;
         m_openProjectFilePath.clear();
+        UnsubclassParentWindow();
 
         if (nullptr != parentWindow)
         {
@@ -393,17 +665,488 @@ namespace Xelqoria::Editor
     {
         m_createRequested = false;
         m_openProjectFilePath.clear();
+        RefreshRecentProjects();
+        RefreshAllProjects();
     }
 
     void StartupScreenController::RefreshRecentProjects()
     {
         m_recentProjects = m_recentProjectsStore.Load();
         SendMessageW(m_recentListBox, LB_RESETCONTENT, 0, 0);
+        if (m_recentProjects.empty())
+        {
+            SendMessageW(m_recentListBox, LB_ADDSTRING, 0, reinterpret_cast<LPARAM>(L"最近使ったプロジェクトはありません"));
+            return;
+        }
+
         for (const EditorProjectInfo& project : m_recentProjects)
         {
             const std::wstring label = BuildRecentProjectLabel(project);
             SendMessageW(m_recentListBox, LB_ADDSTRING, 0, reinterpret_cast<LPARAM>(label.c_str()));
         }
+    }
+
+    void StartupScreenController::RefreshAllProjects()
+    {
+        m_allProjects = m_recentProjectsStore.Load();
+        m_allProjects.erase(
+            std::remove_if(
+                m_allProjects.begin(),
+                m_allProjects.end(),
+                [](const EditorProjectInfo& project)
+                {
+                    return false == IsExistingValidProject(project);
+                }),
+            m_allProjects.end());
+        std::sort(
+            m_allProjects.begin(),
+            m_allProjects.end(),
+            [](const EditorProjectInfo& left, const EditorProjectInfo& right)
+            {
+                return GetSortableProjectTime(right) < GetSortableProjectTime(left);
+            });
+
+        SendMessageW(m_allProjectsListBox, LB_RESETCONTENT, 0, 0);
+        if (m_allProjects.empty())
+        {
+            SendMessageW(m_allProjectsListBox, LB_ADDSTRING, 0, reinterpret_cast<LPARAM>(L"表示できるプロジェクトはありません"));
+            return;
+        }
+
+        for (const EditorProjectInfo& project : m_allProjects)
+        {
+            const std::wstring label = BuildAllProjectLabel(project);
+            SendMessageW(m_allProjectsListBox, LB_ADDSTRING, 0, reinterpret_cast<LPARAM>(label.c_str()));
+        }
+    }
+
+    void StartupScreenController::SetActiveTab(StartupTab tab)
+    {
+        m_activeTab = tab;
+        const bool showProjects = StartupTab::Projects == m_activeTab;
+        ShowWindow(m_createButton, showProjects ? SW_SHOW : SW_HIDE);
+        ShowWindow(m_openButton, showProjects ? SW_SHOW : SW_HIDE);
+        ShowWindow(m_recentLabel, showProjects ? SW_SHOW : SW_HIDE);
+        ShowWindow(m_recentListBox, showProjects ? SW_SHOW : SW_HIDE);
+        ShowWindow(m_allProjectsLabel, showProjects ? SW_HIDE : SW_SHOW);
+        ShowWindow(m_allProjectsListBox, showProjects ? SW_HIDE : SW_SHOW);
+        InvalidateRect(m_projectTabButton, nullptr, TRUE);
+        InvalidateRect(m_viewTabButton, nullptr, TRUE);
+        if (nullptr != m_parentWindow)
+        {
+            InvalidateRect(m_parentWindow, nullptr, TRUE);
+        }
+    }
+
+    void StartupScreenController::EnsureThemeResources()
+    {
+        if (nullptr != m_darkBackgroundBrush)
+        {
+            return;
+        }
+
+        m_darkBackgroundBrush = CreateSolidBrush(BackgroundColor);
+        m_panelBackgroundBrush = CreateSolidBrush(PanelColor);
+        m_editBackgroundBrush = CreateSolidBrush(EditColor);
+        m_accentPen = CreatePen(PS_SOLID, 1, AccentColor);
+        m_dimAccentPen = CreatePen(PS_SOLID, 1, BorderColor);
+        m_blueAccentPen = CreatePen(PS_SOLID, 1, AccentBlueColor);
+    }
+
+    void StartupScreenController::DestroyThemeResources()
+    {
+        if (nullptr != m_darkBackgroundBrush)
+        {
+            DeleteObject(m_darkBackgroundBrush);
+            m_darkBackgroundBrush = nullptr;
+        }
+
+        if (nullptr != m_panelBackgroundBrush)
+        {
+            DeleteObject(m_panelBackgroundBrush);
+            m_panelBackgroundBrush = nullptr;
+        }
+
+        if (nullptr != m_editBackgroundBrush)
+        {
+            DeleteObject(m_editBackgroundBrush);
+            m_editBackgroundBrush = nullptr;
+        }
+
+        if (nullptr != m_accentPen)
+        {
+            DeleteObject(m_accentPen);
+            m_accentPen = nullptr;
+        }
+
+        if (nullptr != m_dimAccentPen)
+        {
+            DeleteObject(m_dimAccentPen);
+            m_dimAccentPen = nullptr;
+        }
+
+        if (nullptr != m_blueAccentPen)
+        {
+            DeleteObject(m_blueAccentPen);
+            m_blueAccentPen = nullptr;
+        }
+    }
+
+    void StartupScreenController::SubclassParentWindow(HWND parentWindow)
+    {
+        if (nullptr == parentWindow || m_parentWindow == parentWindow)
+        {
+            return;
+        }
+
+        m_parentWindow = parentWindow;
+        SetPropW(m_parentWindow, ParentControllerPropertyName, this);
+        m_originalParentWindowProc =
+            reinterpret_cast<WNDPROC>(SetWindowLongPtrW(m_parentWindow, GWLP_WNDPROC, reinterpret_cast<LONG_PTR>(StartupParentWindowProc)));
+    }
+
+    void StartupScreenController::UnsubclassParentWindow()
+    {
+        if (nullptr != m_parentWindow && nullptr != m_originalParentWindowProc)
+        {
+            SetWindowLongPtrW(m_parentWindow, GWLP_WNDPROC, reinterpret_cast<LONG_PTR>(m_originalParentWindowProc));
+        }
+
+        if (nullptr != m_parentWindow)
+        {
+            RemovePropW(m_parentWindow, ParentControllerPropertyName);
+        }
+
+        m_parentWindow = nullptr;
+        m_originalParentWindowProc = nullptr;
+    }
+
+    void StartupScreenController::PaintStartupBackground(HDC deviceContext)
+    {
+        RECT clientRect{};
+        GetClientRect(m_parentWindow, &clientRect);
+        FillRect(deviceContext, &clientRect, m_darkBackgroundBrush);
+
+        RECT headerRect{ clientRect.left, clientRect.top, clientRect.right, ScaleMetric(48) };
+        HBRUSH headerBrush = CreateSolidBrush(HeaderColor);
+        FillRect(deviceContext, &headerRect, headerBrush);
+        DeleteObject(headerBrush);
+
+        RECT tabRect{ clientRect.left, ScaleMetric(48), clientRect.right, ScaleMetric(100) };
+        HBRUSH tabBrush = CreateSolidBrush(RGB(8, 10, 28));
+        FillRect(deviceContext, &tabRect, tabBrush);
+        DeleteObject(tabBrush);
+
+        SelectObject(deviceContext, m_dimAccentPen);
+        MoveToEx(deviceContext, 0, ScaleMetric(99), nullptr);
+        LineTo(deviceContext, clientRect.right, ScaleMetric(99));
+
+        SetBkMode(deviceContext, TRANSPARENT);
+        SetTextColor(deviceContext, TextColor);
+        RECT logoRect{ ScaleMetric(12), ScaleMetric(8), ScaleMetric(38), ScaleMetric(38) };
+        SelectObject(deviceContext, m_accentPen);
+        MoveToEx(deviceContext, logoRect.left, logoRect.top, nullptr);
+        LineTo(deviceContext, logoRect.right, logoRect.bottom);
+        MoveToEx(deviceContext, logoRect.right, logoRect.top, nullptr);
+        LineTo(deviceContext, logoRect.left, logoRect.bottom);
+
+        RECT titleRect{ ScaleMetric(52), ScaleMetric(10), ScaleMetric(360), ScaleMetric(42) };
+        DrawTextW(deviceContext, L"Xelqoria Editor", -1, &titleRect, DT_LEFT | DT_VCENTER | DT_SINGLELINE);
+
+        SelectObject(deviceContext, m_blueAccentPen);
+        const int baseX = clientRect.right - ScaleMetric(210);
+        const int baseY = clientRect.bottom - ScaleMetric(160);
+        for (int index = 0; index < 6; ++index)
+        {
+            const int offset = ScaleMetric(index * 22);
+            POINT points[6]{
+                { baseX + offset, baseY - ScaleMetric(40) - offset / 2 },
+                { baseX + ScaleMetric(58) + offset, baseY - ScaleMetric(12) - offset / 2 },
+                { baseX + ScaleMetric(58) + offset, baseY + ScaleMetric(48) - offset / 2 },
+                { baseX + offset, baseY + ScaleMetric(78) - offset / 2 },
+                { baseX - ScaleMetric(58) + offset, baseY + ScaleMetric(48) - offset / 2 },
+                { baseX - ScaleMetric(58) + offset, baseY - ScaleMetric(12) - offset / 2 }
+            };
+            Polyline(deviceContext, points, 6);
+            LineTo(deviceContext, points[0].x, points[0].y);
+        }
+    }
+
+    void StartupScreenController::PaintCreateProjectBackground(HDC deviceContext)
+    {
+        RECT clientRect{};
+        GetClientRect(m_createProjectWindow, &clientRect);
+        FillRect(deviceContext, &clientRect, m_darkBackgroundBrush);
+
+        SetBkMode(deviceContext, TRANSPARENT);
+        SetTextColor(deviceContext, TextColor);
+        SelectObject(deviceContext, m_blueAccentPen);
+        const int baseX = clientRect.right - ScaleMetric(82);
+        const int baseY = clientRect.bottom - ScaleMetric(36);
+        for (int index = 0; index < 4; ++index)
+        {
+            RECT rect{
+                baseX - ScaleMetric(18 * index),
+                baseY - ScaleMetric(18 * index),
+                baseX + ScaleMetric(48 + 18 * index),
+                baseY + ScaleMetric(48 + 18 * index)
+            };
+            RoundRect(deviceContext, rect.left, rect.top, rect.right, rect.bottom, ScaleMetric(8), ScaleMetric(8));
+        }
+    }
+
+    void StartupScreenController::DrawThemedButton(const DRAWITEMSTRUCT& drawItem) const
+    {
+        const bool selected = 0 != (drawItem.itemState & ODS_SELECTED);
+        const bool hot = 0 != (drawItem.itemState & ODS_HOTLIGHT);
+        HBRUSH fillBrush = CreateSolidBrush(selected ? RGB(18, 16, 50) : (hot ? PanelHoverColor : PanelColor));
+        HPEN borderPen = CreatePen(PS_SOLID, 1, drawItem.CtlID == CreateConfirmButtonId ? AccentColor : BorderColor);
+        SelectPenAndBrush(drawItem.hDC, borderPen, fillBrush);
+        const RECT rect = drawItem.rcItem;
+        RoundRect(drawItem.hDC, rect.left, rect.top, rect.right, rect.bottom, ScaleMetric(8), ScaleMetric(8));
+
+        SetBkMode(drawItem.hDC, TRANSPARENT);
+        SetTextColor(drawItem.hDC, drawItem.CtlID == CreateCancelButtonId ? MutedTextColor : TextColor);
+        const int textLength = GetWindowTextLengthW(drawItem.hwndItem);
+        std::wstring text(static_cast<std::size_t>(textLength) + 1u, L'\0');
+        GetWindowTextW(drawItem.hwndItem, text.data(), textLength + 1);
+        text.resize(static_cast<std::size_t>(textLength));
+
+        RECT textRect = rect;
+        if (drawItem.CtlID == CreateProjectButtonId || drawItem.CtlID == OpenProjectButtonId)
+        {
+            textRect.left += ScaleMetric(132);
+            textRect.right -= ScaleMetric(24);
+            DrawTextW(drawItem.hDC, text.c_str(), -1, &textRect, DT_LEFT | DT_VCENTER | DT_SINGLELINE);
+
+            SelectObject(drawItem.hDC, m_accentPen);
+            if (drawItem.CtlID == CreateProjectButtonId)
+            {
+                const int centerX = rect.left + ScaleMetric(78);
+                const int centerY = rect.top + (rect.bottom - rect.top) / 2;
+                POINT hex[7]{
+                    { centerX, centerY - ScaleMetric(34) },
+                    { centerX + ScaleMetric(30), centerY - ScaleMetric(17) },
+                    { centerX + ScaleMetric(30), centerY + ScaleMetric(17) },
+                    { centerX, centerY + ScaleMetric(34) },
+                    { centerX - ScaleMetric(30), centerY + ScaleMetric(17) },
+                    { centerX - ScaleMetric(30), centerY - ScaleMetric(17) },
+                    { centerX, centerY - ScaleMetric(34) }
+                };
+                Polyline(drawItem.hDC, hex, 7);
+                MoveToEx(drawItem.hDC, centerX - ScaleMetric(14), centerY, nullptr);
+                LineTo(drawItem.hDC, centerX + ScaleMetric(14), centerY);
+                MoveToEx(drawItem.hDC, centerX, centerY - ScaleMetric(14), nullptr);
+                LineTo(drawItem.hDC, centerX, centerY + ScaleMetric(14));
+            }
+            else
+            {
+                RECT folder{ rect.left + ScaleMetric(58), rect.top + ScaleMetric(38), rect.left + ScaleMetric(120), rect.top + ScaleMetric(82) };
+                MoveToEx(drawItem.hDC, folder.left, folder.top + ScaleMetric(10), nullptr);
+                LineTo(drawItem.hDC, folder.left + ScaleMetric(18), folder.top + ScaleMetric(10));
+                LineTo(drawItem.hDC, folder.left + ScaleMetric(24), folder.top);
+                LineTo(drawItem.hDC, folder.right - ScaleMetric(10), folder.top);
+                LineTo(drawItem.hDC, folder.right - ScaleMetric(10), folder.top + ScaleMetric(16));
+                LineTo(drawItem.hDC, folder.right, folder.top + ScaleMetric(16));
+                LineTo(drawItem.hDC, folder.right, folder.bottom);
+                LineTo(drawItem.hDC, folder.left, folder.bottom);
+                LineTo(drawItem.hDC, folder.left, folder.top + ScaleMetric(10));
+            }
+        }
+        else
+        {
+            DrawTextW(drawItem.hDC, text.c_str(), -1, &textRect, DT_CENTER | DT_VCENTER | DT_SINGLELINE);
+        }
+
+        DeleteObject(fillBrush);
+        DeleteObject(borderPen);
+    }
+
+    void StartupScreenController::DrawTabButton(const DRAWITEMSTRUCT& drawItem, StartupTab tab) const
+    {
+        const bool active = m_activeTab == tab;
+        FillRect(drawItem.hDC, &drawItem.rcItem, m_darkBackgroundBrush);
+        SetBkMode(drawItem.hDC, TRANSPARENT);
+        SetTextColor(drawItem.hDC, active ? TextColor : MutedTextColor);
+        const int textLength = GetWindowTextLengthW(drawItem.hwndItem);
+        std::wstring text(static_cast<std::size_t>(textLength) + 1u, L'\0');
+        GetWindowTextW(drawItem.hwndItem, text.data(), textLength + 1);
+        text.resize(static_cast<std::size_t>(textLength));
+        RECT textRect = drawItem.rcItem;
+        DrawTextW(drawItem.hDC, text.c_str(), -1, &textRect, DT_CENTER | DT_VCENTER | DT_SINGLELINE);
+        if (active)
+        {
+            HPEN glowPen = CreatePen(PS_SOLID, ScaleMetric(3), AccentColor);
+            SelectObject(drawItem.hDC, glowPen);
+            MoveToEx(drawItem.hDC, drawItem.rcItem.left + ScaleMetric(10), drawItem.rcItem.bottom - ScaleMetric(4), nullptr);
+            LineTo(drawItem.hDC, drawItem.rcItem.right - ScaleMetric(10), drawItem.rcItem.bottom - ScaleMetric(4));
+            DeleteObject(glowPen);
+        }
+    }
+
+    void StartupScreenController::DrawProjectListItem(const DRAWITEMSTRUCT& drawItem) const
+    {
+        if (drawItem.itemID == static_cast<UINT>(-1))
+        {
+            FillRect(drawItem.hDC, &drawItem.rcItem, m_panelBackgroundBrush);
+            return;
+        }
+
+        const bool selected = 0 != (drawItem.itemState & ODS_SELECTED);
+        HBRUSH rowBrush = CreateSolidBrush(selected ? RGB(34, 24, 80) : RGB(18, 18, 48));
+        RECT rowRect = drawItem.rcItem;
+        rowRect.left += ScaleMetric(8);
+        rowRect.right -= ScaleMetric(8);
+        rowRect.top += ScaleMetric(4);
+        rowRect.bottom -= ScaleMetric(4);
+        FillRect(drawItem.hDC, &drawItem.rcItem, m_panelBackgroundBrush);
+        SelectPenAndBrush(drawItem.hDC, selected ? m_accentPen : m_dimAccentPen, rowBrush);
+        RoundRect(drawItem.hDC, rowRect.left, rowRect.top, rowRect.right, rowRect.bottom, ScaleMetric(6), ScaleMetric(6));
+        DeleteObject(rowBrush);
+
+        wchar_t buffer[1024]{};
+        SendMessageW(drawItem.hwndItem, LB_GETTEXT, drawItem.itemID, reinterpret_cast<LPARAM>(buffer));
+        SetBkMode(drawItem.hDC, TRANSPARENT);
+        SetTextColor(drawItem.hDC, TextColor);
+        RECT textRect = rowRect;
+        textRect.left += ScaleMetric(18);
+        textRect.right -= ScaleMetric(18);
+        DrawTextW(drawItem.hDC, buffer, -1, &textRect, DT_LEFT | DT_VCENTER | DT_SINGLELINE | DT_END_ELLIPSIS);
+    }
+
+    LRESULT StartupScreenController::HandleParentWindowMessage(HWND window, UINT message, WPARAM wParam, LPARAM lParam)
+    {
+        if (false == m_hidden)
+        {
+            if (WM_ERASEBKGND == message)
+            {
+                return 1;
+            }
+
+            if (WM_PAINT == message)
+            {
+                PAINTSTRUCT paintStruct{};
+                HDC deviceContext = BeginPaint(window, &paintStruct);
+                PaintStartupBackground(deviceContext);
+                EndPaint(window, &paintStruct);
+                return 0;
+            }
+
+            if (WM_CTLCOLORSTATIC == message || WM_CTLCOLOREDIT == message || WM_CTLCOLORLISTBOX == message)
+            {
+                HDC deviceContext = reinterpret_cast<HDC>(wParam);
+                SetBkMode(deviceContext, TRANSPARENT);
+                SetTextColor(deviceContext, TextColor);
+                if (WM_CTLCOLOREDIT == message)
+                {
+                    SetBkColor(deviceContext, EditColor);
+                    return reinterpret_cast<LRESULT>(m_editBackgroundBrush);
+                }
+
+                if (WM_CTLCOLORLISTBOX == message)
+                {
+                    SetBkColor(deviceContext, PanelColor);
+                    return reinterpret_cast<LRESULT>(m_panelBackgroundBrush);
+                }
+
+                return reinterpret_cast<LRESULT>(m_darkBackgroundBrush);
+            }
+        }
+
+        return CallWindowProcW(m_originalParentWindowProc, window, message, wParam, lParam);
+    }
+
+    LRESULT StartupScreenController::HandleCreateProjectWindowMessage(HWND window, UINT message, WPARAM wParam, LPARAM lParam)
+    {
+        if (WM_CLOSE == message)
+        {
+            ShowWindow(window, SW_HIDE);
+            return 0;
+        }
+
+        if (WM_ERASEBKGND == message)
+        {
+            return 1;
+        }
+
+        if (WM_PAINT == message)
+        {
+            PAINTSTRUCT paintStruct{};
+            HDC deviceContext = BeginPaint(window, &paintStruct);
+            PaintCreateProjectBackground(deviceContext);
+            EndPaint(window, &paintStruct);
+            return 0;
+        }
+
+        if (WM_DRAWITEM == message)
+        {
+            return HandleDrawItem(lParam) ? TRUE : FALSE;
+        }
+
+        if (WM_CTLCOLORSTATIC == message || WM_CTLCOLOREDIT == message)
+        {
+            HDC deviceContext = reinterpret_cast<HDC>(wParam);
+            SetBkMode(deviceContext, TRANSPARENT);
+            SetTextColor(deviceContext, TextColor);
+            if (WM_CTLCOLOREDIT == message)
+            {
+                SetBkColor(deviceContext, EditColor);
+                return reinterpret_cast<LRESULT>(m_editBackgroundBrush);
+            }
+
+            return reinterpret_cast<LRESULT>(m_darkBackgroundBrush);
+        }
+
+        return DefWindowProcW(window, message, wParam, lParam);
+    }
+
+    bool StartupScreenController::HandleProjectListDoubleClick(
+        HWND listBox,
+        const std::vector<EditorProjectInfo>& projects,
+        POINT cursorPosition)
+    {
+        POINT listBoxPosition = cursorPosition;
+        ScreenToClient(listBox, &listBoxPosition);
+
+        const LPARAM positionParameter = MAKELPARAM(listBoxPosition.x, listBoxPosition.y);
+        const LRESULT itemResult = SendMessageW(listBox, LB_ITEMFROMPOINT, 0, positionParameter);
+        if (HIWORD(itemResult) != 0)
+        {
+            if (listBox == m_recentListBox)
+            {
+                m_lastRecentClickIndex = -1;
+            }
+            else
+            {
+                m_lastAllProjectsClickIndex = -1;
+            }
+            return false;
+        }
+
+        const int clickedIndex = LOWORD(itemResult);
+        DWORD& lastClickTime = listBox == m_recentListBox ? m_lastRecentClickTime : m_lastAllProjectsClickTime;
+        int& lastClickIndex = listBox == m_recentListBox ? m_lastRecentClickIndex : m_lastAllProjectsClickIndex;
+        const DWORD currentTime = GetTickCount();
+        const bool isDoubleClick =
+            clickedIndex == lastClickIndex
+            && currentTime - lastClickTime <= GetDoubleClickTime();
+
+        lastClickIndex = clickedIndex;
+        lastClickTime = currentTime;
+
+        if (false == isDoubleClick)
+        {
+            return false;
+        }
+
+        const auto projectIndex = static_cast<std::size_t>(clickedIndex);
+        if (projectIndex >= projects.size())
+        {
+            return false;
+        }
+
+        m_openProjectFilePath = projects[projectIndex].projectFilePath;
+        return true;
     }
 
     void StartupScreenController::ShowCreateProjectWindow()
@@ -418,8 +1161,8 @@ namespace Xelqoria::Editor
         RECT parentRect{};
         GetWindowRect(parentWindow, &parentRect);
 
-        const int width = ScaleMetric(560);
-        const int height = ScaleMetric(180);
+        const int width = ScaleMetric(640);
+        const int height = ScaleMetric(260);
         const int left = parentRect.left + ((parentRect.right - parentRect.left) - width) / 2;
         const int top = parentRect.top + ((parentRect.bottom - parentRect.top) - height) / 2;
 
@@ -449,50 +1192,22 @@ namespace Xelqoria::Editor
 
     void StartupScreenController::UpdateCreateProjectWindowLayout()
     {
-        MoveWindow(m_nameLabel, ScaleMetric(16), ScaleMetric(18), ScaleMetric(140), ScaleMetric(24), TRUE);
-        MoveWindow(m_projectNameEdit, ScaleMetric(156), ScaleMetric(14), ScaleMetric(360), ScaleMetric(28), TRUE);
-        MoveWindow(m_folderLabel, ScaleMetric(16), ScaleMetric(58), ScaleMetric(140), ScaleMetric(24), TRUE);
-        MoveWindow(m_projectFolderEdit, ScaleMetric(156), ScaleMetric(54), ScaleMetric(276), ScaleMetric(28), TRUE);
-        MoveWindow(m_browseFolderButton, ScaleMetric(444), ScaleMetric(54), ScaleMetric(72), ScaleMetric(28), TRUE);
-        MoveWindow(m_createConfirmButton, ScaleMetric(316), ScaleMetric(100), ScaleMetric(96), ScaleMetric(30), TRUE);
-        MoveWindow(m_createCancelButton, ScaleMetric(420), ScaleMetric(100), ScaleMetric(96), ScaleMetric(30), TRUE);
+        MoveWindow(m_nameLabel, ScaleMetric(32), ScaleMetric(48), ScaleMetric(150), ScaleMetric(28), TRUE);
+        MoveWindow(m_projectNameEdit, ScaleMetric(190), ScaleMetric(44), ScaleMetric(400), ScaleMetric(32), TRUE);
+        MoveWindow(m_folderLabel, ScaleMetric(32), ScaleMetric(98), ScaleMetric(150), ScaleMetric(28), TRUE);
+        MoveWindow(m_projectFolderEdit, ScaleMetric(190), ScaleMetric(94), ScaleMetric(286), ScaleMetric(32), TRUE);
+        MoveWindow(m_browseFolderButton, ScaleMetric(492), ScaleMetric(94), ScaleMetric(98), ScaleMetric(32), TRUE);
+        MoveWindow(m_createConfirmButton, ScaleMetric(356), ScaleMetric(160), ScaleMetric(112), ScaleMetric(36), TRUE);
+        MoveWindow(m_createCancelButton, ScaleMetric(478), ScaleMetric(160), ScaleMetric(112), ScaleMetric(36), TRUE);
+        if (nullptr != m_createProjectWindow)
+        {
+            InvalidateRect(m_createProjectWindow, nullptr, TRUE);
+        }
     }
 
     bool StartupScreenController::HandleRecentProjectDoubleClick(POINT cursorPosition)
     {
-        POINT listBoxPosition = cursorPosition;
-        ScreenToClient(m_recentListBox, &listBoxPosition);
-
-        const LPARAM positionParameter = MAKELPARAM(listBoxPosition.x, listBoxPosition.y);
-        const LRESULT itemResult = SendMessageW(m_recentListBox, LB_ITEMFROMPOINT, 0, positionParameter);
-        if (HIWORD(itemResult) != 0)
-        {
-            m_lastRecentClickIndex = -1;
-            return false;
-        }
-
-        const int clickedIndex = LOWORD(itemResult);
-        const DWORD currentTime = GetTickCount();
-        const bool isDoubleClick =
-            clickedIndex == m_lastRecentClickIndex
-            && currentTime - m_lastRecentClickTime <= GetDoubleClickTime();
-
-        m_lastRecentClickIndex = clickedIndex;
-        m_lastRecentClickTime = currentTime;
-
-        if (false == isDoubleClick)
-        {
-            return false;
-        }
-
-        const auto projectIndex = static_cast<std::size_t>(clickedIndex);
-        if (projectIndex >= m_recentProjects.size())
-        {
-            return false;
-        }
-
-        m_openProjectFilePath = m_recentProjects[projectIndex].projectFilePath;
-        return true;
+        return HandleProjectListDoubleClick(m_recentListBox, m_recentProjects, cursorPosition);
     }
 
     std::optional<EditorProjectInfo> StartupScreenController::GetSelectedRecentProject() const
@@ -510,6 +1225,23 @@ namespace Xelqoria::Editor
         }
 
         return m_recentProjects[index];
+    }
+
+    std::optional<EditorProjectInfo> StartupScreenController::GetSelectedAllProject() const
+    {
+        const LRESULT selectedIndex = SendMessageW(m_allProjectsListBox, LB_GETCURSEL, 0, 0);
+        if (selectedIndex == LB_ERR || selectedIndex < 0)
+        {
+            return std::nullopt;
+        }
+
+        const auto index = static_cast<std::size_t>(selectedIndex);
+        if (index >= m_allProjects.size())
+        {
+            return std::nullopt;
+        }
+
+        return m_allProjects[index];
     }
 
     HWND StartupScreenController::CreateChildWindow(
@@ -560,7 +1292,7 @@ namespace Xelqoria::Editor
         m_currentDpi = dpi;
 
         LOGFONTW fontDesc{};
-        fontDesc.lfHeight = -MulDiv(9, static_cast<int>(m_currentDpi), 72);
+        fontDesc.lfHeight = -MulDiv(11, static_cast<int>(m_currentDpi), 72);
         fontDesc.lfWeight = FW_NORMAL;
         wcscpy_s(fontDesc.lfFaceName, L"Segoe UI");
         m_defaultFont = CreateFontIndirectW(&fontDesc);
@@ -571,7 +1303,12 @@ namespace Xelqoria::Editor
             m_ownsDefaultFont = false;
         }
 
-        const std::array<HWND, 12> controls{
+        const std::array<HWND, 19> controls{
+            m_projectTabButton,
+            m_viewTabButton,
+            m_minimizeButton,
+            m_maximizeButton,
+            m_closeButton,
             m_nameLabel,
             m_projectNameEdit,
             m_folderLabel,
@@ -583,7 +1320,9 @@ namespace Xelqoria::Editor
             m_createButton,
             m_openButton,
             m_recentLabel,
-            m_recentListBox
+            m_recentListBox,
+            m_allProjectsLabel,
+            m_allProjectsListBox
         };
 
         for (HWND control : controls)

--- a/Editor/Source/StartupScreenController.cpp
+++ b/Editor/Source/StartupScreenController.cpp
@@ -26,9 +26,6 @@ namespace Xelqoria::Editor
         constexpr int CreateCancelButtonId = 4305;
         constexpr int ProjectTabButtonId = 4306;
         constexpr int ViewTabButtonId = 4307;
-        constexpr int MinimizeButtonId = 4308;
-        constexpr int MaximizeButtonId = 4309;
-        constexpr int CloseButtonId = 4310;
         constexpr int RecentProjectsListBoxId = 4311;
         constexpr int AllProjectsListBoxId = 4312;
         constexpr const wchar_t* CreateProjectWindowClassName = L"XelqoriaCreateProjectWindow";
@@ -196,9 +193,6 @@ namespace Xelqoria::Editor
 
         m_projectTabButton = CreateChildWindow(parentWindow, hInstance, L"Button", L"プロジェクト", WS_CHILD | WS_VISIBLE | BS_OWNERDRAW);
         m_viewTabButton = CreateChildWindow(parentWindow, hInstance, L"Button", L"表示", WS_CHILD | WS_VISIBLE | BS_OWNERDRAW);
-        m_minimizeButton = CreateChildWindow(parentWindow, hInstance, L"Button", L"ー", WS_CHILD | WS_VISIBLE | BS_OWNERDRAW);
-        m_maximizeButton = CreateChildWindow(parentWindow, hInstance, L"Button", L"□", WS_CHILD | WS_VISIBLE | BS_OWNERDRAW);
-        m_closeButton = CreateChildWindow(parentWindow, hInstance, L"Button", L"×", WS_CHILD | WS_VISIBLE | BS_OWNERDRAW);
         m_createButton = CreateChildWindow(parentWindow, hInstance, L"Button", L"プロジェクト作成", WS_CHILD | WS_VISIBLE | BS_OWNERDRAW);
         m_openButton = CreateChildWindow(parentWindow, hInstance, L"Button", L"プロジェクトを開く", WS_CHILD | WS_VISIBLE | BS_OWNERDRAW);
         m_recentLabel = CreateChildWindow(parentWindow, hInstance, L"Static", L"最近使ったプロジェクト一覧", WS_CHILD | WS_VISIBLE);
@@ -218,9 +212,6 @@ namespace Xelqoria::Editor
 
         if (nullptr == m_projectTabButton
             || nullptr == m_viewTabButton
-            || nullptr == m_minimizeButton
-            || nullptr == m_maximizeButton
-            || nullptr == m_closeButton
             || nullptr == m_createButton
             || nullptr == m_openButton
             || nullptr == m_recentLabel
@@ -278,9 +269,6 @@ namespace Xelqoria::Editor
 
         SetWindowLongPtrW(m_projectTabButton, GWLP_ID, ProjectTabButtonId);
         SetWindowLongPtrW(m_viewTabButton, GWLP_ID, ViewTabButtonId);
-        SetWindowLongPtrW(m_minimizeButton, GWLP_ID, MinimizeButtonId);
-        SetWindowLongPtrW(m_maximizeButton, GWLP_ID, MaximizeButtonId);
-        SetWindowLongPtrW(m_closeButton, GWLP_ID, CloseButtonId);
         SetWindowLongPtrW(m_createButton, GWLP_ID, CreateProjectButtonId);
         SetWindowLongPtrW(m_openButton, GWLP_ID, OpenProjectButtonId);
         SetWindowLongPtrW(m_recentListBox, GWLP_ID, RecentProjectsListBoxId);
@@ -305,12 +293,9 @@ namespace Xelqoria::Editor
         if (m_ownsDefaultFont && nullptr != m_defaultFont)
         {
             HFONT stockFont = static_cast<HFONT>(GetStockObject(DEFAULT_GUI_FONT));
-            const std::array<HWND, 19> controls{
+            const std::array<HWND, 16> controls{
                 m_projectTabButton,
                 m_viewTabButton,
-                m_minimizeButton,
-                m_maximizeButton,
-                m_closeButton,
                 m_nameLabel,
                 m_projectNameEdit,
                 m_folderLabel,
@@ -375,9 +360,6 @@ namespace Xelqoria::Editor
 
         MoveWindow(m_projectTabButton, ScaleMetric(16), headerHeight, ScaleMetric(130), tabHeight, TRUE);
         MoveWindow(m_viewTabButton, ScaleMetric(154), headerHeight, ScaleMetric(90), tabHeight, TRUE);
-        MoveWindow(m_minimizeButton, clientWidth - ScaleMetric(156), ScaleMetric(8), ScaleMetric(42), ScaleMetric(32), TRUE);
-        MoveWindow(m_maximizeButton, clientWidth - ScaleMetric(108), ScaleMetric(8), ScaleMetric(42), ScaleMetric(32), TRUE);
-        MoveWindow(m_closeButton, clientWidth - ScaleMetric(60), ScaleMetric(8), ScaleMetric(42), ScaleMetric(32), TRUE);
         MoveWindow(m_createButton, contentLeft, contentTop, actualCardWidth, cardHeight, TRUE);
         MoveWindow(m_openButton, secondCardLeft, secondCardTop, actualCardWidth, cardHeight, TRUE);
         MoveWindow(m_recentLabel, contentLeft + ScaleMetric(20), listTop - ScaleMetric(38), contentWidth, ScaleMetric(28), TRUE);
@@ -408,9 +390,6 @@ namespace Xelqoria::Editor
         case BrowseFolderButtonId:
         case CreateConfirmButtonId:
         case CreateCancelButtonId:
-        case MinimizeButtonId:
-        case MaximizeButtonId:
-        case CloseButtonId:
             DrawThemedButton(*drawItem);
             return true;
         case ProjectTabButtonId:
@@ -456,25 +435,6 @@ namespace Xelqoria::Editor
         {
             RefreshAllProjects();
             SetActiveTab(StartupTab::View);
-            return;
-        }
-
-        if (clickedWindow == m_minimizeButton)
-        {
-            ShowWindow(m_parentWindow, SW_MINIMIZE);
-            return;
-        }
-
-        if (clickedWindow == m_maximizeButton)
-        {
-            const bool isMaximized = IsZoomed(m_parentWindow);
-            ShowWindow(m_parentWindow, isMaximized ? SW_RESTORE : SW_MAXIMIZE);
-            return;
-        }
-
-        if (clickedWindow == m_closeButton)
-        {
-            PostMessageW(m_parentWindow, WM_CLOSE, 0, 0);
             return;
         }
 
@@ -564,12 +524,9 @@ namespace Xelqoria::Editor
     void StartupScreenController::Hide()
     {
         m_hidden = true;
-        std::array<HWND, 11> controls{
+        std::array<HWND, 8> controls{
             m_projectTabButton,
             m_viewTabButton,
-            m_minimizeButton,
-            m_maximizeButton,
-            m_closeButton,
             m_createButton,
             m_openButton,
             m_recentLabel,
@@ -594,12 +551,9 @@ namespace Xelqoria::Editor
     {
         HWND parentWindow = m_parentWindow;
 
-        std::array<HWND*, 11> startupControls{
+        std::array<HWND*, 8> startupControls{
             &m_projectTabButton,
             &m_viewTabButton,
-            &m_minimizeButton,
-            &m_maximizeButton,
-            &m_closeButton,
             &m_createButton,
             &m_openButton,
             &m_recentLabel,
@@ -843,15 +797,6 @@ namespace Xelqoria::Editor
 
         SetBkMode(deviceContext, TRANSPARENT);
         SetTextColor(deviceContext, TextColor);
-        RECT logoRect{ ScaleMetric(12), ScaleMetric(8), ScaleMetric(38), ScaleMetric(38) };
-        SelectObject(deviceContext, m_accentPen);
-        MoveToEx(deviceContext, logoRect.left, logoRect.top, nullptr);
-        LineTo(deviceContext, logoRect.right, logoRect.bottom);
-        MoveToEx(deviceContext, logoRect.right, logoRect.top, nullptr);
-        LineTo(deviceContext, logoRect.left, logoRect.bottom);
-
-        RECT titleRect{ ScaleMetric(52), ScaleMetric(10), ScaleMetric(360), ScaleMetric(42) };
-        DrawTextW(deviceContext, L"Xelqoria Editor", -1, &titleRect, DT_LEFT | DT_VCENTER | DT_SINGLELINE);
 
         SelectObject(deviceContext, m_blueAccentPen);
         const int baseX = clientRect.right - ScaleMetric(210);
@@ -859,16 +804,16 @@ namespace Xelqoria::Editor
         for (int index = 0; index < 6; ++index)
         {
             const int offset = ScaleMetric(index * 22);
-            POINT points[6]{
+            POINT points[7]{
                 { baseX + offset, baseY - ScaleMetric(40) - offset / 2 },
                 { baseX + ScaleMetric(58) + offset, baseY - ScaleMetric(12) - offset / 2 },
                 { baseX + ScaleMetric(58) + offset, baseY + ScaleMetric(48) - offset / 2 },
                 { baseX + offset, baseY + ScaleMetric(78) - offset / 2 },
                 { baseX - ScaleMetric(58) + offset, baseY + ScaleMetric(48) - offset / 2 },
-                { baseX - ScaleMetric(58) + offset, baseY - ScaleMetric(12) - offset / 2 }
+                { baseX - ScaleMetric(58) + offset, baseY - ScaleMetric(12) - offset / 2 },
+                { baseX + offset, baseY - ScaleMetric(40) - offset / 2 }
             };
-            Polyline(deviceContext, points, 6);
-            LineTo(deviceContext, points[0].x, points[0].y);
+            Polyline(deviceContext, points, 7);
         }
     }
 
@@ -1303,12 +1248,9 @@ namespace Xelqoria::Editor
             m_ownsDefaultFont = false;
         }
 
-        const std::array<HWND, 19> controls{
+        const std::array<HWND, 16> controls{
             m_projectTabButton,
             m_viewTabButton,
-            m_minimizeButton,
-            m_maximizeButton,
-            m_closeButton,
             m_nameLabel,
             m_projectNameEdit,
             m_folderLabel,

--- a/Editor/Source/StartupScreenController.h
+++ b/Editor/Source/StartupScreenController.h
@@ -278,9 +278,6 @@ namespace Xelqoria::Editor
         HPEN m_blueAccentPen = nullptr;
         HWND m_projectTabButton = nullptr;
         HWND m_viewTabButton = nullptr;
-        HWND m_minimizeButton = nullptr;
-        HWND m_maximizeButton = nullptr;
-        HWND m_closeButton = nullptr;
         HWND m_nameLabel = nullptr;
         HWND m_projectNameEdit = nullptr;
         HWND m_folderLabel = nullptr;

--- a/Editor/Source/StartupScreenController.h
+++ b/Editor/Source/StartupScreenController.h
@@ -38,6 +38,13 @@ namespace Xelqoria::Editor
         void UpdateLayout(HWND parentWindow);
 
         /// <summary>
+        /// 起動画面に属する owner draw コントロールを描画する。
+        /// </summary>
+        /// <param name="drawItemParameter">WM_DRAWITEM の LPARAM。</param>
+        /// <returns>描画を処理した場合は true。</returns>
+        bool HandleDrawItem(LPARAM drawItemParameter);
+
+        /// <summary>
         /// 入力状態を更新し、プロジェクト操作要求を検出する。
         /// </summary>
         /// <param name="inputSnapshot">現在フレームの入力状態。</param>
@@ -47,6 +54,16 @@ namespace Xelqoria::Editor
         /// 起動画面を非表示にする。
         /// </summary>
         void Hide();
+
+        /// <summary>
+        /// 起動画面の親ウィンドウメッセージを処理する。
+        /// </summary>
+        LRESULT HandleParentWindowMessage(HWND window, UINT message, WPARAM wParam, LPARAM lParam);
+
+        /// <summary>
+        /// プロジェクト作成ダイアログのメッセージを処理する。
+        /// </summary>
+        LRESULT HandleCreateProjectWindowMessage(HWND window, UINT message, WPARAM wParam, LPARAM lParam);
 
         /// <summary>
         /// 起動画面のウィンドウ群を破棄する。
@@ -89,10 +106,91 @@ namespace Xelqoria::Editor
         void ClearRequests();
 
     private:
+        enum class StartupTab
+        {
+            Projects,
+            View
+        };
+
         /// <summary>
         /// 最近使ったプロジェクト一覧を再表示する。
         /// </summary>
         void RefreshRecentProjects();
+
+        /// <summary>
+        /// 表示タブのプロジェクト一覧を再表示する。
+        /// </summary>
+        void RefreshAllProjects();
+
+        /// <summary>
+        /// 起動画面の現在タブを変更する。
+        /// </summary>
+        /// <param name="tab">変更後のタブ。</param>
+        void SetActiveTab(StartupTab tab);
+
+        /// <summary>
+        /// 起動画面用のブラシなどの GDI リソースを作成する。
+        /// </summary>
+        void EnsureThemeResources();
+
+        /// <summary>
+        /// 起動画面用の GDI リソースを破棄する。
+        /// </summary>
+        void DestroyThemeResources();
+
+        /// <summary>
+        /// 起動画面の親ウィンドウをサブクラス化する。
+        /// </summary>
+        /// <param name="parentWindow">サブクラス化する親ウィンドウ。</param>
+        void SubclassParentWindow(HWND parentWindow);
+
+        /// <summary>
+        /// 起動画面の親ウィンドウのサブクラス化を解除する。
+        /// </summary>
+        void UnsubclassParentWindow();
+
+        /// <summary>
+        /// 起動画面の背景を描画する。
+        /// </summary>
+        /// <param name="deviceContext">描画先。</param>
+        void PaintStartupBackground(HDC deviceContext);
+
+        /// <summary>
+        /// プロジェクト作成ダイアログの背景を描画する。
+        /// </summary>
+        /// <param name="deviceContext">描画先。</param>
+        void PaintCreateProjectBackground(HDC deviceContext);
+
+        /// <summary>
+        /// テーマ適用済みボタンを描画する。
+        /// </summary>
+        /// <param name="drawItem">owner draw 情報。</param>
+        void DrawThemedButton(const DRAWITEMSTRUCT& drawItem) const;
+
+        /// <summary>
+        /// テーマ適用済みタブを描画する。
+        /// </summary>
+        /// <param name="drawItem">owner draw 情報。</param>
+        /// <param name="tab">描画対象タブ。</param>
+        void DrawTabButton(const DRAWITEMSTRUCT& drawItem, StartupTab tab) const;
+
+        /// <summary>
+        /// テーマ適用済みリスト行を描画する。
+        /// </summary>
+        /// <param name="drawItem">owner draw 情報。</param>
+        void DrawProjectListItem(const DRAWITEMSTRUCT& drawItem) const;
+
+        /// <summary>
+        /// プロジェクト一覧行に対応するプロジェクトを開く要求として設定する。
+        /// </summary>
+        /// <param name="listBox">対象 ListBox。</param>
+        /// <param name="projects">ListBox に対応するプロジェクト一覧。</param>
+        /// <param name="cursorPosition">スクリーン座標のカーソル位置。</param>
+        /// <returns>要求を設定した場合は true。</returns>
+        bool HandleProjectListDoubleClick(
+            HWND listBox,
+            const std::vector<EditorProjectInfo>& projects,
+            POINT cursorPosition);
 
         /// <summary>
         /// プロジェクト作成ウィンドウを表示する。
@@ -143,6 +241,12 @@ namespace Xelqoria::Editor
         [[nodiscard]] std::optional<EditorProjectInfo> GetSelectedRecentProject() const;
 
         /// <summary>
+        /// 表示タブ ListBox の選択行に対応するプロジェクトを取得する。
+        /// </summary>
+        /// <returns>選択中プロジェクト。未選択時は空。</returns>
+        [[nodiscard]] std::optional<EditorProjectInfo> GetSelectedAllProject() const;
+
+        /// <summary>
         /// 子ウィンドウを生成する。
         /// </summary>
         HWND CreateChildWindow(
@@ -162,6 +266,21 @@ namespace Xelqoria::Editor
         HFONT m_defaultFont = nullptr;
         UINT m_currentDpi = 96;
         bool m_ownsDefaultFont = false;
+        bool m_hidden = false;
+        StartupTab m_activeTab = StartupTab::Projects;
+        HWND m_parentWindow = nullptr;
+        WNDPROC m_originalParentWindowProc = nullptr;
+        HBRUSH m_darkBackgroundBrush = nullptr;
+        HBRUSH m_panelBackgroundBrush = nullptr;
+        HBRUSH m_editBackgroundBrush = nullptr;
+        HPEN m_accentPen = nullptr;
+        HPEN m_dimAccentPen = nullptr;
+        HPEN m_blueAccentPen = nullptr;
+        HWND m_projectTabButton = nullptr;
+        HWND m_viewTabButton = nullptr;
+        HWND m_minimizeButton = nullptr;
+        HWND m_maximizeButton = nullptr;
+        HWND m_closeButton = nullptr;
         HWND m_nameLabel = nullptr;
         HWND m_projectNameEdit = nullptr;
         HWND m_folderLabel = nullptr;
@@ -174,13 +293,18 @@ namespace Xelqoria::Editor
         HWND m_openButton = nullptr;
         HWND m_recentLabel = nullptr;
         HWND m_recentListBox = nullptr;
+        HWND m_allProjectsLabel = nullptr;
+        HWND m_allProjectsListBox = nullptr;
         RecentProjectsStore m_recentProjectsStore{};
         Platform::IFileDialog* m_fileDialog = nullptr;
         std::vector<EditorProjectInfo> m_recentProjects{};
+        std::vector<EditorProjectInfo> m_allProjects{};
         bool m_createRequested = false;
         bool m_wasLeftMouseDown = false;
         DWORD m_lastRecentClickTime = 0;
         int m_lastRecentClickIndex = -1;
+        DWORD m_lastAllProjectsClickTime = 0;
+        int m_lastAllProjectsClickIndex = -1;
         bool m_layoutInitialized = false;
         int m_lastLayoutClientWidth = 0;
         int m_lastLayoutClientHeight = 0;

--- a/docs/plans/issue-287-startup-screen-redesign.md
+++ b/docs/plans/issue-287-startup-screen-redesign.md
@@ -1,0 +1,62 @@
+# ExecPlan: issue-287 Xelqoria Editor startup screen redesign
+
+## 目的
+
+Editor 起動直後の初期画面とプロジェクト作成ダイアログを、既存の Win32 UI 実装を保ったままダークテーマ、紫/青アクセント、幾何学風装飾の見た目へ刷新する。
+
+## 対象範囲
+
+- 変更対象プロジェクト: `Editor`
+- 変更対象ファイル:
+  - `Editor/Source/StartupScreenController.h`
+  - `Editor/Source/StartupScreenController.cpp`
+  - `Editor/Source/Application.cpp`
+- 変更対象クラス:
+  - `StartupScreenController`
+  - `Application`
+- 影響する機能:
+  - 起動画面
+  - プロジェクト作成ダイアログ
+  - 最近使ったプロジェクト一覧
+  - 起動画面の表示タブ
+
+## 前提
+
+- parent issue: なし
+- ブランチ運用ルール: `branch-rules.md`
+- この issue のブランチ: `issue-287`
+- PR の向き: `issue-287` -> `master`
+- Issue に記載された `assets/...` パスは固定パスとして扱わず、添付された PNG を見た目の参照として扱う。
+
+## 実装方針
+
+Editor の OS ネイティブ UI シェル内に閉じて、Game / Graphics / RHI / Backends へ依存を追加しない。
+
+StartupScreenController が起動画面専用のサブクラス化、描画、状態、入力処理を担当する。見た目は GDI ベースの背景塗り、枠線、テキスト、簡易アイコンで表現し、標準 Button / ListBox / Edit を owner draw / color hook / layout 調整で拡張する。表示タブは新規永続ストアを追加せず、`RecentProjectsStore` から読み込める既存 `.proj` を `EditorProject::Open` で検証し、ファイル時刻の降順で表示する。
+
+## 作業手順
+
+1. 関連コードとメッセージ経路を確認する。
+2. StartupScreenController にタブ、タイトル領域、カスタム描画、表示タブ用一覧を追加する。
+3. プロジェクト作成ダイアログを同じテーマに合わせる。
+4. 起動画面中はネイティブメニューバーを非表示にし、Editor 遷移時に復元する。
+5. ビルドまたは関連テストを実行する。
+6. `branch-rules.md` に従って PR を作成する。
+
+## 検証方法
+
+- 実行するビルド: `msbuild Xelqoria.sln /t:Xelqoria.Editor /p:Configuration=Debug /p:Platform=x64`
+- 実行するテスト: `msbuild tests/Editor/Xelqoria.Tests.Editor.vcxproj /p:Configuration=Debug /p:Platform=x64`
+- 手動確認項目:
+  - 起動時にプロジェクトタブが選択される。
+  - プロジェクト作成、プロジェクトを開く、最近使った一覧、表示タブが操作できる。
+  - ダイアログの作成、参照、キャンセルが既存どおり動く。
+  - ウィンドウリサイズで主要要素が崩れない。
+
+## 完了条件
+
+- Issue の受け入れ条件に対応している。
+- Editor 層内の変更に閉じている。
+- ビルドまたは関連テストの結果を報告できる。
+- 不要な変更が含まれていない。
+- PR が作成されている。


### PR DESCRIPTION
## 概要
- 起動画面をダークテーマ、紫/青アクセント、カード型ボタン、タブ構成へ刷新
- プロジェクト作成ダイアログを同テーマへ更新
- `表示` タブに `RecentProjectsStore` 由来の検証済みプロジェクトを日付降順で表示
- 起動画面中はネイティブメニューバーを隠し、Editor 遷移時に復元

## 検証
- `MSBuild.exe Editor\Xelqoria.Editor.vcxproj /p:Configuration=Debug /p:Platform=x64 /m`
- `MSBuild.exe tests\Editor\Xelqoria.Tests.Editor.vcxproj /p:Configuration=Debug /p:Platform=x64 /m`
- `artifacts\x64\Debug\Xelqoria.Tests.Editor.exe`。68 tests passed

Closes #287