### PR TITLE
Game 層に Collider2DComponent と AABB 変換を追加する

### DIFF
--- a/Editor/Source/SceneEditingOperations.cpp
+++ b/Editor/Source/SceneEditingOperations.cpp
@@ -5,6 +5,7 @@
 #include <optional>
 #include <string>
 #include <string_view>
+#include <Collider2DComponent.h>
 #include <Entity.h>
 #include <Scene.h>
 #include <SpriteComponent.h>
@@ -84,6 +85,11 @@ namespace Xelqoria::Editor
             /// Entity の SpriteComponent を保持する。
             /// </summary>
             std::optional<Game::SpriteComponent> spriteComponent{};
+
+            /// <summary>
+            /// Entity の Collider2DComponent を保持する。
+            /// </summary>
+            std::optional<Game::Collider2DComponent> collider2DComponent{};
         };
 
         /// <summary>
@@ -102,6 +108,11 @@ namespace Xelqoria::Editor
                 snapshot.spriteComponent = spriteComponent->get();
             }
 
+            if (const auto collider2DComponent = source.GetCollider2DComponent(); collider2DComponent.has_value())
+            {
+                snapshot.collider2DComponent = collider2DComponent->get();
+            }
+
             return snapshot;
         }
 
@@ -118,10 +129,19 @@ namespace Xelqoria::Editor
             if (snapshot.spriteComponent.has_value())
             {
                 destination.SetSpriteComponent(*snapshot.spriteComponent);
+            }
+            else
+            {
+                destination.RemoveSpriteComponent();
+            }
+
+            if (snapshot.collider2DComponent.has_value())
+            {
+                destination.SetCollider2DComponent(*snapshot.collider2DComponent);
                 return;
             }
 
-            destination.RemoveSpriteComponent();
+            destination.RemoveCollider2DComponent();
         }
     }
 
@@ -334,6 +354,28 @@ namespace Xelqoria::Editor
         }
 
         entity.RemoveSpriteComponent();
+        return true;
+    }
+
+    bool SceneEditingOperations::AddCollider2DComponent(Game::Entity& entity)
+    {
+        if (entity.HasCollider2DComponent())
+        {
+            return false;
+        }
+
+        entity.SetCollider2DComponent(Game::Collider2DComponent{});
+        return true;
+    }
+
+    bool SceneEditingOperations::RemoveCollider2DComponent(Game::Entity& entity)
+    {
+        if (false == entity.HasCollider2DComponent())
+        {
+            return false;
+        }
+
+        entity.RemoveCollider2DComponent();
         return true;
     }
 }

--- a/Editor/Source/SceneEditingOperations.h
+++ b/Editor/Source/SceneEditingOperations.h
@@ -136,5 +136,19 @@ namespace Xelqoria::Editor
         /// <param name="entity">削除対象の Entity。</param>
         /// <returns>削除で変更が発生した場合は true。</returns>
         static bool RemoveSpriteComponent(Game::Entity& entity);
+
+        /// <summary>
+        /// Entity に既定の Collider2DComponent を追加する。
+        /// </summary>
+        /// <param name="entity">追加対象の Entity。</param>
+        /// <returns>追加で変更が発生した場合は true。</returns>
+        static bool AddCollider2DComponent(Game::Entity& entity);
+
+        /// <summary>
+        /// Entity から Collider2DComponent を削除する。
+        /// </summary>
+        /// <param name="entity">削除対象の Entity。</param>
+        /// <returns>削除で変更が発生した場合は true。</returns>
+        static bool RemoveCollider2DComponent(Game::Entity& entity);
     };
 }

--- a/Game/Source/Collider2DComponent.cpp
+++ b/Game/Source/Collider2DComponent.cpp
@@ -1,0 +1,28 @@
+#include "Collider2DComponent.h"
+
+#include <cmath>
+
+#include "Physics2D.h"
+#include "Transform.h"
+
+namespace Xelqoria::Game
+{
+	AabbCollider2D BuildAabbCollider2D(
+		const Transform& transform,
+		const Collider2DComponent& collider)
+	{
+		const float scaleX = transform.scale.x;
+		const float scaleY = transform.scale.y;
+
+		AabbCollider2D result{};
+		result.center = {
+			transform.position.x + (collider.offset.x * scaleX),
+			transform.position.y + (collider.offset.y * scaleY)
+		};
+		result.halfSize = {
+			(std::fabs(collider.size.x * scaleX)) * 0.5f,
+			(std::fabs(collider.size.y * scaleY)) * 0.5f
+		};
+		return result;
+	}
+}

--- a/Game/Source/Collider2DComponent.h
+++ b/Game/Source/Collider2DComponent.h
@@ -1,0 +1,61 @@
+#pragma once
+
+#include "Vector2.h"
+
+namespace Xelqoria::Game
+{
+	struct AabbCollider2D;
+	struct Transform;
+
+	/// <summary>
+	/// Collider2DComponent が表す 2D 形状種別。
+	/// </summary>
+	enum class Collider2DShapeType
+	{
+		/// <summary>
+		/// 軸平行矩形として扱う Box Collider。
+		/// </summary>
+		Box
+	};
+
+	/// <summary>
+	/// Entity に付与する 2D 当たり判定情報。
+	/// </summary>
+	struct Collider2DComponent
+	{
+		/// <summary>
+		/// Collider が有効かを表す。
+		/// </summary>
+		bool enabled = true;
+
+		/// <summary>
+		/// Trigger として扱うかを表す。
+		/// </summary>
+		bool isTrigger = false;
+
+		/// <summary>
+		/// Collider の形状種別。
+		/// </summary>
+		Collider2DShapeType shapeType = Collider2DShapeType::Box;
+
+		/// <summary>
+		/// Transform 位置からの 2D オフセット。
+		/// </summary>
+		Xelqoria::Math::Vector2 offset{};
+
+		/// <summary>
+		/// Collider の幅と高さ。
+		/// </summary>
+		Xelqoria::Math::Vector2 size{ 1.0f, 1.0f };
+	};
+
+	/// <summary>
+	/// Transform と Collider2DComponent から AABB Collider を生成する。
+	/// </summary>
+	/// <param name="transform">Entity の Transform。</param>
+	/// <param name="collider">AABB に変換する Collider2DComponent。</param>
+	/// <returns>Physics2D で扱う AABB Collider。</returns>
+	[[nodiscard]] AabbCollider2D BuildAabbCollider2D(
+		const Transform& transform,
+		const Collider2DComponent& collider);
+}

--- a/Game/Source/Entity.cpp
+++ b/Game/Source/Entity.cpp
@@ -4,6 +4,7 @@
 #include <string>
 #include <utility>
 
+#include "Collider2DComponent.h"
 #include "SpriteComponent.h"
 
 namespace Xelqoria::Game
@@ -120,5 +121,43 @@ namespace Xelqoria::Game
 	void Entity::RemoveSpriteComponent()
 	{
 		m_spriteComponent.reset();
+	}
+
+	void Entity::SetCollider2DComponent(const Collider2DComponent& collider2DComponent)
+	{
+		m_collider2DComponent = collider2DComponent;
+	}
+
+	void Entity::SetCollider2DComponent(Collider2DComponent&& collider2DComponent)
+	{
+		m_collider2DComponent = std::move(collider2DComponent);
+	}
+
+	std::optional<std::reference_wrapper<Collider2DComponent>> Entity::GetCollider2DComponent()
+	{
+		if (false == m_collider2DComponent.has_value()) {
+			return std::nullopt;
+		}
+
+		return *m_collider2DComponent;
+	}
+
+	std::optional<std::reference_wrapper<const Collider2DComponent>> Entity::GetCollider2DComponent() const
+	{
+		if (false == m_collider2DComponent.has_value()) {
+			return std::nullopt;
+		}
+
+		return *m_collider2DComponent;
+	}
+
+	bool Entity::HasCollider2DComponent() const
+	{
+		return m_collider2DComponent.has_value();
+	}
+
+	void Entity::RemoveCollider2DComponent()
+	{
+		m_collider2DComponent.reset();
 	}
 }

--- a/Game/Source/Entity.h
+++ b/Game/Source/Entity.h
@@ -5,6 +5,7 @@
 #include <optional>
 #include <string>
 
+#include "Collider2DComponent.h"
 #include "SpriteComponent.h"
 #include "Transform.h"
 
@@ -152,10 +153,46 @@ namespace Xelqoria::Game
 		/// </summary>
 		void RemoveSpriteComponent();
 
+		/// <summary>
+		/// Collider2DComponent を Entity に設定する。
+		/// </summary>
+		/// <param name="collider2DComponent">設定する Collider2DComponent。</param>
+		void SetCollider2DComponent(const Collider2DComponent& collider2DComponent);
+
+		/// <summary>
+		/// Collider2DComponent を Entity に設定する。
+		/// </summary>
+		/// <param name="collider2DComponent">設定する Collider2DComponent。</param>
+		void SetCollider2DComponent(Collider2DComponent&& collider2DComponent);
+
+		/// <summary>
+		/// Entity に設定されている Collider2DComponent を取得する。
+		/// </summary>
+		/// <returns>Collider2DComponent。未設定の場合は空。</returns>
+		std::optional<std::reference_wrapper<Collider2DComponent>> GetCollider2DComponent();
+
+		/// <summary>
+		/// Entity に設定されている Collider2DComponent を取得する。
+		/// </summary>
+		/// <returns>読み取り専用の Collider2DComponent。未設定時は空。</returns>
+		std::optional<std::reference_wrapper<const Collider2DComponent>> GetCollider2DComponent() const;
+
+		/// <summary>
+		/// Entity に Collider2DComponent が設定されているかを取得する。
+		/// </summary>
+		/// <returns>設定済みの場合は true。</returns>
+		bool HasCollider2DComponent() const;
+
+		/// <summary>
+		/// Entity から Collider2DComponent を取り外す。
+		/// </summary>
+		void RemoveCollider2DComponent();
+
 	private:
 		EntityId m_id = 0;
 		std::string m_name{};
 		Transform m_transform{};
 		std::optional<SpriteComponent> m_spriteComponent{};
+		std::optional<Collider2DComponent> m_collider2DComponent{};
 	};
 }

--- a/Game/Xelqoria.Game.vcxproj
+++ b/Game/Xelqoria.Game.vcxproj
@@ -30,6 +30,7 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
+    <ClCompile Include="Source\Collider2DComponent.cpp" />
     <ClCompile Include="Source\Assets\SpriteAssetRegistry.cpp" />
     <ClCompile Include="Source\Assets\SpriteAssetLoader.cpp" />
     <ClCompile Include="Source\Assets\SpriteMaterialAssetLoader.cpp" />
@@ -43,6 +44,7 @@
     <ClCompile Include="Source\Transform.cpp" />
   </ItemGroup>
   <ItemGroup>
+    <ClInclude Include="Source\Collider2DComponent.h" />
     <ClInclude Include="Source\Assets\ISpriteAssetResolver.h" />
     <ClInclude Include="Source\Assets\IMaterialAssetResolver.h" />
     <ClInclude Include="Source\Assets\SpriteAsset.h" />

--- a/Game/Xelqoria.Game.vcxproj.filters
+++ b/Game/Xelqoria.Game.vcxproj.filters
@@ -11,6 +11,9 @@
     </Filter>
   </ItemGroup>
   <ItemGroup>
+    <ClCompile Include="Source\Collider2DComponent.cpp">
+      <Filter>Source</Filter>
+    </ClCompile>
     <ClCompile Include="Source\Assets\SpriteAssetRegistry.cpp">
       <Filter>Source\Assets</Filter>
     </ClCompile>
@@ -46,6 +49,9 @@
     </ClCompile>
   </ItemGroup>
   <ItemGroup>
+    <ClInclude Include="Source\Collider2DComponent.h">
+      <Filter>Source</Filter>
+    </ClInclude>
     <ClInclude Include="Source\Assets\ISpriteAssetResolver.h">
       <Filter>Source\Assets</Filter>
     </ClInclude>

--- a/docs/plans/issue-290-collider2d-game.md
+++ b/docs/plans/issue-290-collider2d-game.md
@@ -1,0 +1,54 @@
+# ExecPlan: issue-290 Game 層に Collider2DComponent と AABB 変換を追加する
+
+## 目的
+
+Entity に 2D Collider 情報を保持する Game 層の最小構成を追加し、既存 Physics2D の `AabbCollider2D` へ変換できるようにする。
+
+## 対象範囲
+
+- 変更対象プロジェクト: `Game`, `Editor`, `tests/Game`, `tests/Editor`
+- 変更対象ファイル: `Game/Source/Collider2DComponent.*`, `Game/Source/Entity.*`, `Editor/Source/SceneEditingOperations.*`
+- 変更対象クラス: `Entity`, `SceneEditingOperations`
+- 影響する機能: Entity の Component 保持、Entity 複製、Scene 編集操作、AABB 変換
+
+## 前提
+
+- parent issue: issue-289
+- ブランチ運用ルール: `docs/agents/branch-rules.md`
+- parent issue ブランチ: `issue-289`
+- この child issue のブランチ: `issue-290`
+- PR の向き: `issue-289`
+
+## 実装方針
+
+Collider2DComponent は Game 層の Component として追加し、Graphics / RHI / Backends には依存させない。
+
+初期形状は `Box` のみにし、Transform の position / scale と Collider の offset / size から Physics2D の `AabbCollider2D` を生成する。`rotation.z` は AABB 変換に反映しない。
+
+## 作業手順
+
+1. `Collider2DShapeType` と `Collider2DComponent` を追加する
+2. `BuildAabbCollider2D` を追加する
+3. `Entity` に Collider2DComponent の保持、取得、有無判定、削除 API を追加する
+4. `SceneEditingOperations` に追加・削除 API と複製時コピーを追加する
+5. Game / Editor の関連テストを追加する
+6. レイヤー依存チェック、Game / Editor テストのビルドと実行を行う
+
+## 検証方法
+
+- `dotnet run --project tools/LayerDependencyChecker/LayerDependencyChecker.csproj -c Debug -- "D:\github\Xelqoria"`
+- `MSBuild.exe tests\Game\Xelqoria.Tests.Game.vcxproj /m /p:Configuration=Debug /p:Platform=x64 /v:minimal`
+- `MSBuild.exe tests\Editor\Xelqoria.Tests.Editor.vcxproj /m /p:Configuration=Debug /p:Platform=x64 /v:minimal`
+- `artifacts\x64\Debug\Xelqoria.Tests.Game.exe`
+- `artifacts\x64\Debug\Xelqoria.Tests.Editor.exe`
+
+## 完了条件
+
+- Entity に Collider2DComponent を追加、取得、有無判定、削除できる
+- SceneEditingOperations の追加・削除 API が変更有無を返す
+- Entity 複製時に Collider2DComponent がコピーされる
+- Transform と Collider2DComponent から AABB を生成できる
+- 負の scale は halfSize に絶対値として反映され、rotation.z は影響しない
+- レイヤー責務に違反していない
+- 関連テストが通る
+- `issue-290` から `issue-289` への PR が作成されている

--- a/tests/Editor/Source/SceneEditingOperationsTests.cpp
+++ b/tests/Editor/Source/SceneEditingOperationsTests.cpp
@@ -2,6 +2,7 @@
 
 #include <string>
 
+#include "Collider2DComponent.h"
 #include "SceneEditingOperations.h"
 #include "SceneSerializer.h"
 
@@ -259,4 +260,56 @@ TEST(SceneEditingOperationsTests, RemoveSpriteComponentDetachesComponentAndSurvi
     const auto loadedEntity = loadResult.scene->FindEntity(entity.GetId());
     ASSERT_TRUE(loadedEntity.has_value());
     EXPECT_FALSE(loadedEntity->get().HasSpriteComponent());
+}
+
+TEST(SceneEditingOperationsTests, AddAndRemoveCollider2DComponentReturnWhetherChanged)
+{
+    Xelqoria::Game::Scene scene;
+    auto& entity = scene.CreateEntity();
+
+    EXPECT_TRUE(Xelqoria::Editor::SceneEditingOperations::AddCollider2DComponent(entity));
+    EXPECT_TRUE(entity.HasCollider2DComponent());
+    EXPECT_FALSE(Xelqoria::Editor::SceneEditingOperations::AddCollider2DComponent(entity));
+
+    const auto collider = entity.GetCollider2DComponent();
+    ASSERT_TRUE(collider.has_value());
+    EXPECT_TRUE(collider->get().enabled);
+    EXPECT_FALSE(collider->get().isTrigger);
+    EXPECT_EQ(Xelqoria::Game::Collider2DShapeType::Box, collider->get().shapeType);
+
+    EXPECT_TRUE(Xelqoria::Editor::SceneEditingOperations::RemoveCollider2DComponent(entity));
+    EXPECT_FALSE(entity.HasCollider2DComponent());
+    EXPECT_FALSE(Xelqoria::Editor::SceneEditingOperations::RemoveCollider2DComponent(entity));
+}
+
+TEST(SceneEditingOperationsTests, DuplicateSelectedEntityCopiesCollider2DComponent)
+{
+    Xelqoria::Game::Scene scene;
+    auto& sourceEntity = scene.CreateEntity();
+    sourceEntity.SetName("Collider");
+    sourceEntity.SetCollider2DComponent(Xelqoria::Game::Collider2DComponent{
+        false,
+        true,
+        Xelqoria::Game::Collider2DShapeType::Box,
+        { 3.0f, -4.0f },
+        { 5.0f, 6.0f }
+    });
+
+    const auto result =
+        Xelqoria::Editor::SceneEditingOperations::DuplicateSelectedEntity(scene, sourceEntity.GetId());
+
+    ASSERT_TRUE(result.changed);
+    ASSERT_TRUE(result.selectedEntityId.has_value());
+    const auto duplicateEntity = scene.FindEntity(*result.selectedEntityId);
+    ASSERT_TRUE(duplicateEntity.has_value());
+
+    const auto duplicateCollider = duplicateEntity->get().GetCollider2DComponent();
+    ASSERT_TRUE(duplicateCollider.has_value());
+    EXPECT_FALSE(duplicateCollider->get().enabled);
+    EXPECT_TRUE(duplicateCollider->get().isTrigger);
+    EXPECT_EQ(Xelqoria::Game::Collider2DShapeType::Box, duplicateCollider->get().shapeType);
+    EXPECT_FLOAT_EQ(3.0f, duplicateCollider->get().offset.x);
+    EXPECT_FLOAT_EQ(-4.0f, duplicateCollider->get().offset.y);
+    EXPECT_FLOAT_EQ(5.0f, duplicateCollider->get().size.x);
+    EXPECT_FLOAT_EQ(6.0f, duplicateCollider->get().size.y);
 }

--- a/tests/Game/Source/EntityTests.cpp
+++ b/tests/Game/Source/EntityTests.cpp
@@ -1,0 +1,44 @@
+#include <gtest/gtest.h>
+
+#include "Collider2DComponent.h"
+#include "Entity.h"
+
+TEST(EntityTests, Collider2DComponentCanBeSetReadAndRemoved)
+{
+	Xelqoria::Game::Entity entity(1);
+	Xelqoria::Game::Collider2DComponent collider{};
+	collider.enabled = false;
+	collider.isTrigger = true;
+	collider.offset = { 2.0f, -3.0f };
+	collider.size = { 4.0f, 5.0f };
+
+	entity.SetCollider2DComponent(collider);
+
+	ASSERT_TRUE(entity.HasCollider2DComponent());
+	const auto storedCollider = entity.GetCollider2DComponent();
+	ASSERT_TRUE(storedCollider.has_value());
+	EXPECT_FALSE(storedCollider->get().enabled);
+	EXPECT_TRUE(storedCollider->get().isTrigger);
+	EXPECT_FLOAT_EQ(2.0f, storedCollider->get().offset.x);
+	EXPECT_FLOAT_EQ(-3.0f, storedCollider->get().offset.y);
+	EXPECT_FLOAT_EQ(4.0f, storedCollider->get().size.x);
+	EXPECT_FLOAT_EQ(5.0f, storedCollider->get().size.y);
+
+	entity.RemoveCollider2DComponent();
+
+	EXPECT_FALSE(entity.HasCollider2DComponent());
+	EXPECT_FALSE(entity.GetCollider2DComponent().has_value());
+}
+
+TEST(EntityTests, DefaultCollider2DComponentUsesBoxDefaults)
+{
+	const Xelqoria::Game::Collider2DComponent collider{};
+
+	EXPECT_TRUE(collider.enabled);
+	EXPECT_FALSE(collider.isTrigger);
+	EXPECT_EQ(Xelqoria::Game::Collider2DShapeType::Box, collider.shapeType);
+	EXPECT_FLOAT_EQ(0.0f, collider.offset.x);
+	EXPECT_FLOAT_EQ(0.0f, collider.offset.y);
+	EXPECT_FLOAT_EQ(1.0f, collider.size.x);
+	EXPECT_FLOAT_EQ(1.0f, collider.size.y);
+}

--- a/tests/Game/Source/Physics2DTests.cpp
+++ b/tests/Game/Source/Physics2DTests.cpp
@@ -2,7 +2,9 @@
 
 #include <gtest/gtest.h>
 
+#include "Collider2DComponent.h"
 #include "Physics2D.h"
+#include "Transform.h"
 
 namespace
 {
@@ -114,4 +116,41 @@ TEST(Physics2DTests, SpatialHashRemovesDuplicatePairsAcrossCells)
 	ASSERT_EQ(pairs.size(), 1u);
 	EXPECT_EQ(pairs[0].first, 1u);
 	EXPECT_EQ(pairs[0].second, 2u);
+}
+
+TEST(Physics2DTests, BuildAabbCollider2DUsesTransformPositionOffsetAndScale)
+{
+	Xelqoria::Game::Transform transform{};
+	transform.position = { 10.0f, -20.0f, 5.0f };
+	transform.scale = { 2.0f, 3.0f, 1.0f };
+	Xelqoria::Game::Collider2DComponent collider{};
+	collider.offset = { 4.0f, -5.0f };
+	collider.size = { 6.0f, 8.0f };
+
+	const Xelqoria::Game::AabbCollider2D aabb =
+		Xelqoria::Game::BuildAabbCollider2D(transform, collider);
+
+	EXPECT_TRUE(IsEqual(aabb.center.x, 18.0f));
+	EXPECT_TRUE(IsEqual(aabb.center.y, -35.0f));
+	EXPECT_TRUE(IsEqual(aabb.halfSize.x, 6.0f));
+	EXPECT_TRUE(IsEqual(aabb.halfSize.y, 12.0f));
+}
+
+TEST(Physics2DTests, BuildAabbCollider2DUsesAbsoluteScaleAndIgnoresRotationZ)
+{
+	Xelqoria::Game::Transform transform{};
+	transform.position = { 1.0f, 2.0f, 0.0f };
+	transform.rotation = { 0.0f, 0.0f, 90.0f };
+	transform.scale = { -2.0f, -4.0f, 1.0f };
+	Xelqoria::Game::Collider2DComponent collider{};
+	collider.offset = { 3.0f, 5.0f };
+	collider.size = { 7.0f, 11.0f };
+
+	const Xelqoria::Game::AabbCollider2D aabb =
+		Xelqoria::Game::BuildAabbCollider2D(transform, collider);
+
+	EXPECT_TRUE(IsEqual(aabb.center.x, -5.0f));
+	EXPECT_TRUE(IsEqual(aabb.center.y, -18.0f));
+	EXPECT_TRUE(IsEqual(aabb.halfSize.x, 7.0f));
+	EXPECT_TRUE(IsEqual(aabb.halfSize.y, 22.0f));
 }

--- a/tests/Game/Xelqoria.Tests.Game.vcxproj
+++ b/tests/Game/Xelqoria.Tests.Game.vcxproj
@@ -19,6 +19,7 @@
     </ProjectConfiguration>
   </ItemGroup>
   <ItemGroup>
+    <ClCompile Include="Source\EntityTests.cpp" />
     <ClCompile Include="Source\Physics2DTests.cpp" />
     <ClCompile Include="Source\TransformTests.cpp" />
   </ItemGroup>

--- a/tests/Game/Xelqoria.Tests.Game.vcxproj.filters
+++ b/tests/Game/Xelqoria.Tests.Game.vcxproj.filters
@@ -6,6 +6,9 @@
     </Filter>
   </ItemGroup>
   <ItemGroup>
+    <ClCompile Include="Source\EntityTests.cpp">
+      <Filter>Source</Filter>
+    </ClCompile>
     <ClCompile Include="Source\Physics2DTests.cpp">
       <Filter>Source</Filter>
     </ClCompile>


### PR DESCRIPTION
## 概要
- `Collider2DComponent` / `Collider2DShapeType` を Game 層に追加
- Entity の Collider2DComponent 保持・取得・有無判定・削除 API を追加
- Transform と Collider2DComponent から `AabbCollider2D` を生成する処理を追加
- `SceneEditingOperations` の追加・削除 API と Entity 複製時コピーを追加
- 関連テストと ExecPlan を追加

## 検証
- `dotnet run --project tools/LayerDependencyChecker/LayerDependencyChecker.csproj -c Debug -- "D:\github\Xelqoria"`
- `MSBuild.exe tests\Game\Xelqoria.Tests.Game.vcxproj /m /p:Configuration=Debug /p:Platform=x64 /v:minimal`
- `MSBuild.exe tests\Editor\Xelqoria.Tests.Editor.vcxproj /m /p:Configuration=Debug /p:Platform=x64 /v:minimal`
- `artifacts\x64\Debug\Xelqoria.Tests.Game.exe`
- `artifacts\x64\Debug\Xelqoria.Tests.Editor.exe`

Closes #290
Parent: #289