### PR TITLE
SceneView に Collider2D 枠表示を追加する

### DIFF
--- a/Editor/Source/EditorShell.cpp
+++ b/Editor/Source/EditorShell.cpp
@@ -1030,7 +1030,7 @@ namespace Xelqoria::Editor
         if (m_ownsDefaultFont && nullptr != m_defaultFont)
         {
             HFONT stockFont = static_cast<HFONT>(GetStockObject(DEFAULT_GUI_FONT));
-            const std::array<HWND, 88> controls = CollectControls();
+            const std::array<HWND, 100> controls = CollectControls();
             for (HWND control : controls)
             {
                 if (nullptr != control)
@@ -1440,7 +1440,59 @@ namespace Xelqoria::Editor
             L"Button",
             L"Add SpriteComponent",
             WS_CHILD | WS_VISIBLE | BS_PUSHBUTTON);
-        return nullptr != m_spriteComponentActionButton;
+        if (nullptr == m_spriteComponentActionButton)
+        {
+            return false;
+        }
+
+        m_collider2DComponentSectionLabel = CreateChildWindow(
+            parentWindow,
+            hInstance,
+            L"Static",
+            L"Collider2DComponent",
+            WS_CHILD | WS_VISIBLE | SS_OWNERDRAW);
+        if (nullptr == m_collider2DComponentSectionLabel)
+        {
+            return false;
+        }
+
+        m_collider2DEnabledCheckBox = CreateChildWindow(parentWindow, hInstance, L"Button", L"Enabled", WS_CHILD | WS_VISIBLE | BS_AUTOCHECKBOX);
+        m_collider2DTriggerCheckBox = CreateChildWindow(parentWindow, hInstance, L"Button", L"Is Trigger", WS_CHILD | WS_VISIBLE | BS_AUTOCHECKBOX);
+        m_collider2DShapeTypeLabel = CreateChildWindow(parentWindow, hInstance, L"Static", L"Shape", WS_CHILD | WS_VISIBLE);
+        m_collider2DShapeTypeEdit = CreateChildWindow(parentWindow, hInstance, L"Edit", L"Box", WS_CHILD | WS_VISIBLE | WS_BORDER | ES_AUTOHSCROLL | ES_READONLY);
+        m_collider2DOffsetLabel = CreateChildWindow(parentWindow, hInstance, L"Static", L"Offset", WS_CHILD | WS_VISIBLE);
+        m_collider2DSizeLabel = CreateChildWindow(parentWindow, hInstance, L"Static", L"Size", WS_CHILD | WS_VISIBLE);
+        if (nullptr == m_collider2DEnabledCheckBox
+            || nullptr == m_collider2DTriggerCheckBox
+            || nullptr == m_collider2DShapeTypeLabel
+            || nullptr == m_collider2DShapeTypeEdit
+            || nullptr == m_collider2DOffsetLabel
+            || nullptr == m_collider2DSizeLabel)
+        {
+            return false;
+        }
+
+        for (HWND& handle : m_collider2DEditControls)
+        {
+            handle = CreateChildWindow(
+                parentWindow,
+                hInstance,
+                L"Edit",
+                L"",
+                WS_CHILD | WS_VISIBLE | WS_BORDER | ES_AUTOHSCROLL);
+            if (nullptr == handle)
+            {
+                return false;
+            }
+        }
+
+        m_collider2DComponentActionButton = CreateChildWindow(
+            parentWindow,
+            hInstance,
+            L"Button",
+            L"Add Collider2DComponent",
+            WS_CHILD | WS_VISIBLE | BS_PUSHBUTTON);
+        return nullptr != m_collider2DComponentActionButton;
     }
 
     bool EditorShell::InitializeMaterialPanel(HWND parentWindow, HINSTANCE hInstance)
@@ -2110,6 +2162,13 @@ namespace Xelqoria::Editor
         const int spriteRefTop = spriteSectionTop + labelHeight + ScaleMetric(4);
         const int scriptAssetTop = spriteRefTop + rowHeight + rowSpacing;
         const int scriptButtonTop = scriptAssetTop + rowHeight + rowSpacing;
+        const int spriteActionTop = scriptButtonTop + rowHeight + ScaleMetric(4) + rowSpacing;
+        const int colliderSectionTop = spriteActionTop + rowHeight + ScaleMetric(4) + sectionSpacing;
+        const int colliderCheckTop = colliderSectionTop + labelHeight + ScaleMetric(4);
+        const int colliderShapeTop = colliderCheckTop + rowHeight + rowSpacing;
+        const int colliderOffsetTop = colliderShapeTop + rowHeight + rowSpacing;
+        const int colliderSizeTop = colliderOffsetTop + rowHeight + rowSpacing;
+        const int colliderActionTop = colliderSizeTop + rowHeight + rowSpacing;
         const int scriptButtonGap = ScaleMetric(6);
         const int scriptButtonWidth = (std::max)(0, (innerWidth - scriptButtonGap * 2) / 3);
         const int materialOpenButtonWidth = ScaleMetric(56);
@@ -2141,7 +2200,19 @@ namespace Xelqoria::Editor
         MoveChildWindowNoRedraw(m_scriptCreateButton, innerX, scriptButtonTop, scriptButtonWidth, rowHeight + ScaleMetric(4));
         MoveChildWindowNoRedraw(m_scriptAssignButton, innerX + scriptButtonWidth + scriptButtonGap, scriptButtonTop, scriptButtonWidth, rowHeight + ScaleMetric(4));
         MoveChildWindowNoRedraw(m_scriptClearButton, innerX + (scriptButtonWidth + scriptButtonGap) * 2, scriptButtonTop, (std::max)(0, innerWidth - (scriptButtonWidth + scriptButtonGap) * 2), rowHeight + ScaleMetric(4));
-        MoveChildWindowNoRedraw(m_spriteComponentActionButton, innerX, scriptButtonTop + rowHeight + ScaleMetric(4) + rowSpacing, innerWidth, rowHeight + ScaleMetric(4));
+        MoveChildWindowNoRedraw(m_spriteComponentActionButton, innerX, spriteActionTop, innerWidth, rowHeight + ScaleMetric(4));
+        MoveChildWindowNoRedraw(m_collider2DComponentSectionLabel, innerX, colliderSectionTop, innerWidth, labelHeight);
+        MoveChildWindowNoRedraw(m_collider2DEnabledCheckBox, innerX, colliderCheckTop, (std::max)(0, innerWidth / 2), rowHeight);
+        MoveChildWindowNoRedraw(m_collider2DTriggerCheckBox, innerX + (std::max)(0, innerWidth / 2), colliderCheckTop, (std::max)(0, innerWidth / 2), rowHeight);
+        MoveChildWindowNoRedraw(m_collider2DShapeTypeLabel, innerX, colliderShapeTop + ScaleMetric(4), labelWidth, rowHeight);
+        MoveChildWindowNoRedraw(m_collider2DShapeTypeEdit, innerX + labelWidth, colliderShapeTop, (std::max)(0, innerWidth - labelWidth), rowHeight);
+        MoveChildWindowNoRedraw(m_collider2DOffsetLabel, innerX, colliderOffsetTop + ScaleMetric(4), labelWidth, rowHeight);
+        MoveChildWindowNoRedraw(m_collider2DEditControls[0], innerX + labelWidth, colliderOffsetTop, editWidth, rowHeight);
+        MoveChildWindowNoRedraw(m_collider2DEditControls[1], innerX + labelWidth + editWidth + ScaleMetric(8), colliderOffsetTop, editWidth, rowHeight);
+        MoveChildWindowNoRedraw(m_collider2DSizeLabel, innerX, colliderSizeTop + ScaleMetric(4), labelWidth, rowHeight);
+        MoveChildWindowNoRedraw(m_collider2DEditControls[2], innerX + labelWidth, colliderSizeTop, editWidth, rowHeight);
+        MoveChildWindowNoRedraw(m_collider2DEditControls[3], innerX + labelWidth + editWidth + ScaleMetric(8), colliderSizeTop, editWidth, rowHeight);
+        MoveChildWindowNoRedraw(m_collider2DComponentActionButton, innerX, colliderActionTop, innerWidth, rowHeight + ScaleMetric(4));
     }
 
     void EditorShell::LayoutMaterialPanelInRect(const RECT& panelRect)
@@ -2450,6 +2521,26 @@ namespace Xelqoria::Editor
             scriptButtonTop + metrics.inspectorRowHeight + ScaleMetric(4) + metrics.inspectorRowSpacing,
             metrics.inspectorInnerWidth,
             metrics.inspectorRowHeight + ScaleMetric(4));
+
+        const int colliderSectionTop =
+            scriptButtonTop + metrics.inspectorRowHeight + ScaleMetric(4) + metrics.inspectorRowSpacing + metrics.inspectorRowHeight + ScaleMetric(4) + ScaleMetric(12);
+        const int colliderCheckTop = colliderSectionTop + metrics.labelHeight + ScaleMetric(4);
+        const int colliderShapeTop = colliderCheckTop + metrics.inspectorRowHeight + metrics.inspectorRowSpacing;
+        const int colliderOffsetTop = colliderShapeTop + metrics.inspectorRowHeight + metrics.inspectorRowSpacing;
+        const int colliderSizeTop = colliderOffsetTop + metrics.inspectorRowHeight + metrics.inspectorRowSpacing;
+        const int colliderActionTop = colliderSizeTop + metrics.inspectorRowHeight + metrics.inspectorRowSpacing;
+        MoveChildWindowNoRedraw(m_collider2DComponentSectionLabel, metrics.inspectorInnerX, colliderSectionTop, metrics.inspectorInnerWidth, metrics.labelHeight);
+        MoveChildWindowNoRedraw(m_collider2DEnabledCheckBox, metrics.inspectorInnerX, colliderCheckTop, (std::max)(0, metrics.inspectorInnerWidth / 2), metrics.inspectorRowHeight);
+        MoveChildWindowNoRedraw(m_collider2DTriggerCheckBox, metrics.inspectorInnerX + (std::max)(0, metrics.inspectorInnerWidth / 2), colliderCheckTop, (std::max)(0, metrics.inspectorInnerWidth / 2), metrics.inspectorRowHeight);
+        MoveChildWindowNoRedraw(m_collider2DShapeTypeLabel, metrics.inspectorInnerX, colliderShapeTop + ScaleMetric(4), metrics.inspectorLabelWidth, metrics.inspectorRowHeight);
+        MoveChildWindowNoRedraw(m_collider2DShapeTypeEdit, metrics.inspectorInnerX + metrics.inspectorLabelWidth, colliderShapeTop, (std::max)(0, metrics.inspectorInnerWidth - metrics.inspectorLabelWidth), metrics.inspectorRowHeight);
+        MoveChildWindowNoRedraw(m_collider2DOffsetLabel, metrics.inspectorInnerX, colliderOffsetTop + ScaleMetric(4), metrics.inspectorLabelWidth, metrics.inspectorRowHeight);
+        MoveChildWindowNoRedraw(m_collider2DEditControls[0], metrics.inspectorInnerX + metrics.inspectorLabelWidth, colliderOffsetTop, metrics.inspectorEditWidth, metrics.inspectorRowHeight);
+        MoveChildWindowNoRedraw(m_collider2DEditControls[1], metrics.inspectorInnerX + metrics.inspectorLabelWidth + metrics.inspectorEditWidth + ScaleMetric(8), colliderOffsetTop, metrics.inspectorEditWidth, metrics.inspectorRowHeight);
+        MoveChildWindowNoRedraw(m_collider2DSizeLabel, metrics.inspectorInnerX, colliderSizeTop + ScaleMetric(4), metrics.inspectorLabelWidth, metrics.inspectorRowHeight);
+        MoveChildWindowNoRedraw(m_collider2DEditControls[2], metrics.inspectorInnerX + metrics.inspectorLabelWidth, colliderSizeTop, metrics.inspectorEditWidth, metrics.inspectorRowHeight);
+        MoveChildWindowNoRedraw(m_collider2DEditControls[3], metrics.inspectorInnerX + metrics.inspectorLabelWidth + metrics.inspectorEditWidth + ScaleMetric(8), colliderSizeTop, metrics.inspectorEditWidth, metrics.inspectorRowHeight);
+        MoveChildWindowNoRedraw(m_collider2DComponentActionButton, metrics.inspectorInnerX, colliderActionTop, metrics.inspectorInnerWidth, metrics.inspectorRowHeight + ScaleMetric(4));
     }
 
     void EditorShell::LayoutSceneViewPanel(const LayoutMetrics& metrics)
@@ -3130,7 +3221,7 @@ namespace Xelqoria::Editor
             ShowWindow(m_sceneViewSizeLabel, SW_HIDE);
             break;
         case EditorPanelId::Inspector:
-            for (HWND control : { m_inspectorPanel, m_inspectorSummaryLabel, m_transformSectionLabel, m_transformLabels[0], m_transformLabels[1], m_transformLabels[2], m_transformEditControls[0], m_transformEditControls[1], m_transformEditControls[2], m_transformEditControls[3], m_transformEditControls[4], m_transformEditControls[5], m_transformEditControls[6], m_transformEditControls[7], m_transformEditControls[8], m_spriteComponentSectionLabel, m_spriteRefLabel, m_spriteRefEdit, m_materialOpenButton, m_scriptAssetLabel, m_scriptAssetEdit, m_scriptCreateButton, m_scriptAssignButton, m_scriptClearButton, m_spriteComponentActionButton })
+            for (HWND control : { m_inspectorPanel, m_inspectorSummaryLabel, m_transformSectionLabel, m_transformLabels[0], m_transformLabels[1], m_transformLabels[2], m_transformEditControls[0], m_transformEditControls[1], m_transformEditControls[2], m_transformEditControls[3], m_transformEditControls[4], m_transformEditControls[5], m_transformEditControls[6], m_transformEditControls[7], m_transformEditControls[8], m_spriteComponentSectionLabel, m_spriteRefLabel, m_spriteRefEdit, m_materialOpenButton, m_scriptAssetLabel, m_scriptAssetEdit, m_scriptCreateButton, m_scriptAssignButton, m_scriptClearButton, m_spriteComponentActionButton, m_collider2DComponentSectionLabel, m_collider2DEnabledCheckBox, m_collider2DTriggerCheckBox, m_collider2DShapeTypeLabel, m_collider2DShapeTypeEdit, m_collider2DOffsetLabel, m_collider2DSizeLabel, m_collider2DEditControls[0], m_collider2DEditControls[1], m_collider2DEditControls[2], m_collider2DEditControls[3], m_collider2DComponentActionButton })
             {
                 ShowWindow(control, showCommand);
             }
@@ -3199,7 +3290,7 @@ namespace Xelqoria::Editor
             }
             break;
         case EditorPanelId::Inspector:
-            for (HWND control : { m_inspectorPanel, m_inspectorSummaryLabel, m_transformSectionLabel, m_transformLabels[0], m_transformLabels[1], m_transformLabels[2], m_transformEditControls[0], m_transformEditControls[1], m_transformEditControls[2], m_transformEditControls[3], m_transformEditControls[4], m_transformEditControls[5], m_transformEditControls[6], m_transformEditControls[7], m_transformEditControls[8], m_spriteComponentSectionLabel, m_spriteRefLabel, m_spriteRefDropHighlight, m_spriteRefEdit, m_materialOpenButton, m_scriptAssetLabel, m_scriptAssetEdit, m_scriptCreateButton, m_scriptAssignButton, m_scriptClearButton, m_spriteComponentActionButton })
+            for (HWND control : { m_inspectorPanel, m_inspectorSummaryLabel, m_transformSectionLabel, m_transformLabels[0], m_transformLabels[1], m_transformLabels[2], m_transformEditControls[0], m_transformEditControls[1], m_transformEditControls[2], m_transformEditControls[3], m_transformEditControls[4], m_transformEditControls[5], m_transformEditControls[6], m_transformEditControls[7], m_transformEditControls[8], m_spriteComponentSectionLabel, m_spriteRefLabel, m_spriteRefDropHighlight, m_spriteRefEdit, m_materialOpenButton, m_scriptAssetLabel, m_scriptAssetEdit, m_scriptCreateButton, m_scriptAssignButton, m_scriptClearButton, m_spriteComponentActionButton, m_collider2DComponentSectionLabel, m_collider2DEnabledCheckBox, m_collider2DTriggerCheckBox, m_collider2DShapeTypeLabel, m_collider2DShapeTypeEdit, m_collider2DOffsetLabel, m_collider2DSizeLabel, m_collider2DEditControls[0], m_collider2DEditControls[1], m_collider2DEditControls[2], m_collider2DEditControls[3], m_collider2DComponentActionButton })
             {
                 setParent(control);
             }
@@ -5245,7 +5336,7 @@ namespace Xelqoria::Editor
             m_ownsDefaultFont = false;
         }
 
-        const std::array<HWND, 88> controls = CollectControls();
+        const std::array<HWND, 100> controls = CollectControls();
 
         for (HWND control : controls)
         {
@@ -5268,7 +5359,7 @@ namespace Xelqoria::Editor
         return true;
     }
 
-    std::array<HWND, 88> EditorShell::CollectControls() const
+    std::array<HWND, 100> EditorShell::CollectControls() const
     {
         return {
             m_workspaceBackground,
@@ -5358,7 +5449,19 @@ namespace Xelqoria::Editor
             m_scriptCreateButton,
             m_scriptAssignButton,
             m_scriptClearButton,
-            m_spriteComponentActionButton
+            m_spriteComponentActionButton,
+            m_collider2DComponentSectionLabel,
+            m_collider2DEnabledCheckBox,
+            m_collider2DTriggerCheckBox,
+            m_collider2DShapeTypeLabel,
+            m_collider2DShapeTypeEdit,
+            m_collider2DOffsetLabel,
+            m_collider2DSizeLabel,
+            m_collider2DEditControls[0],
+            m_collider2DEditControls[1],
+            m_collider2DEditControls[2],
+            m_collider2DEditControls[3],
+            m_collider2DComponentActionButton
         };
     }
 
@@ -5681,7 +5784,17 @@ namespace Xelqoria::Editor
             }
         }
 
-        return window == m_spriteRefEdit || window == m_scriptAssetEdit;
+        for (HWND colliderEdit : m_collider2DEditControls)
+        {
+            if (window == colliderEdit)
+            {
+                return true;
+            }
+        }
+
+        return window == m_spriteRefEdit
+            || window == m_scriptAssetEdit
+            || window == m_collider2DShapeTypeEdit;
     }
 
     bool EditorShell::IsInspectorSecondaryLabel(HWND window) const
@@ -5701,7 +5814,10 @@ namespace Xelqoria::Editor
 
         return window == m_inspectorSummaryLabel
             || window == m_spriteRefLabel
-            || window == m_scriptAssetLabel;
+            || window == m_scriptAssetLabel
+            || window == m_collider2DShapeTypeLabel
+            || window == m_collider2DOffsetLabel
+            || window == m_collider2DSizeLabel;
     }
 
     HWND EditorShell::GetHierarchyListBox() const
@@ -5870,6 +5986,51 @@ namespace Xelqoria::Editor
     HWND EditorShell::GetSpriteComponentActionButton() const
     {
         return m_spriteComponentActionButton;
+    }
+
+    HWND EditorShell::GetCollider2DComponentSectionLabel() const
+    {
+        return m_collider2DComponentSectionLabel;
+    }
+
+    HWND EditorShell::GetCollider2DEnabledCheckBox() const
+    {
+        return m_collider2DEnabledCheckBox;
+    }
+
+    HWND EditorShell::GetCollider2DTriggerCheckBox() const
+    {
+        return m_collider2DTriggerCheckBox;
+    }
+
+    HWND EditorShell::GetCollider2DShapeTypeLabel() const
+    {
+        return m_collider2DShapeTypeLabel;
+    }
+
+    HWND EditorShell::GetCollider2DShapeTypeEdit() const
+    {
+        return m_collider2DShapeTypeEdit;
+    }
+
+    HWND EditorShell::GetCollider2DOffsetLabel() const
+    {
+        return m_collider2DOffsetLabel;
+    }
+
+    HWND EditorShell::GetCollider2DSizeLabel() const
+    {
+        return m_collider2DSizeLabel;
+    }
+
+    const std::array<HWND, 4>& EditorShell::GetCollider2DEditControls() const
+    {
+        return m_collider2DEditControls;
+    }
+
+    HWND EditorShell::GetCollider2DComponentActionButton() const
+    {
+        return m_collider2DComponentActionButton;
     }
 
     HWND EditorShell::GetSceneViewSizeLabel() const

--- a/Editor/Source/EditorShell.h
+++ b/Editor/Source/EditorShell.h
@@ -242,6 +242,60 @@ namespace Xelqoria::Editor
         [[nodiscard]] HWND GetSpriteComponentActionButton() const;
 
         /// <summary>
+        /// Collider2DComponent セクション見出しラベルを取得する。
+        /// </summary>
+        /// <returns>Collider2DComponent セクション見出しの HWND。</returns>
+        [[nodiscard]] HWND GetCollider2DComponentSectionLabel() const;
+
+        /// <summary>
+        /// Collider2DComponent enabled チェックボックスを取得する。
+        /// </summary>
+        /// <returns>enabled チェックボックスの HWND。</returns>
+        [[nodiscard]] HWND GetCollider2DEnabledCheckBox() const;
+
+        /// <summary>
+        /// Collider2DComponent isTrigger チェックボックスを取得する。
+        /// </summary>
+        /// <returns>isTrigger チェックボックスの HWND。</returns>
+        [[nodiscard]] HWND GetCollider2DTriggerCheckBox() const;
+
+        /// <summary>
+        /// Collider2D shapeType ラベルを取得する。
+        /// </summary>
+        /// <returns>shapeType ラベルの HWND。</returns>
+        [[nodiscard]] HWND GetCollider2DShapeTypeLabel() const;
+
+        /// <summary>
+        /// Collider2D shapeType 表示欄を取得する。
+        /// </summary>
+        /// <returns>shapeType 表示欄の HWND。</returns>
+        [[nodiscard]] HWND GetCollider2DShapeTypeEdit() const;
+
+        /// <summary>
+        /// Collider2D offset ラベルを取得する。
+        /// </summary>
+        /// <returns>offset ラベルの HWND。</returns>
+        [[nodiscard]] HWND GetCollider2DOffsetLabel() const;
+
+        /// <summary>
+        /// Collider2D size ラベルを取得する。
+        /// </summary>
+        /// <returns>size ラベルの HWND。</returns>
+        [[nodiscard]] HWND GetCollider2DSizeLabel() const;
+
+        /// <summary>
+        /// Collider2D 数値入力欄群を取得する。
+        /// </summary>
+        /// <returns>offset.x, offset.y, size.x, size.y の入力欄配列。</returns>
+        [[nodiscard]] const std::array<HWND, 4>& GetCollider2DEditControls() const;
+
+        /// <summary>
+        /// Collider2DComponent 操作ボタンを取得する。
+        /// </summary>
+        /// <returns>Collider2DComponent 操作用ボタンの HWND。</returns>
+        [[nodiscard]] HWND GetCollider2DComponentActionButton() const;
+
+        /// <summary>
         /// SceneView の状態ラベルを取得する。
         /// </summary>
         /// <returns>SceneView サイズラベルの HWND。</returns>
@@ -910,7 +964,7 @@ namespace Xelqoria::Editor
         /// EditorShell が管理する child window 群を列挙する。
         /// </summary>
         /// <returns>管理対象 child window の一覧。</returns>
-        [[nodiscard]] std::array<HWND, 88> CollectControls() const;
+        [[nodiscard]] std::array<HWND, 100> CollectControls() const;
 
         /// <summary>
         /// 指定値を現在 DPI に合わせて拡大縮小する。
@@ -1138,6 +1192,15 @@ namespace Xelqoria::Editor
         HWND m_scriptAssignButton = nullptr;
         HWND m_scriptClearButton = nullptr;
         HWND m_spriteComponentActionButton = nullptr;
+        HWND m_collider2DComponentSectionLabel = nullptr;
+        HWND m_collider2DEnabledCheckBox = nullptr;
+        HWND m_collider2DTriggerCheckBox = nullptr;
+        HWND m_collider2DShapeTypeLabel = nullptr;
+        HWND m_collider2DShapeTypeEdit = nullptr;
+        HWND m_collider2DOffsetLabel = nullptr;
+        HWND m_collider2DSizeLabel = nullptr;
+        std::array<HWND, 4> m_collider2DEditControls{};
+        HWND m_collider2DComponentActionButton = nullptr;
         std::uint32_t m_sceneViewWidth = 0;
         std::uint32_t m_sceneViewHeight = 0;
         std::vector<EditorPanelId> m_leftTopDockPanels{};

--- a/Editor/Source/HierarchyPanelController.cpp
+++ b/Editor/Source/HierarchyPanelController.cpp
@@ -51,6 +51,12 @@ namespace Xelqoria::Editor
 
                 label.insert(0, L"+ ");
                 SendMessageW(m_hierarchyListBox, LB_ADDSTRING, 0, reinterpret_cast<LPARAM>(label.c_str()));
+
+                if (entity.HasCollider2DComponent())
+                {
+                    m_visibleEntityIds.push_back(entity.GetId());
+                    SendMessageW(m_hierarchyListBox, LB_ADDSTRING, 0, reinterpret_cast<LPARAM>(L"  Collider2DComponent"));
+                }
             }
         }
 

--- a/Editor/Source/InspectorPanelController.cpp
+++ b/Editor/Source/InspectorPanelController.cpp
@@ -10,6 +10,7 @@
 #include <iterator>
 #include <optional>
 #include <AssetId.h>
+#include <Collider2DComponent.h>
 #include "AssetsPanelController.h"
 #include "EditorShell.h"
 #include <Entity.h>
@@ -22,6 +23,55 @@ namespace Xelqoria::Editor
         [[nodiscard]] POINT ToWin32Point(Platform::Point point)
         {
             return POINT{ static_cast<LONG>(point.x), static_cast<LONG>(point.y) };
+        }
+
+        void SetWindowVisible(HWND window, bool visible)
+        {
+            ShowWindow(window, visible ? SW_SHOW : SW_HIDE);
+        }
+
+        void SetEditFloat(HWND editControl, float value)
+        {
+            wchar_t valueText[32]{};
+            std::swprintf(valueText, std::size(valueText), L"%.3f", value);
+            SetWindowTextW(editControl, valueText);
+        }
+
+        std::optional<float> ReadEditFloat(HWND editControl)
+        {
+            wchar_t buffer[64]{};
+            GetWindowTextW(editControl, buffer, static_cast<int>(std::size(buffer)));
+
+            wchar_t* end = nullptr;
+            const float parsed = std::wcstof(buffer, &end);
+            if (end == buffer || *end != L'\0')
+            {
+                return std::nullopt;
+            }
+
+            return parsed;
+        }
+
+        void SetCollider2DControlsVisible(
+            HWND enabledCheckBox,
+            HWND triggerCheckBox,
+            HWND shapeTypeLabel,
+            HWND shapeTypeEdit,
+            HWND offsetLabel,
+            HWND sizeLabel,
+            const std::array<HWND, 4>& editControls,
+            bool visible)
+        {
+            SetWindowVisible(enabledCheckBox, visible);
+            SetWindowVisible(triggerCheckBox, visible);
+            SetWindowVisible(shapeTypeLabel, visible);
+            SetWindowVisible(shapeTypeEdit, visible);
+            SetWindowVisible(offsetLabel, visible);
+            SetWindowVisible(sizeLabel, visible);
+            for (HWND editControl : editControls)
+            {
+                SetWindowVisible(editControl, visible);
+            }
         }
     }
 
@@ -40,6 +90,15 @@ namespace Xelqoria::Editor
         m_scriptAssignButton = shell.GetScriptAssignButton();
         m_scriptClearButton = shell.GetScriptClearButton();
         m_spriteComponentActionButton = shell.GetSpriteComponentActionButton();
+        m_collider2DComponentSectionLabel = shell.GetCollider2DComponentSectionLabel();
+        m_collider2DEnabledCheckBox = shell.GetCollider2DEnabledCheckBox();
+        m_collider2DTriggerCheckBox = shell.GetCollider2DTriggerCheckBox();
+        m_collider2DShapeTypeLabel = shell.GetCollider2DShapeTypeLabel();
+        m_collider2DShapeTypeEdit = shell.GetCollider2DShapeTypeEdit();
+        m_collider2DOffsetLabel = shell.GetCollider2DOffsetLabel();
+        m_collider2DSizeLabel = shell.GetCollider2DSizeLabel();
+        m_collider2DEditControls = shell.GetCollider2DEditControls();
+        m_collider2DComponentActionButton = shell.GetCollider2DComponentActionButton();
         m_materialOpenButton = shell.GetMaterialOpenButton();
         m_cursor = &cursor;
         SetWindowTextW(m_spriteRefLabel, L"Material");
@@ -76,6 +135,17 @@ namespace Xelqoria::Editor
             ShowWindow(m_scriptAssignButton, SW_HIDE);
             ShowWindow(m_scriptClearButton, SW_HIDE);
             ShowWindow(m_materialOpenButton, SW_HIDE);
+            SetWindowTextW(m_collider2DComponentSectionLabel, L"Collider2DComponent (not attached)");
+            SetWindowTextW(m_collider2DComponentActionButton, L"Add Collider2DComponent");
+            SetCollider2DControlsVisible(
+                m_collider2DEnabledCheckBox,
+                m_collider2DTriggerCheckBox,
+                m_collider2DShapeTypeLabel,
+                m_collider2DShapeTypeEdit,
+                m_collider2DOffsetLabel,
+                m_collider2DSizeLabel,
+                m_collider2DEditControls,
+                false);
             m_lastSpriteRefAssetId = {};
             m_lastSpriteRefDisplayText.clear();
             m_lastScriptAssetId = {};
@@ -95,6 +165,17 @@ namespace Xelqoria::Editor
             ShowWindow(m_scriptAssignButton, SW_HIDE);
             ShowWindow(m_scriptClearButton, SW_HIDE);
             ShowWindow(m_materialOpenButton, SW_HIDE);
+            SetWindowTextW(m_collider2DComponentSectionLabel, L"Collider2DComponent (not attached)");
+            SetWindowTextW(m_collider2DComponentActionButton, L"Add Collider2DComponent");
+            SetCollider2DControlsVisible(
+                m_collider2DEnabledCheckBox,
+                m_collider2DTriggerCheckBox,
+                m_collider2DShapeTypeLabel,
+                m_collider2DShapeTypeEdit,
+                m_collider2DOffsetLabel,
+                m_collider2DSizeLabel,
+                m_collider2DEditControls,
+                false);
             m_lastSpriteRefAssetId = {};
             m_lastSpriteRefDisplayText.clear();
             m_lastScriptAssetId = {};
@@ -175,6 +256,32 @@ namespace Xelqoria::Editor
             m_lastSpriteRefDisplayText.clear();
             m_lastScriptAssetId = {};
             m_lastScriptDisplayText.clear();
+        }
+
+        const auto collider2DComponent = entity->get().GetCollider2DComponent();
+        const InspectorCollider2DComponentActionState colliderActionState =
+            ComputeCollider2DComponentActionState(collider2DComponent.has_value());
+        SetWindowTextW(m_collider2DComponentSectionLabel, colliderActionState.sectionLabel);
+        SetWindowTextW(m_collider2DComponentActionButton, colliderActionState.buttonLabel);
+        SetCollider2DControlsVisible(
+            m_collider2DEnabledCheckBox,
+            m_collider2DTriggerCheckBox,
+            m_collider2DShapeTypeLabel,
+            m_collider2DShapeTypeEdit,
+            m_collider2DOffsetLabel,
+            m_collider2DSizeLabel,
+            m_collider2DEditControls,
+            colliderActionState.showColliderControls);
+        if (collider2DComponent.has_value())
+        {
+            const Game::Collider2DComponent& collider = collider2DComponent->get();
+            SendMessageW(m_collider2DEnabledCheckBox, BM_SETCHECK, collider.enabled ? BST_CHECKED : BST_UNCHECKED, 0);
+            SendMessageW(m_collider2DTriggerCheckBox, BM_SETCHECK, collider.isTrigger ? BST_CHECKED : BST_UNCHECKED, 0);
+            SetWindowTextW(m_collider2DShapeTypeEdit, L"Box");
+            SetEditFloat(m_collider2DEditControls[0], collider.offset.x);
+            SetEditFloat(m_collider2DEditControls[1], collider.offset.y);
+            SetEditFloat(m_collider2DEditControls[2], collider.size.x);
+            SetEditFloat(m_collider2DEditControls[3], collider.size.y);
         }
 
         wchar_t summaryText[128]{};
@@ -265,6 +372,68 @@ namespace Xelqoria::Editor
             if (false == entity->get().HasSpriteComponent())
             {
                 SetWindowTextW(m_spriteRefEdit, L"");
+            }
+        }
+
+        if (true == ConsumeButtonClick(m_collider2DComponentActionButton, inputSnapshot))
+        {
+            const bool hadCollider2DComponent = entity->get().HasCollider2DComponent();
+            const bool actionChanged = ApplyCollider2DComponentAction(entity->get());
+            result.changed = actionChanged || result.changed;
+            if (actionChanged)
+            {
+                result.operationName = hadCollider2DComponent
+                    ? "Remove Collider2DComponent"
+                    : "Add Collider2DComponent";
+            }
+        }
+
+        auto collider2DComponent = entity->get().GetCollider2DComponent();
+        if (collider2DComponent.has_value())
+        {
+            Game::Collider2DComponent& collider = collider2DComponent->get();
+            const bool enabled = SendMessageW(m_collider2DEnabledCheckBox, BM_GETCHECK, 0, 0) == BST_CHECKED;
+            const bool isTrigger = SendMessageW(m_collider2DTriggerCheckBox, BM_GETCHECK, 0, 0) == BST_CHECKED;
+            if (collider.enabled != enabled)
+            {
+                collider.enabled = enabled;
+                result.changed = true;
+                result.operationName = "Edit Collider2DComponent";
+            }
+            if (collider.isTrigger != isTrigger)
+            {
+                collider.isTrigger = isTrigger;
+                result.changed = true;
+                result.operationName = "Edit Collider2DComponent";
+            }
+
+            const std::optional<float> offsetX = ReadEditFloat(m_collider2DEditControls[0]);
+            const std::optional<float> offsetY = ReadEditFloat(m_collider2DEditControls[1]);
+            const std::optional<float> sizeX = ReadEditFloat(m_collider2DEditControls[2]);
+            const std::optional<float> sizeY = ReadEditFloat(m_collider2DEditControls[3]);
+            if (offsetX.has_value() && collider.offset.x != *offsetX)
+            {
+                collider.offset.x = *offsetX;
+                result.changed = true;
+                result.operationName = "Edit Collider2DComponent";
+            }
+            if (offsetY.has_value() && collider.offset.y != *offsetY)
+            {
+                collider.offset.y = *offsetY;
+                result.changed = true;
+                result.operationName = "Edit Collider2DComponent";
+            }
+            if (sizeX.has_value() && *sizeX > 0.0f && collider.size.x != *sizeX)
+            {
+                collider.size.x = *sizeX;
+                result.changed = true;
+                result.operationName = "Edit Collider2DComponent";
+            }
+            if (sizeY.has_value() && *sizeY > 0.0f && collider.size.y != *sizeY)
+            {
+                collider.size.y = *sizeY;
+                result.changed = true;
+                result.operationName = "Edit Collider2DComponent";
             }
         }
 

--- a/Editor/Source/InspectorPanelController.h
+++ b/Editor/Source/InspectorPanelController.h
@@ -102,6 +102,27 @@ namespace Xelqoria::Editor
     };
 
     /// <summary>
+    /// Collider2DComponent 操作 UI の表示状態を表す。
+    /// </summary>
+    struct InspectorCollider2DComponentActionState
+    {
+        /// <summary>
+        /// Collider2D 編集欄を表示するかを表す。
+        /// </summary>
+        bool showColliderControls = false;
+
+        /// <summary>
+        /// Collider2DComponent セクション見出しを表す。
+        /// </summary>
+        const wchar_t* sectionLabel = L"Collider2DComponent";
+
+        /// <summary>
+        /// Collider2DComponent 操作ボタン文言を表す。
+        /// </summary>
+        const wchar_t* buttonLabel = L"Add Collider2DComponent";
+    };
+
+    /// <summary>
     /// Script 操作 UI の表示状態を表す。
     /// </summary>
     struct InspectorScriptActionState
@@ -375,6 +396,45 @@ namespace Xelqoria::Editor
             return SceneEditingOperations::AddSpriteComponent(entity);
         }
 
+        /// <summary>
+        /// Collider2DComponent 操作 UI の表示状態を計算する。
+        /// </summary>
+        /// <param name="hasCollider2DComponent">Entity が Collider2DComponent を保持しているか。</param>
+        /// <returns>UI 表示状態。</returns>
+        [[nodiscard]] static InspectorCollider2DComponentActionState ComputeCollider2DComponentActionState(
+            bool hasCollider2DComponent)
+        {
+            if (hasCollider2DComponent)
+            {
+                return InspectorCollider2DComponentActionState{
+                    true,
+                    L"Collider2DComponent",
+                    L"Remove Collider2DComponent"
+                };
+            }
+
+            return InspectorCollider2DComponentActionState{
+                false,
+                L"Collider2DComponent (not attached)",
+                L"Add Collider2DComponent"
+            };
+        }
+
+        /// <summary>
+        /// Collider2DComponent 操作ボタン押下時の追加・削除処理を適用する。
+        /// </summary>
+        /// <param name="entity">更新対象 Entity。</param>
+        /// <returns>Entity が更新された場合は true。</returns>
+        [[nodiscard]] static bool ApplyCollider2DComponentAction(Game::Entity& entity)
+        {
+            if (entity.HasCollider2DComponent())
+            {
+                return SceneEditingOperations::RemoveCollider2DComponent(entity);
+            }
+
+            return SceneEditingOperations::AddCollider2DComponent(entity);
+        }
+
     private:
         /// <summary>
         /// ボタン押下の完了を検出してクリックとして消費する。
@@ -410,6 +470,15 @@ namespace Xelqoria::Editor
         HWND m_scriptAssignButton = nullptr;
         HWND m_scriptClearButton = nullptr;
         HWND m_spriteComponentActionButton = nullptr;
+        HWND m_collider2DComponentSectionLabel = nullptr;
+        HWND m_collider2DEnabledCheckBox = nullptr;
+        HWND m_collider2DTriggerCheckBox = nullptr;
+        HWND m_collider2DShapeTypeLabel = nullptr;
+        HWND m_collider2DShapeTypeEdit = nullptr;
+        HWND m_collider2DOffsetLabel = nullptr;
+        HWND m_collider2DSizeLabel = nullptr;
+        std::array<HWND, 4> m_collider2DEditControls{};
+        HWND m_collider2DComponentActionButton = nullptr;
         HWND m_materialOpenButton = nullptr;
         Platform::ICursor* m_cursor = nullptr;
         std::optional<Game::EntityId> m_lastInspectorEntityId{};

--- a/Editor/Source/SceneEditingOperations.cpp
+++ b/Editor/Source/SceneEditingOperations.cpp
@@ -5,6 +5,7 @@
 #include <optional>
 #include <string>
 #include <string_view>
+#include <Collider2DComponent.h>
 #include <Entity.h>
 #include <Scene.h>
 #include <SpriteComponent.h>
@@ -84,6 +85,11 @@ namespace Xelqoria::Editor
             /// Entity の SpriteComponent を保持する。
             /// </summary>
             std::optional<Game::SpriteComponent> spriteComponent{};
+
+            /// <summary>
+            /// Entity の Collider2DComponent を保持する。
+            /// </summary>
+            std::optional<Game::Collider2DComponent> collider2DComponent{};
         };
 
         /// <summary>
@@ -102,6 +108,11 @@ namespace Xelqoria::Editor
                 snapshot.spriteComponent = spriteComponent->get();
             }
 
+            if (const auto collider2DComponent = source.GetCollider2DComponent(); collider2DComponent.has_value())
+            {
+                snapshot.collider2DComponent = collider2DComponent->get();
+            }
+
             return snapshot;
         }
 
@@ -118,10 +129,19 @@ namespace Xelqoria::Editor
             if (snapshot.spriteComponent.has_value())
             {
                 destination.SetSpriteComponent(*snapshot.spriteComponent);
+            }
+            else
+            {
+                destination.RemoveSpriteComponent();
+            }
+
+            if (snapshot.collider2DComponent.has_value())
+            {
+                destination.SetCollider2DComponent(*snapshot.collider2DComponent);
                 return;
             }
 
-            destination.RemoveSpriteComponent();
+            destination.RemoveCollider2DComponent();
         }
     }
 
@@ -334,6 +354,28 @@ namespace Xelqoria::Editor
         }
 
         entity.RemoveSpriteComponent();
+        return true;
+    }
+
+    bool SceneEditingOperations::AddCollider2DComponent(Game::Entity& entity)
+    {
+        if (entity.HasCollider2DComponent())
+        {
+            return false;
+        }
+
+        entity.SetCollider2DComponent(Game::Collider2DComponent{});
+        return true;
+    }
+
+    bool SceneEditingOperations::RemoveCollider2DComponent(Game::Entity& entity)
+    {
+        if (false == entity.HasCollider2DComponent())
+        {
+            return false;
+        }
+
+        entity.RemoveCollider2DComponent();
         return true;
     }
 }

--- a/Editor/Source/SceneEditingOperations.h
+++ b/Editor/Source/SceneEditingOperations.h
@@ -136,5 +136,19 @@ namespace Xelqoria::Editor
         /// <param name="entity">削除対象の Entity。</param>
         /// <returns>削除で変更が発生した場合は true。</returns>
         static bool RemoveSpriteComponent(Game::Entity& entity);
+
+        /// <summary>
+        /// Entity に既定の Collider2DComponent を追加する。
+        /// </summary>
+        /// <param name="entity">追加対象の Entity。</param>
+        /// <returns>追加で変更が発生した場合は true。</returns>
+        static bool AddCollider2DComponent(Game::Entity& entity);
+
+        /// <summary>
+        /// Entity から Collider2DComponent を削除する。
+        /// </summary>
+        /// <param name="entity">削除対象の Entity。</param>
+        /// <returns>削除で変更が発生した場合は true。</returns>
+        static bool RemoveCollider2DComponent(Game::Entity& entity);
     };
 }

--- a/Editor/Source/SceneViewOverlay.h
+++ b/Editor/Source/SceneViewOverlay.h
@@ -5,10 +5,49 @@
 #include <optional>
 #include <span>
 
+#include "Collider2DComponent.h"
+#include "EditorCamera2D.h"
 #include "Entity.h"
+#include "Physics2D.h"
 
 namespace Xelqoria::Editor
 {
+    /// <summary>
+    /// SceneView に描画する Collider2D 枠のビュー座標矩形を表す。
+    /// </summary>
+    struct SceneViewCollider2DOverlayRect
+    {
+        /// <summary>
+        /// ビュー中心基準の X 座標。
+        /// </summary>
+        float centerX = 0.0f;
+
+        /// <summary>
+        /// ビュー中心基準の Y 座標。
+        /// </summary>
+        float centerY = 0.0f;
+
+        /// <summary>
+        /// ビュー上の矩形幅。
+        /// </summary>
+        float width = 0.0f;
+
+        /// <summary>
+        /// ビュー上の矩形高さ。
+        /// </summary>
+        float height = 0.0f;
+
+        /// <summary>
+        /// 無効な Collider かを表す。
+        /// </summary>
+        bool disabled = false;
+
+        /// <summary>
+        /// Trigger Collider かを表す。
+        /// </summary>
+        bool trigger = false;
+    };
+
     /// <summary>
     /// SceneView の選択ヒット判定に使用する矩形ターゲットを表す。
     /// </summary>
@@ -82,5 +121,28 @@ namespace Xelqoria::Editor
         }
 
         return std::nullopt;
+    }
+
+    /// <summary>
+    /// Collider2DComponent から SceneView 用の枠表示矩形を生成する。
+    /// </summary>
+    /// <param name="transform">Entity の Transform。</param>
+    /// <param name="collider">表示対象の Collider2DComponent。</param>
+    /// <param name="camera">SceneView 用カメラ。</param>
+    /// <returns>ビュー座標上の Collider 枠。</returns>
+    inline SceneViewCollider2DOverlayRect BuildCollider2DOverlayRect(
+        const Game::Transform& transform,
+        const Game::Collider2DComponent& collider,
+        const EditorCamera2D& camera)
+    {
+        const Game::AabbCollider2D aabb = Game::BuildAabbCollider2D(transform, collider);
+        return SceneViewCollider2DOverlayRect{
+            camera.TransformWorldToViewX(aabb.center.x),
+            camera.TransformWorldToViewY(aabb.center.y),
+            camera.TransformWorldScale(aabb.halfSize.x * 2.0f),
+            camera.TransformWorldScale(aabb.halfSize.y * 2.0f),
+            false == collider.enabled,
+            collider.isTrigger
+        };
     }
 }

--- a/Editor/Source/SceneViewRenderer.cpp
+++ b/Editor/Source/SceneViewRenderer.cpp
@@ -11,6 +11,7 @@
 #include "EditorTheme.h"
 #include "ITextureAssetResolver.h"
 #include "RenderBackendBootstrap.h"
+#include "SceneViewOverlay.h"
 #include "Sprite.h"
 #include <Windows.h>
 #include <cstdint>
@@ -35,6 +36,7 @@ namespace Xelqoria::Editor
         constexpr float SceneGridLineThicknessPixels = 1.0f;
         constexpr float SceneAxisLineThicknessPixels = 2.0f;
         constexpr float SelectionOutlineThicknessPixels = 2.0f;
+        constexpr float Collider2DOutlineThicknessPixels = 2.0f;
         constexpr float SelectionPivotSizePixels = 8.0f;
         constexpr float SceneViewBorderThicknessPixels = 1.0f;
         constexpr float EditModeIndicatorLineThicknessPixels = 5.0f;
@@ -214,6 +216,69 @@ namespace Xelqoria::Editor
                 height,
                 fillColor
             });
+        }
+
+        /// <summary>
+        /// Collider2D の AABB 枠を SceneView 補助表示として描画する。
+        /// </summary>
+        /// <param name="renderer">描画に使用する SolidQuadRenderer。</param>
+        /// <param name="overlayRect">ビュー座標上の Collider 枠。</param>
+        void DrawCollider2DOverlay(
+            Graphics::SolidQuadRenderer& renderer,
+            const SceneViewCollider2DOverlayRect& overlayRect)
+        {
+            if (overlayRect.width <= 0.0f || overlayRect.height <= 0.0f)
+            {
+                return;
+            }
+
+            const float alpha = overlayRect.disabled ? 0.32f : 0.92f;
+            const std::array<float, 4> outlineColor = overlayRect.trigger
+                ? MakeColor(0.96f, 0.72f, 0.24f, alpha)
+                : MakeThemeColor(EditorThemes::XelqoriaDark.accent, alpha);
+            const float horizontalBorderY = (overlayRect.height * 0.5f) + (Collider2DOutlineThicknessPixels * 0.5f);
+            const float verticalBorderX = (overlayRect.width * 0.5f) + (Collider2DOutlineThicknessPixels * 0.5f);
+
+            renderer.Draw(Graphics::SolidQuad{
+                overlayRect.centerX,
+                overlayRect.centerY - horizontalBorderY,
+                overlayRect.width + Collider2DOutlineThicknessPixels * 2.0f,
+                Collider2DOutlineThicknessPixels,
+                outlineColor
+            });
+            renderer.Draw(Graphics::SolidQuad{
+                overlayRect.centerX,
+                overlayRect.centerY + horizontalBorderY,
+                overlayRect.width + Collider2DOutlineThicknessPixels * 2.0f,
+                Collider2DOutlineThicknessPixels,
+                outlineColor
+            });
+            renderer.Draw(Graphics::SolidQuad{
+                overlayRect.centerX - verticalBorderX,
+                overlayRect.centerY,
+                Collider2DOutlineThicknessPixels,
+                overlayRect.height + Collider2DOutlineThicknessPixels * 2.0f,
+                outlineColor
+            });
+            renderer.Draw(Graphics::SolidQuad{
+                overlayRect.centerX + verticalBorderX,
+                overlayRect.centerY,
+                Collider2DOutlineThicknessPixels,
+                overlayRect.height + Collider2DOutlineThicknessPixels * 2.0f,
+                outlineColor
+            });
+
+            if (overlayRect.trigger)
+            {
+                const float markerSize = 7.0f;
+                renderer.Draw(Graphics::SolidQuad{
+                    overlayRect.centerX,
+                    overlayRect.centerY - horizontalBorderY,
+                    markerSize,
+                    markerSize,
+                    outlineColor
+                });
+            }
         }
 
         /// <summary>
@@ -584,6 +649,21 @@ namespace Xelqoria::Editor
 
             if (nullptr != m_solidQuadRenderer && true == selectedEntityId.has_value())
             {
+                const auto selectedEntity = scene->FindEntity(*selectedEntityId);
+                if (selectedEntity.has_value())
+                {
+                    const auto collider2DComponent = selectedEntity->get().GetCollider2DComponent();
+                    if (collider2DComponent.has_value())
+                    {
+                        DrawCollider2DOverlay(
+                            *m_solidQuadRenderer,
+                            BuildCollider2DOverlayRect(
+                                selectedEntity->get().GetTransform(),
+                                collider2DComponent->get(),
+                                camera));
+                    }
+                }
+
                 const auto selectedTarget = std::find_if(
                     resolvedSprites.begin(),
                     resolvedSprites.end(),

--- a/Game/Source/Collider2DComponent.cpp
+++ b/Game/Source/Collider2DComponent.cpp
@@ -1,0 +1,28 @@
+#include "Collider2DComponent.h"
+
+#include <cmath>
+
+#include "Physics2D.h"
+#include "Transform.h"
+
+namespace Xelqoria::Game
+{
+	AabbCollider2D BuildAabbCollider2D(
+		const Transform& transform,
+		const Collider2DComponent& collider)
+	{
+		const float scaleX = transform.scale.x;
+		const float scaleY = transform.scale.y;
+
+		AabbCollider2D result{};
+		result.center = {
+			transform.position.x + (collider.offset.x * scaleX),
+			transform.position.y + (collider.offset.y * scaleY)
+		};
+		result.halfSize = {
+			(std::fabs(collider.size.x * scaleX)) * 0.5f,
+			(std::fabs(collider.size.y * scaleY)) * 0.5f
+		};
+		return result;
+	}
+}

--- a/Game/Source/Collider2DComponent.h
+++ b/Game/Source/Collider2DComponent.h
@@ -1,0 +1,61 @@
+#pragma once
+
+#include "Vector2.h"
+
+namespace Xelqoria::Game
+{
+	struct AabbCollider2D;
+	struct Transform;
+
+	/// <summary>
+	/// Collider2DComponent が表す 2D 形状種別。
+	/// </summary>
+	enum class Collider2DShapeType
+	{
+		/// <summary>
+		/// 軸平行矩形として扱う Box Collider。
+		/// </summary>
+		Box
+	};
+
+	/// <summary>
+	/// Entity に付与する 2D 当たり判定情報。
+	/// </summary>
+	struct Collider2DComponent
+	{
+		/// <summary>
+		/// Collider が有効かを表す。
+		/// </summary>
+		bool enabled = true;
+
+		/// <summary>
+		/// Trigger として扱うかを表す。
+		/// </summary>
+		bool isTrigger = false;
+
+		/// <summary>
+		/// Collider の形状種別。
+		/// </summary>
+		Collider2DShapeType shapeType = Collider2DShapeType::Box;
+
+		/// <summary>
+		/// Transform 位置からの 2D オフセット。
+		/// </summary>
+		Xelqoria::Math::Vector2 offset{};
+
+		/// <summary>
+		/// Collider の幅と高さ。
+		/// </summary>
+		Xelqoria::Math::Vector2 size{ 1.0f, 1.0f };
+	};
+
+	/// <summary>
+	/// Transform と Collider2DComponent から AABB Collider を生成する。
+	/// </summary>
+	/// <param name="transform">Entity の Transform。</param>
+	/// <param name="collider">AABB に変換する Collider2DComponent。</param>
+	/// <returns>Physics2D で扱う AABB Collider。</returns>
+	[[nodiscard]] AabbCollider2D BuildAabbCollider2D(
+		const Transform& transform,
+		const Collider2DComponent& collider);
+}

--- a/Game/Source/Entity.cpp
+++ b/Game/Source/Entity.cpp
@@ -4,6 +4,7 @@
 #include <string>
 #include <utility>
 
+#include "Collider2DComponent.h"
 #include "SpriteComponent.h"
 
 namespace Xelqoria::Game
@@ -120,5 +121,43 @@ namespace Xelqoria::Game
 	void Entity::RemoveSpriteComponent()
 	{
 		m_spriteComponent.reset();
+	}
+
+	void Entity::SetCollider2DComponent(const Collider2DComponent& collider2DComponent)
+	{
+		m_collider2DComponent = collider2DComponent;
+	}
+
+	void Entity::SetCollider2DComponent(Collider2DComponent&& collider2DComponent)
+	{
+		m_collider2DComponent = std::move(collider2DComponent);
+	}
+
+	std::optional<std::reference_wrapper<Collider2DComponent>> Entity::GetCollider2DComponent()
+	{
+		if (false == m_collider2DComponent.has_value()) {
+			return std::nullopt;
+		}
+
+		return *m_collider2DComponent;
+	}
+
+	std::optional<std::reference_wrapper<const Collider2DComponent>> Entity::GetCollider2DComponent() const
+	{
+		if (false == m_collider2DComponent.has_value()) {
+			return std::nullopt;
+		}
+
+		return *m_collider2DComponent;
+	}
+
+	bool Entity::HasCollider2DComponent() const
+	{
+		return m_collider2DComponent.has_value();
+	}
+
+	void Entity::RemoveCollider2DComponent()
+	{
+		m_collider2DComponent.reset();
 	}
 }

--- a/Game/Source/Entity.h
+++ b/Game/Source/Entity.h
@@ -5,6 +5,7 @@
 #include <optional>
 #include <string>
 
+#include "Collider2DComponent.h"
 #include "SpriteComponent.h"
 #include "Transform.h"
 
@@ -152,10 +153,46 @@ namespace Xelqoria::Game
 		/// </summary>
 		void RemoveSpriteComponent();
 
+		/// <summary>
+		/// Collider2DComponent を Entity に設定する。
+		/// </summary>
+		/// <param name="collider2DComponent">設定する Collider2DComponent。</param>
+		void SetCollider2DComponent(const Collider2DComponent& collider2DComponent);
+
+		/// <summary>
+		/// Collider2DComponent を Entity に設定する。
+		/// </summary>
+		/// <param name="collider2DComponent">設定する Collider2DComponent。</param>
+		void SetCollider2DComponent(Collider2DComponent&& collider2DComponent);
+
+		/// <summary>
+		/// Entity に設定されている Collider2DComponent を取得する。
+		/// </summary>
+		/// <returns>Collider2DComponent。未設定の場合は空。</returns>
+		std::optional<std::reference_wrapper<Collider2DComponent>> GetCollider2DComponent();
+
+		/// <summary>
+		/// Entity に設定されている Collider2DComponent を取得する。
+		/// </summary>
+		/// <returns>読み取り専用の Collider2DComponent。未設定時は空。</returns>
+		std::optional<std::reference_wrapper<const Collider2DComponent>> GetCollider2DComponent() const;
+
+		/// <summary>
+		/// Entity に Collider2DComponent が設定されているかを取得する。
+		/// </summary>
+		/// <returns>設定済みの場合は true。</returns>
+		bool HasCollider2DComponent() const;
+
+		/// <summary>
+		/// Entity から Collider2DComponent を取り外す。
+		/// </summary>
+		void RemoveCollider2DComponent();
+
 	private:
 		EntityId m_id = 0;
 		std::string m_name{};
 		Transform m_transform{};
 		std::optional<SpriteComponent> m_spriteComponent{};
+		std::optional<Collider2DComponent> m_collider2DComponent{};
 	};
 }

--- a/Game/Source/SceneSaveFormat.h
+++ b/Game/Source/SceneSaveFormat.h
@@ -6,6 +6,7 @@
 #include <string_view>
 
 #include "AssetId.h"
+#include "Collider2DComponent.h"
 #include "Entity.h"
 #include "Transform.h"
 
@@ -17,9 +18,9 @@ namespace Xelqoria::Game
 	inline constexpr std::string_view SceneSaveFormatMagic = "xelqoria.scene";
 
 	/// <summary>
-	/// Scene 保存フォーマットの初期バージョンを表す。
+	/// Scene 保存フォーマットの現在バージョンを表す。
 	/// </summary>
-	inline constexpr std::uint32_t SceneSaveFormatVersion = 1;
+	inline constexpr std::uint32_t SceneSaveFormatVersion = 2;
 
 	/// <summary>
 	/// 将来拡張用フィールドを配置する接頭辞を表す。
@@ -46,6 +47,37 @@ namespace Xelqoria::Game
 		/// Entity に関連付ける Material アセット参照を表す。
 		/// </summary>
 		Core::AssetId materialAssetRef{};
+	};
+
+	/// <summary>
+	/// Scene 保存時に 1 Entity 分の Collider2DComponent を表す。
+	/// </summary>
+	struct SceneCollider2DRecord
+	{
+		/// <summary>
+		/// Collider が有効かを表す。
+		/// </summary>
+		bool enabled = true;
+
+		/// <summary>
+		/// Trigger として扱うかを表す。
+		/// </summary>
+		bool isTrigger = false;
+
+		/// <summary>
+		/// Collider の形状種別。
+		/// </summary>
+		Collider2DShapeType shapeType = Collider2DShapeType::Box;
+
+		/// <summary>
+		/// Transform 位置からの 2D オフセット。
+		/// </summary>
+		Xelqoria::Math::Vector2 offset{};
+
+		/// <summary>
+		/// Collider の幅と高さ。
+		/// </summary>
+		Xelqoria::Math::Vector2 size{ 1.0f, 1.0f };
 	};
 
 	/// <summary>
@@ -89,6 +121,16 @@ namespace Xelqoria::Game
 		/// 未設定の Entity では空を許容する。
 		/// </summary>
 		std::optional<SceneMaterialRefRecord> materialRef{};
+
+		/// <summary>
+		/// Collider2DComponent を保持しているかを表す。
+		/// </summary>
+		bool hasCollider2DComponent = false;
+
+		/// <summary>
+		/// 保存対象の Collider2DComponent を表す。
+		/// </summary>
+		std::optional<SceneCollider2DRecord> collider2D{};
 	};
 
 	/// <summary>
@@ -97,6 +139,7 @@ namespace Xelqoria::Game
 	inline constexpr std::string_view SceneSaveFormatDocumentation =
 		R"(magic=xelqoria.scene
 version=1
+version=2
 entity.<index>.id=<EntityId>
 entity.<index>.name="<EntityName>"
 entity.<index>.hasSpriteComponent=<true|false>
@@ -105,5 +148,11 @@ entity.<index>.transform.rotation=<x>,<y>,<z>
 entity.<index>.transform.scale=<x>,<y>,<z>
 entity.<index>.spriteRef=<SpriteAssetId>
 entity.<index>.materialRef=<MaterialAssetId>
+entity.<index>.hasCollider2DComponent=<true|false>
+entity.<index>.collider2D.enabled=<true|false>
+entity.<index>.collider2D.isTrigger=<true|false>
+entity.<index>.collider2D.shapeType=Box
+entity.<index>.collider2D.offset=<x>,<y>
+entity.<index>.collider2D.size=<x>,<y>
 entity.<index>.extensions.<name>=<reserved>)";
 }

--- a/Game/Source/SceneTextReader.cpp
+++ b/Game/Source/SceneTextReader.cpp
@@ -14,6 +14,7 @@
 #include <system_error>
 #include <utility>
 #include <AssetId.h>
+#include "Collider2DComponent.h"
 #include "Scene.h"
 #include "SpriteComponent.h"
 #include "Transform.h"
@@ -147,6 +148,11 @@ namespace
 				return index == 2 ? std::optional<Xelqoria::Math::Vector3>(vector) : std::nullopt;
 			}
 
+			if (index == 2)
+			{
+				return std::nullopt;
+			}
+
 			cursor = separator + 1;
 		}
 
@@ -156,6 +162,66 @@ namespace
 		}
 
 		return vector;
+	}
+
+	/// <summary>
+	/// `x,y` 形式の文字列を Vector2 へ変換する。
+	/// </summary>
+	/// <param name="value">変換対象の文字列。</param>
+	/// <returns>変換に成功した Vector2。失敗時は nullopt。</returns>
+	std::optional<Xelqoria::Math::Vector2> ParseVector2(std::string_view value)
+	{
+		Xelqoria::Math::Vector2 vector{};
+		std::size_t cursor = 0;
+		float* components[2] = { &vector.x, &vector.y };
+
+		for (int index = 0; index < 2; ++index)
+		{
+			const std::size_t separator = value.find(',', cursor);
+			const std::string_view token = separator == std::string_view::npos
+				? value.substr(cursor)
+				: value.substr(cursor, separator - cursor);
+			const auto parsedComponent = ParseFloat(Trim(token));
+			if (false == parsedComponent.has_value())
+			{
+				return std::nullopt;
+			}
+
+			*components[index] = *parsedComponent;
+			if (separator == std::string_view::npos)
+			{
+				return index == 1 ? std::optional<Xelqoria::Math::Vector2>(vector) : std::nullopt;
+			}
+
+			if (index == 1)
+			{
+				return std::nullopt;
+			}
+
+			cursor = separator + 1;
+		}
+
+		if (value.find(',', cursor) != std::string_view::npos)
+		{
+			return std::nullopt;
+		}
+
+		return vector;
+	}
+
+	/// <summary>
+	/// Collider2D の shapeType 文字列を変換する。
+	/// </summary>
+	/// <param name="value">変換対象の文字列。</param>
+	/// <returns>変換に成功した shapeType。失敗時は nullopt。</returns>
+	std::optional<Xelqoria::Game::Collider2DShapeType> ParseCollider2DShapeType(std::string_view value)
+	{
+		if (value == "Box")
+		{
+			return Xelqoria::Game::Collider2DShapeType::Box;
+		}
+
+		return std::nullopt;
 	}
 
 	/// <summary>
@@ -233,6 +299,22 @@ namespace
 			return std::nullopt;
 		}
 
+		if (fieldKey == "hasCollider2DComponent")
+		{
+			const auto hasCollider2DComponent = ParseBool(value);
+			if (false == hasCollider2DComponent.has_value())
+			{
+				return MakeError(lineNumber, key, "hasCollider2DComponent は true または false である必要があります。");
+			}
+
+			record.hasCollider2DComponent = *hasCollider2DComponent;
+			if (*hasCollider2DComponent && false == record.collider2D.has_value())
+			{
+				record.collider2D = Xelqoria::Game::SceneCollider2DRecord{};
+			}
+			return std::nullopt;
+		}
+
 		if (fieldKey == "transform.position")
 		{
 			const auto parsedVector = ParseVector3(value);
@@ -280,6 +362,96 @@ namespace
 		{
 			record.hasSpriteComponent = true;
 			record.materialRef = Xelqoria::Game::SceneMaterialRefRecord{ Xelqoria::Core::AssetId(value) };
+			return std::nullopt;
+		}
+
+		if (fieldKey == "collider2D.enabled")
+		{
+			const auto enabled = ParseBool(value);
+			if (false == enabled.has_value())
+			{
+				return MakeError(lineNumber, key, "collider2D.enabled は true または false である必要があります。");
+			}
+
+			record.hasCollider2DComponent = true;
+			if (false == record.collider2D.has_value())
+			{
+				record.collider2D = Xelqoria::Game::SceneCollider2DRecord{};
+			}
+			record.collider2D->enabled = *enabled;
+			return std::nullopt;
+		}
+
+		if (fieldKey == "collider2D.isTrigger")
+		{
+			const auto isTrigger = ParseBool(value);
+			if (false == isTrigger.has_value())
+			{
+				return MakeError(lineNumber, key, "collider2D.isTrigger は true または false である必要があります。");
+			}
+
+			record.hasCollider2DComponent = true;
+			if (false == record.collider2D.has_value())
+			{
+				record.collider2D = Xelqoria::Game::SceneCollider2DRecord{};
+			}
+			record.collider2D->isTrigger = *isTrigger;
+			return std::nullopt;
+		}
+
+		if (fieldKey == "collider2D.shapeType")
+		{
+			const auto shapeType = ParseCollider2DShapeType(value);
+			if (false == shapeType.has_value())
+			{
+				return MakeError(lineNumber, key, "collider2D.shapeType は Box である必要があります。");
+			}
+
+			record.hasCollider2DComponent = true;
+			if (false == record.collider2D.has_value())
+			{
+				record.collider2D = Xelqoria::Game::SceneCollider2DRecord{};
+			}
+			record.collider2D->shapeType = *shapeType;
+			return std::nullopt;
+		}
+
+		if (fieldKey == "collider2D.offset")
+		{
+			const auto offset = ParseVector2(value);
+			if (false == offset.has_value())
+			{
+				return MakeError(lineNumber, key, "collider2D.offset は x,y 形式である必要があります。");
+			}
+
+			record.hasCollider2DComponent = true;
+			if (false == record.collider2D.has_value())
+			{
+				record.collider2D = Xelqoria::Game::SceneCollider2DRecord{};
+			}
+			record.collider2D->offset = *offset;
+			return std::nullopt;
+		}
+
+		if (fieldKey == "collider2D.size")
+		{
+			const auto size = ParseVector2(value);
+			if (false == size.has_value())
+			{
+				return MakeError(lineNumber, key, "collider2D.size は x,y 形式である必要があります。");
+			}
+
+			if (size->x <= 0.0f || size->y <= 0.0f)
+			{
+				return MakeError(lineNumber, key, "collider2D.size は 0 より大きい必要があります。");
+			}
+
+			record.hasCollider2DComponent = true;
+			if (false == record.collider2D.has_value())
+			{
+				record.collider2D = Xelqoria::Game::SceneCollider2DRecord{};
+			}
+			record.collider2D->size = *size;
 			return std::nullopt;
 		}
 
@@ -376,7 +548,7 @@ namespace Xelqoria::Game
 			return MakeError(0, "magic", "SceneSaveFormatMagic と一致する magic が必要です。");
 		}
 
-		if (false == version.has_value() || *version != SceneSaveFormatVersion)
+		if (false == version.has_value() || (*version != 1 && *version != SceneSaveFormatVersion))
 		{
 			return MakeError(0, "version", "対応していない Scene 保存バージョンです。");
 		}
@@ -416,6 +588,17 @@ namespace Xelqoria::Game
 				}
 
 				entity.SetSpriteComponent(spriteComponent);
+			}
+			if (record.hasCollider2DComponent || record.collider2D.has_value())
+			{
+				const SceneCollider2DRecord colliderRecord = record.collider2D.value_or(SceneCollider2DRecord{});
+				entity.SetCollider2DComponent(Collider2DComponent{
+					colliderRecord.enabled,
+					colliderRecord.isTrigger,
+					colliderRecord.shapeType,
+					colliderRecord.offset,
+					colliderRecord.size
+				});
 			}
 		}
 

--- a/Game/Source/SceneTextWriter.cpp
+++ b/Game/Source/SceneTextWriter.cpp
@@ -8,6 +8,7 @@
 #include <string>
 #include <ios>
 #include "Scene.h"
+#include <Vector2.h>
 #include <Vector3.h>
 
 namespace
@@ -20,6 +21,16 @@ namespace
 	void AppendVector3(std::ostringstream& stream, const Xelqoria::Math::Vector3& value)
 	{
 		stream << value.x << "," << value.y << "," << value.z;
+	}
+
+	/// <summary>
+	/// Vector2 をシーン保存形式の `x,y` 文字列として追記する。
+	/// </summary>
+	/// <param name="stream">出力先ストリーム。</param>
+	/// <param name="value">追記するベクトル値。</param>
+	void AppendVector2(std::ostringstream& stream, const Xelqoria::Math::Vector2& value)
+	{
+		stream << value.x << "," << value.y;
 	}
 
 	/// <summary>
@@ -72,6 +83,22 @@ namespace Xelqoria::Game
 				{
 					stream << prefix << ".materialRef=" << spriteComponent->get().materialAssetRef.GetValue() << "\n";
 				}
+			}
+
+			const auto collider2DComponent = entity.GetCollider2DComponent();
+			stream << prefix << ".hasCollider2DComponent=" << (collider2DComponent.has_value() ? "true" : "false") << "\n";
+			if (collider2DComponent.has_value())
+			{
+				const Collider2DComponent& collider = collider2DComponent->get();
+				stream << prefix << ".collider2D.enabled=" << (collider.enabled ? "true" : "false") << "\n";
+				stream << prefix << ".collider2D.isTrigger=" << (collider.isTrigger ? "true" : "false") << "\n";
+				stream << prefix << ".collider2D.shapeType=Box\n";
+				stream << prefix << ".collider2D.offset=";
+				AppendVector2(stream, collider.offset);
+				stream << "\n";
+				stream << prefix << ".collider2D.size=";
+				AppendVector2(stream, collider.size);
+				stream << "\n";
 			}
 		}
 

--- a/Game/Xelqoria.Game.vcxproj
+++ b/Game/Xelqoria.Game.vcxproj
@@ -30,6 +30,7 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
+    <ClCompile Include="Source\Collider2DComponent.cpp" />
     <ClCompile Include="Source\Assets\SpriteAssetRegistry.cpp" />
     <ClCompile Include="Source\Assets\SpriteAssetLoader.cpp" />
     <ClCompile Include="Source\Assets\SpriteMaterialAssetLoader.cpp" />
@@ -43,6 +44,7 @@
     <ClCompile Include="Source\Transform.cpp" />
   </ItemGroup>
   <ItemGroup>
+    <ClInclude Include="Source\Collider2DComponent.h" />
     <ClInclude Include="Source\Assets\ISpriteAssetResolver.h" />
     <ClInclude Include="Source\Assets\IMaterialAssetResolver.h" />
     <ClInclude Include="Source\Assets\SpriteAsset.h" />

--- a/Game/Xelqoria.Game.vcxproj.filters
+++ b/Game/Xelqoria.Game.vcxproj.filters
@@ -11,6 +11,9 @@
     </Filter>
   </ItemGroup>
   <ItemGroup>
+    <ClCompile Include="Source\Collider2DComponent.cpp">
+      <Filter>Source</Filter>
+    </ClCompile>
     <ClCompile Include="Source\Assets\SpriteAssetRegistry.cpp">
       <Filter>Source\Assets</Filter>
     </ClCompile>
@@ -46,6 +49,9 @@
     </ClCompile>
   </ItemGroup>
   <ItemGroup>
+    <ClInclude Include="Source\Collider2DComponent.h">
+      <Filter>Source</Filter>
+    </ClInclude>
     <ClInclude Include="Source\Assets\ISpriteAssetResolver.h">
       <Filter>Source\Assets</Filter>
     </ClInclude>

--- a/docs/plans/issue-290-collider2d-game.md
+++ b/docs/plans/issue-290-collider2d-game.md
@@ -1,0 +1,54 @@
+# ExecPlan: issue-290 Game 層に Collider2DComponent と AABB 変換を追加する
+
+## 目的
+
+Entity に 2D Collider 情報を保持する Game 層の最小構成を追加し、既存 Physics2D の `AabbCollider2D` へ変換できるようにする。
+
+## 対象範囲
+
+- 変更対象プロジェクト: `Game`, `Editor`, `tests/Game`, `tests/Editor`
+- 変更対象ファイル: `Game/Source/Collider2DComponent.*`, `Game/Source/Entity.*`, `Editor/Source/SceneEditingOperations.*`
+- 変更対象クラス: `Entity`, `SceneEditingOperations`
+- 影響する機能: Entity の Component 保持、Entity 複製、Scene 編集操作、AABB 変換
+
+## 前提
+
+- parent issue: issue-289
+- ブランチ運用ルール: `docs/agents/branch-rules.md`
+- parent issue ブランチ: `issue-289`
+- この child issue のブランチ: `issue-290`
+- PR の向き: `issue-289`
+
+## 実装方針
+
+Collider2DComponent は Game 層の Component として追加し、Graphics / RHI / Backends には依存させない。
+
+初期形状は `Box` のみにし、Transform の position / scale と Collider の offset / size から Physics2D の `AabbCollider2D` を生成する。`rotation.z` は AABB 変換に反映しない。
+
+## 作業手順
+
+1. `Collider2DShapeType` と `Collider2DComponent` を追加する
+2. `BuildAabbCollider2D` を追加する
+3. `Entity` に Collider2DComponent の保持、取得、有無判定、削除 API を追加する
+4. `SceneEditingOperations` に追加・削除 API と複製時コピーを追加する
+5. Game / Editor の関連テストを追加する
+6. レイヤー依存チェック、Game / Editor テストのビルドと実行を行う
+
+## 検証方法
+
+- `dotnet run --project tools/LayerDependencyChecker/LayerDependencyChecker.csproj -c Debug -- "D:\github\Xelqoria"`
+- `MSBuild.exe tests\Game\Xelqoria.Tests.Game.vcxproj /m /p:Configuration=Debug /p:Platform=x64 /v:minimal`
+- `MSBuild.exe tests\Editor\Xelqoria.Tests.Editor.vcxproj /m /p:Configuration=Debug /p:Platform=x64 /v:minimal`
+- `artifacts\x64\Debug\Xelqoria.Tests.Game.exe`
+- `artifacts\x64\Debug\Xelqoria.Tests.Editor.exe`
+
+## 完了条件
+
+- Entity に Collider2DComponent を追加、取得、有無判定、削除できる
+- SceneEditingOperations の追加・削除 API が変更有無を返す
+- Entity 複製時に Collider2DComponent がコピーされる
+- Transform と Collider2DComponent から AABB を生成できる
+- 負の scale は halfSize に絶対値として反映され、rotation.z は影響しない
+- レイヤー責務に違反していない
+- 関連テストが通る
+- `issue-290` から `issue-289` への PR が作成されている

--- a/docs/plans/issue-291-collider2d-scene-serialization.md
+++ b/docs/plans/issue-291-collider2d-scene-serialization.md
@@ -1,0 +1,52 @@
+# ExecPlan: issue-291 Scene 保存・読み込みを Collider2DComponent に対応する
+
+## 目的
+
+Scene 保存形式を Collider2DComponent に対応させ、既存 version=1 Scene の互換読み込みを維持する。
+
+## 対象範囲
+
+- 変更対象プロジェクト: `Game`, `tests/Game`
+- 変更対象ファイル: `Game/Source/SceneSaveFormat.h`, `Game/Source/SceneTextWriter.cpp`, `Game/Source/SceneTextReader.cpp`, `tests/Game/Source/TransformTests.cpp`
+- 変更対象クラス: `SceneTextWriter`, `SceneTextReader`, `SceneEntitySaveRecord`
+- 影響する機能: Scene 保存・読み込み、保存形式バージョン、Collider2DComponent 復元
+
+## 前提
+
+- parent issue: issue-289
+- 先行 issue: issue-290
+- ブランチ運用ルール: `docs/agents/branch-rules.md`
+- parent issue ブランチ: `issue-289`
+- この child issue のブランチ: `issue-291`
+- PR の向き: `issue-289`
+
+## 実装方針
+
+Scene 保存時は現在バージョンを `2` とし、Entity ごとに `hasCollider2DComponent` を必ず出力する。
+
+読み込み時は `version=1` を Collider2DComponent なしとして受け入れ、`version=2` では Collider2DComponent の各フィールドを読み込む。bool、shapeType、Vector2、非正の size は読み込みエラーにする。
+
+## 作業手順
+
+1. Scene 保存形式の現在バージョンを 2 に更新する
+2. Collider2D 用保存レコードを追加する
+3. SceneTextWriter で Collider2DComponent を出力する
+4. SceneTextReader で Collider2DComponent フィールドを解析・検証する
+5. version=1 互換読み込みと version=2 保存・読み込みのテストを追加する
+6. レイヤー依存チェックと Game テストを実行する
+
+## 検証方法
+
+- `dotnet run --project tools/LayerDependencyChecker/LayerDependencyChecker.csproj -c Debug -- "D:\github\Xelqoria"`
+- `MSBuild.exe tests\Game\Xelqoria.Tests.Game.vcxproj /m /p:Configuration=Debug /p:Platform=x64 /v:minimal`
+- `artifacts\x64\Debug\Xelqoria.Tests.Game.exe`
+
+## 完了条件
+
+- Scene 保存時に Collider2DComponent の有無と各フィールドが出力される
+- Collider2DComponent がない Entity は `hasCollider2DComponent=false` のみ出力される
+- Scene 読み込み時に Collider2DComponent が復元される
+- `version=1` Scene は Collider2DComponent なしとして読み込める
+- 不正な bool、shapeType、offset、size、非正の size は読み込みエラーになる
+- 関連テストが通る
+- `issue-291` から `issue-289` への PR が作成されている

--- a/docs/plans/issue-292-collider2d-inspector-hierarchy.md
+++ b/docs/plans/issue-292-collider2d-inspector-hierarchy.md
@@ -1,0 +1,50 @@
+# ExecPlan: issue-292 Editor の Inspector と Hierarchy を Collider2DComponent に対応する
+
+## 目的
+
+Editor 上で Collider2DComponent を追加、削除、編集できるようにし、Hierarchy 上でも Entity の Component として確認できるようにする。
+
+## 対象範囲
+
+- 変更対象プロジェクト: `Editor`, `tests/Editor`
+- 変更対象ファイル: `Editor/Source/EditorShell.*`, `Editor/Source/InspectorPanelController.*`, `Editor/Source/HierarchyPanelController.cpp`, `tests/Editor/Source/InspectorPanelControllerTests.cpp`
+- 変更対象クラス: `EditorShell`, `InspectorPanelController`, `HierarchyPanelController`
+- 影響する機能: Inspector Component 操作、Hierarchy 表示、Scene dirty 用の編集結果
+
+## 前提
+
+- parent issue: issue-289
+- 先行 issue: issue-290, issue-291
+- ブランチ運用ルール: `docs/agents/branch-rules.md`
+- parent issue ブランチ: `issue-289`
+- この child issue のブランチ: `issue-292`
+- PR の向き: `issue-289`
+
+## 実装方針
+
+Collider2DComponent は Entity 直接付与の Component として扱う。Inspector には追加・削除ボタンと、追加済み時の `enabled` / `isTrigger` / `shapeType` / `offset` / `size` 編集欄を追加する。
+
+`size.x` / `size.y` は 0 より大きい値のみ反映し、不正入力では Component 値を更新しない。編集結果は `InspectorApplyResult.changed` と `operationName` で Scene dirty と履歴記録の既存経路に乗せる。
+
+## 作業手順
+
+1. EditorShell に Collider2D 用 UI コントロールを追加する
+2. InspectorPanelController で Collider2DComponent の表示・追加・削除・編集を反映する
+3. Hierarchy に Collider2DComponent 行を表示する
+4. Inspector の純粋ロジックテストを追加する
+5. Editor テストのビルドと実行を行う
+
+## 検証方法
+
+- `MSBuild.exe tests\Editor\Xelqoria.Tests.Editor.vcxproj /m /p:Configuration=Debug /p:Platform=x64 /v:minimal`
+- `artifacts\x64\Debug\Xelqoria.Tests.Editor.exe`
+
+## 完了条件
+
+- Inspector に Collider2DComponent の Add / Remove 操作がある
+- 追加済み Collider2DComponent の enabled、isTrigger、offset、size を編集できる
+- 不正な size 入力では Component が更新されない
+- 編集後に `InspectorApplyResult.changed` が true になる
+- Hierarchy に `Collider2DComponent` が Entity の子要素として表示される
+- 関連テストが通る
+- `issue-292` から `issue-289` への PR が作成されている

--- a/docs/plans/issue-293-collider2d-sceneview-overlay.md
+++ b/docs/plans/issue-293-collider2d-sceneview-overlay.md
@@ -1,0 +1,52 @@
+# ExecPlan: issue-293 SceneView に Collider2D 枠表示を追加する
+
+## 目的
+
+選択中 Entity の Collider2DComponent を SceneView 上の Editor 補助表示として確認できるようにする。
+
+## 対象範囲
+
+- 変更対象プロジェクト: `Editor`, `tests/Editor`
+- 変更対象ファイル: `Editor/Source/SceneViewOverlay.h`, `Editor/Source/SceneViewRenderer.cpp`, `tests/Editor/Source/EditorCamera2DTests.cpp`
+- 変更対象クラス: `SceneViewRenderer`
+- 影響する機能: SceneView 選択 Entity 補助表示
+
+## 前提
+
+- parent issue: issue-289
+- 先行 issue: issue-290, issue-291, issue-292
+- ブランチ運用ルール: `docs/agents/branch-rules.md`
+- parent issue ブランチ: `issue-289`
+- この child issue のブランチ: `issue-293`
+- PR の向き: `issue-289`
+
+## 実装方針
+
+Collider2DComponent 自身には描画処理を持たせず、SceneViewRenderer が Editor 補助表示として描画する。
+
+Transform と Collider2DComponent から Game 層の `BuildAabbCollider2D` を使ってワールド AABB を生成し、SceneView カメラでビュー座標へ変換した矩形枠を描画する。`enabled == false` は薄く表示し、`isTrigger == true` は通常 Collider と色とマーカーで区別する。
+
+## 作業手順
+
+1. SceneView 用 Collider2D overlay rect 生成処理を追加する
+2. SceneViewRenderer で選択 Entity の Collider2D 枠を描画する
+3. Trigger / disabled の表示差を追加する
+4. overlay rect 生成テストを追加する
+5. Editor テストと Editor 本体ビルドを実行する
+
+## 検証方法
+
+- `MSBuild.exe tests\Editor\Xelqoria.Tests.Editor.vcxproj /m /p:Configuration=Debug /p:Platform=x64 /v:minimal`
+- `MSBuild.exe Editor\Xelqoria.Editor.vcxproj /m /p:Configuration=Debug /p:Platform=x64 /v:minimal`
+- `artifacts\x64\Debug\Xelqoria.Tests.Editor.exe`
+
+## 完了条件
+
+- 選択 Entity に Collider2DComponent がある場合、SceneView に AABB 枠が表示される
+- 枠は Transform position / scale / Collider offset / size を反映する
+- `rotation.z` は枠回転に影響しない
+- `enabled == false` は薄く表示される
+- `isTrigger == true` は通常 Collider と区別できる
+- Collider2DComponent 自身に描画処理を追加していない
+- 関連テストが通る
+- `issue-293` から `issue-289` への PR が作成されている

--- a/tests/Editor/Source/EditorCamera2DTests.cpp
+++ b/tests/Editor/Source/EditorCamera2DTests.cpp
@@ -1,7 +1,9 @@
 #include <gtest/gtest.h>
 
+#include "Collider2DComponent.h"
 #include "EditorCamera2D.h"
 #include "SceneViewOverlay.h"
+#include "Transform.h"
 
 TEST(EditorCamera2DTests, StoresPanZoomAndViewportState)
 {
@@ -123,4 +125,32 @@ TEST(EditorCamera2DTests, ReturnsNoHitWhenPointIsOutsideTargets)
     const auto selectedEntityId = Xelqoria::Editor::PickTopmostEntityAtWorldPoint(targets, 40.0f, 80.0f);
 
     EXPECT_FALSE(selectedEntityId.has_value());
+}
+
+TEST(EditorCamera2DTests, BuildsCollider2DOverlayRectFromAabbAndCamera)
+{
+    Xelqoria::Editor::EditorCamera2D camera;
+    camera.SetCenter(10.0f, -20.0f);
+    camera.SetZoom(2.0f);
+
+    Xelqoria::Game::Transform transform{};
+    transform.position = { 30.0f, -10.0f, 0.0f };
+    transform.rotation = { 0.0f, 0.0f, 90.0f };
+    transform.scale = { -2.0f, 3.0f, 1.0f };
+
+    Xelqoria::Game::Collider2DComponent collider{};
+    collider.enabled = false;
+    collider.isTrigger = true;
+    collider.offset = { 4.0f, 5.0f };
+    collider.size = { 6.0f, 8.0f };
+
+    const Xelqoria::Editor::SceneViewCollider2DOverlayRect overlayRect =
+        Xelqoria::Editor::BuildCollider2DOverlayRect(transform, collider, camera);
+
+    EXPECT_FLOAT_EQ(overlayRect.centerX, 24.0f);
+    EXPECT_FLOAT_EQ(overlayRect.centerY, 50.0f);
+    EXPECT_FLOAT_EQ(overlayRect.width, 24.0f);
+    EXPECT_FLOAT_EQ(overlayRect.height, 48.0f);
+    EXPECT_TRUE(overlayRect.disabled);
+    EXPECT_TRUE(overlayRect.trigger);
 }

--- a/tests/Editor/Source/InspectorPanelControllerTests.cpp
+++ b/tests/Editor/Source/InspectorPanelControllerTests.cpp
@@ -172,3 +172,32 @@ TEST(InspectorPanelControllerTests, ApplySpriteComponentActionSkipsAddWhenNoVisi
     EXPECT_FALSE(changed);
     EXPECT_FALSE(entity.HasSpriteComponent());
 }
+
+TEST(InspectorPanelControllerTests, ComputeCollider2DComponentActionStateReflectsAttachment)
+{
+    const auto detachedState =
+        Xelqoria::Editor::InspectorPanelController::ComputeCollider2DComponentActionState(false);
+
+    EXPECT_FALSE(detachedState.showColliderControls);
+    EXPECT_STREQ(L"Collider2DComponent (not attached)", detachedState.sectionLabel);
+    EXPECT_STREQ(L"Add Collider2DComponent", detachedState.buttonLabel);
+
+    const auto attachedState =
+        Xelqoria::Editor::InspectorPanelController::ComputeCollider2DComponentActionState(true);
+
+    EXPECT_TRUE(attachedState.showColliderControls);
+    EXPECT_STREQ(L"Collider2DComponent", attachedState.sectionLabel);
+    EXPECT_STREQ(L"Remove Collider2DComponent", attachedState.buttonLabel);
+}
+
+TEST(InspectorPanelControllerTests, ApplyCollider2DComponentActionTogglesComponent)
+{
+    Xelqoria::Game::Scene scene;
+    auto& entity = scene.CreateEntity();
+
+    EXPECT_TRUE(Xelqoria::Editor::InspectorPanelController::ApplyCollider2DComponentAction(entity));
+    EXPECT_TRUE(entity.HasCollider2DComponent());
+
+    EXPECT_TRUE(Xelqoria::Editor::InspectorPanelController::ApplyCollider2DComponentAction(entity));
+    EXPECT_FALSE(entity.HasCollider2DComponent());
+}

--- a/tests/Editor/Source/SceneEditingOperationsTests.cpp
+++ b/tests/Editor/Source/SceneEditingOperationsTests.cpp
@@ -2,6 +2,7 @@
 
 #include <string>
 
+#include "Collider2DComponent.h"
 #include "SceneEditingOperations.h"
 #include "SceneSerializer.h"
 
@@ -259,4 +260,56 @@ TEST(SceneEditingOperationsTests, RemoveSpriteComponentDetachesComponentAndSurvi
     const auto loadedEntity = loadResult.scene->FindEntity(entity.GetId());
     ASSERT_TRUE(loadedEntity.has_value());
     EXPECT_FALSE(loadedEntity->get().HasSpriteComponent());
+}
+
+TEST(SceneEditingOperationsTests, AddAndRemoveCollider2DComponentReturnWhetherChanged)
+{
+    Xelqoria::Game::Scene scene;
+    auto& entity = scene.CreateEntity();
+
+    EXPECT_TRUE(Xelqoria::Editor::SceneEditingOperations::AddCollider2DComponent(entity));
+    EXPECT_TRUE(entity.HasCollider2DComponent());
+    EXPECT_FALSE(Xelqoria::Editor::SceneEditingOperations::AddCollider2DComponent(entity));
+
+    const auto collider = entity.GetCollider2DComponent();
+    ASSERT_TRUE(collider.has_value());
+    EXPECT_TRUE(collider->get().enabled);
+    EXPECT_FALSE(collider->get().isTrigger);
+    EXPECT_EQ(Xelqoria::Game::Collider2DShapeType::Box, collider->get().shapeType);
+
+    EXPECT_TRUE(Xelqoria::Editor::SceneEditingOperations::RemoveCollider2DComponent(entity));
+    EXPECT_FALSE(entity.HasCollider2DComponent());
+    EXPECT_FALSE(Xelqoria::Editor::SceneEditingOperations::RemoveCollider2DComponent(entity));
+}
+
+TEST(SceneEditingOperationsTests, DuplicateSelectedEntityCopiesCollider2DComponent)
+{
+    Xelqoria::Game::Scene scene;
+    auto& sourceEntity = scene.CreateEntity();
+    sourceEntity.SetName("Collider");
+    sourceEntity.SetCollider2DComponent(Xelqoria::Game::Collider2DComponent{
+        false,
+        true,
+        Xelqoria::Game::Collider2DShapeType::Box,
+        { 3.0f, -4.0f },
+        { 5.0f, 6.0f }
+    });
+
+    const auto result =
+        Xelqoria::Editor::SceneEditingOperations::DuplicateSelectedEntity(scene, sourceEntity.GetId());
+
+    ASSERT_TRUE(result.changed);
+    ASSERT_TRUE(result.selectedEntityId.has_value());
+    const auto duplicateEntity = scene.FindEntity(*result.selectedEntityId);
+    ASSERT_TRUE(duplicateEntity.has_value());
+
+    const auto duplicateCollider = duplicateEntity->get().GetCollider2DComponent();
+    ASSERT_TRUE(duplicateCollider.has_value());
+    EXPECT_FALSE(duplicateCollider->get().enabled);
+    EXPECT_TRUE(duplicateCollider->get().isTrigger);
+    EXPECT_EQ(Xelqoria::Game::Collider2DShapeType::Box, duplicateCollider->get().shapeType);
+    EXPECT_FLOAT_EQ(3.0f, duplicateCollider->get().offset.x);
+    EXPECT_FLOAT_EQ(-4.0f, duplicateCollider->get().offset.y);
+    EXPECT_FLOAT_EQ(5.0f, duplicateCollider->get().size.x);
+    EXPECT_FLOAT_EQ(6.0f, duplicateCollider->get().size.y);
 }

--- a/tests/Game/Source/EntityTests.cpp
+++ b/tests/Game/Source/EntityTests.cpp
@@ -1,0 +1,44 @@
+#include <gtest/gtest.h>
+
+#include "Collider2DComponent.h"
+#include "Entity.h"
+
+TEST(EntityTests, Collider2DComponentCanBeSetReadAndRemoved)
+{
+	Xelqoria::Game::Entity entity(1);
+	Xelqoria::Game::Collider2DComponent collider{};
+	collider.enabled = false;
+	collider.isTrigger = true;
+	collider.offset = { 2.0f, -3.0f };
+	collider.size = { 4.0f, 5.0f };
+
+	entity.SetCollider2DComponent(collider);
+
+	ASSERT_TRUE(entity.HasCollider2DComponent());
+	const auto storedCollider = entity.GetCollider2DComponent();
+	ASSERT_TRUE(storedCollider.has_value());
+	EXPECT_FALSE(storedCollider->get().enabled);
+	EXPECT_TRUE(storedCollider->get().isTrigger);
+	EXPECT_FLOAT_EQ(2.0f, storedCollider->get().offset.x);
+	EXPECT_FLOAT_EQ(-3.0f, storedCollider->get().offset.y);
+	EXPECT_FLOAT_EQ(4.0f, storedCollider->get().size.x);
+	EXPECT_FLOAT_EQ(5.0f, storedCollider->get().size.y);
+
+	entity.RemoveCollider2DComponent();
+
+	EXPECT_FALSE(entity.HasCollider2DComponent());
+	EXPECT_FALSE(entity.GetCollider2DComponent().has_value());
+}
+
+TEST(EntityTests, DefaultCollider2DComponentUsesBoxDefaults)
+{
+	const Xelqoria::Game::Collider2DComponent collider{};
+
+	EXPECT_TRUE(collider.enabled);
+	EXPECT_FALSE(collider.isTrigger);
+	EXPECT_EQ(Xelqoria::Game::Collider2DShapeType::Box, collider.shapeType);
+	EXPECT_FLOAT_EQ(0.0f, collider.offset.x);
+	EXPECT_FLOAT_EQ(0.0f, collider.offset.y);
+	EXPECT_FLOAT_EQ(1.0f, collider.size.x);
+	EXPECT_FLOAT_EQ(1.0f, collider.size.y);
+}

--- a/tests/Game/Source/Physics2DTests.cpp
+++ b/tests/Game/Source/Physics2DTests.cpp
@@ -2,7 +2,9 @@
 
 #include <gtest/gtest.h>
 
+#include "Collider2DComponent.h"
 #include "Physics2D.h"
+#include "Transform.h"
 
 namespace
 {
@@ -114,4 +116,41 @@ TEST(Physics2DTests, SpatialHashRemovesDuplicatePairsAcrossCells)
 	ASSERT_EQ(pairs.size(), 1u);
 	EXPECT_EQ(pairs[0].first, 1u);
 	EXPECT_EQ(pairs[0].second, 2u);
+}
+
+TEST(Physics2DTests, BuildAabbCollider2DUsesTransformPositionOffsetAndScale)
+{
+	Xelqoria::Game::Transform transform{};
+	transform.position = { 10.0f, -20.0f, 5.0f };
+	transform.scale = { 2.0f, 3.0f, 1.0f };
+	Xelqoria::Game::Collider2DComponent collider{};
+	collider.offset = { 4.0f, -5.0f };
+	collider.size = { 6.0f, 8.0f };
+
+	const Xelqoria::Game::AabbCollider2D aabb =
+		Xelqoria::Game::BuildAabbCollider2D(transform, collider);
+
+	EXPECT_TRUE(IsEqual(aabb.center.x, 18.0f));
+	EXPECT_TRUE(IsEqual(aabb.center.y, -35.0f));
+	EXPECT_TRUE(IsEqual(aabb.halfSize.x, 6.0f));
+	EXPECT_TRUE(IsEqual(aabb.halfSize.y, 12.0f));
+}
+
+TEST(Physics2DTests, BuildAabbCollider2DUsesAbsoluteScaleAndIgnoresRotationZ)
+{
+	Xelqoria::Game::Transform transform{};
+	transform.position = { 1.0f, 2.0f, 0.0f };
+	transform.rotation = { 0.0f, 0.0f, 90.0f };
+	transform.scale = { -2.0f, -4.0f, 1.0f };
+	Xelqoria::Game::Collider2DComponent collider{};
+	collider.offset = { 3.0f, 5.0f };
+	collider.size = { 7.0f, 11.0f };
+
+	const Xelqoria::Game::AabbCollider2D aabb =
+		Xelqoria::Game::BuildAabbCollider2D(transform, collider);
+
+	EXPECT_TRUE(IsEqual(aabb.center.x, -5.0f));
+	EXPECT_TRUE(IsEqual(aabb.center.y, -18.0f));
+	EXPECT_TRUE(IsEqual(aabb.halfSize.x, 7.0f));
+	EXPECT_TRUE(IsEqual(aabb.halfSize.y, 22.0f));
 }

--- a/tests/Game/Source/TransformTests.cpp
+++ b/tests/Game/Source/TransformTests.cpp
@@ -18,6 +18,7 @@
 #include "Texture2D.h"
 #include "Assets/SpriteMaterialAssetLoader.h"
 #include "Assets/SpriteMaterialAssetRegistry.h"
+#include "Collider2DComponent.h"
 #include "Transform.h"
 
 namespace
@@ -52,7 +53,7 @@ namespace
 
 		const std::string sceneSaveSnapshot =
 			"magic=xelqoria.scene\n"
-			"version=1\n"
+			"version=2\n"
 			"entity.0.id=1\n"
 			"entity.0.name=\"Player\"\n"
 			"entity.0.transform.position=12.500000,-8.000000,3.000000\n"
@@ -60,12 +61,14 @@ namespace
 			"entity.0.transform.scale=1.000000,2.000000,1.000000\n"
 			"entity.0.hasSpriteComponent=true\n"
 			"entity.0.spriteRef=sprites/player\n"
+			"entity.0.hasCollider2DComponent=false\n"
 			"entity.1.id=2\n"
 			"entity.1.name=\"Background Layer\"\n"
 			"entity.1.transform.position=-32.000000,64.000000,0.000000\n"
 			"entity.1.transform.rotation=0.000000,0.000000,0.000000\n"
 			"entity.1.transform.scale=4.000000,4.000000,1.000000\n"
-			"entity.1.hasSpriteComponent=false\n";
+			"entity.1.hasSpriteComponent=false\n"
+			"entity.1.hasCollider2DComponent=false\n";
 
 		return Xelqoria::Game::SceneSerializer::SaveToText(saveScene) == sceneSaveSnapshot;
 	}
@@ -450,7 +453,7 @@ TEST(TransformTests, TransformAndSceneRuntimeApiWorks)
 		EXPECT_NE(missingAssetLogs[1].find("sprites/missing"), std::string::npos);
 
 		EXPECT_EQ(Xelqoria::Game::SceneSaveFormatMagic, std::string_view("xelqoria.scene"));
-		EXPECT_EQ(Xelqoria::Game::SceneSaveFormatVersion, static_cast<std::uint32_t>(1));
+		EXPECT_EQ(Xelqoria::Game::SceneSaveFormatVersion, static_cast<std::uint32_t>(2));
 		EXPECT_EQ(Xelqoria::Game::SceneSaveExtensionFieldPrefix, std::string_view("extensions."));
 
 		const std::string sceneSaveFormatDocumentation(Xelqoria::Game::SceneSaveFormatDocumentation);
@@ -458,26 +461,45 @@ TEST(TransformTests, TransformAndSceneRuntimeApiWorks)
 		EXPECT_NE(sceneSaveFormatDocumentation.find("entity.<index>.name=\"<EntityName>\""), std::string::npos);
 		EXPECT_NE(sceneSaveFormatDocumentation.find("entity.<index>.hasSpriteComponent=<true|false>"), std::string::npos);
 		EXPECT_NE(sceneSaveFormatDocumentation.find("entity.<index>.spriteRef=<SpriteAssetId>"), std::string::npos);
+		EXPECT_NE(sceneSaveFormatDocumentation.find("entity.<index>.hasCollider2DComponent=<true|false>"), std::string::npos);
+		EXPECT_NE(sceneSaveFormatDocumentation.find("entity.<index>.collider2D.shapeType=Box"), std::string::npos);
 		EXPECT_NE(sceneSaveFormatDocumentation.find("entity.<index>.extensions.<name>=<reserved>"), std::string::npos);
 
 		Xelqoria::Game::SceneEntitySaveRecord sceneSaveRecord{};
 		sceneSaveRecord.entityId = 77;
 		sceneSaveRecord.name = "Scene Save Record";
 		sceneSaveRecord.hasSpriteComponent = true;
+		sceneSaveRecord.hasCollider2DComponent = true;
 		sceneSaveRecord.transform.SetPosition(4.0f, 5.0f, 6.0f);
 		sceneSaveRecord.transform.rotation = { 0.0f, 0.0f, 45.0f };
 		sceneSaveRecord.transform.scale = { 2.0f, 3.0f, 1.0f };
 		sceneSaveRecord.spriteRef = Xelqoria::Game::SceneSpriteRefRecord{ "sprites/player" };
+		sceneSaveRecord.collider2D = Xelqoria::Game::SceneCollider2DRecord{
+			false,
+			true,
+			Xelqoria::Game::Collider2DShapeType::Box,
+			{ 2.0f, -3.0f },
+			{ 4.0f, 5.0f }
+		};
 
 	EXPECT_EQ(static_cast<Xelqoria::Game::EntityId>(77), sceneSaveRecord.entityId);
 	EXPECT_EQ("Scene Save Record", sceneSaveRecord.name);
 	EXPECT_FALSE(sceneSaveRecord.hasName);
 	EXPECT_TRUE(sceneSaveRecord.hasSpriteComponent);
+	EXPECT_TRUE(sceneSaveRecord.hasCollider2DComponent);
 		EXPECT_TRUE(IsEqual(sceneSaveRecord.transform.position.x, 4.0f));
 		EXPECT_TRUE(IsEqual(sceneSaveRecord.transform.position.y, 5.0f));
 		EXPECT_TRUE(IsEqual(sceneSaveRecord.transform.position.z, 6.0f));
 		ASSERT_TRUE(sceneSaveRecord.spriteRef.has_value());
 		EXPECT_EQ(sceneSaveRecord.spriteRef->spriteAssetRef, Xelqoria::Core::AssetId("sprites/player"));
+		ASSERT_TRUE(sceneSaveRecord.collider2D.has_value());
+		EXPECT_FALSE(sceneSaveRecord.collider2D->enabled);
+		EXPECT_TRUE(sceneSaveRecord.collider2D->isTrigger);
+		EXPECT_EQ(sceneSaveRecord.collider2D->shapeType, Xelqoria::Game::Collider2DShapeType::Box);
+		EXPECT_FLOAT_EQ(2.0f, sceneSaveRecord.collider2D->offset.x);
+		EXPECT_FLOAT_EQ(-3.0f, sceneSaveRecord.collider2D->offset.y);
+		EXPECT_FLOAT_EQ(4.0f, sceneSaveRecord.collider2D->size.x);
+		EXPECT_FLOAT_EQ(5.0f, sceneSaveRecord.collider2D->size.y);
 
 		EXPECT_TRUE(VerifySceneSaveSerialization());
 		EXPECT_TRUE(VerifySceneSaveRoundTrip());
@@ -594,6 +616,107 @@ TEST(TransformTests, SceneSerializerRoundTripPreservesMaterialRef)
 	EXPECT_EQ(
 		Xelqoria::Core::AssetId("materials/player.material"),
 		loadedSpriteComponent->get().materialAssetRef);
+}
+
+TEST(TransformTests, SceneSerializerRoundTripPreservesCollider2DComponent)
+{
+	Xelqoria::Game::Scene scene;
+	auto& entity = scene.CreateEntity();
+	entity.SetCollider2DComponent(Xelqoria::Game::Collider2DComponent{
+		false,
+		true,
+		Xelqoria::Game::Collider2DShapeType::Box,
+		{ 2.5f, -3.5f },
+		{ 4.0f, 6.0f }
+	});
+
+	const std::string saved = Xelqoria::Game::SceneSerializer::SaveToText(scene);
+	EXPECT_NE(std::string::npos, saved.find("version=2\n"));
+	EXPECT_NE(std::string::npos, saved.find("entity.0.hasCollider2DComponent=true\n"));
+	EXPECT_NE(std::string::npos, saved.find("entity.0.collider2D.enabled=false\n"));
+	EXPECT_NE(std::string::npos, saved.find("entity.0.collider2D.isTrigger=true\n"));
+	EXPECT_NE(std::string::npos, saved.find("entity.0.collider2D.shapeType=Box\n"));
+	EXPECT_NE(std::string::npos, saved.find("entity.0.collider2D.offset=2.500000,-3.500000\n"));
+	EXPECT_NE(std::string::npos, saved.find("entity.0.collider2D.size=4.000000,6.000000\n"));
+
+	const auto loaded = Xelqoria::Game::SceneSerializer::LoadFromText(saved);
+
+	ASSERT_TRUE(loaded.IsSuccess());
+	const auto loadedEntity = loaded.scene->FindEntity(entity.GetId());
+	ASSERT_TRUE(loadedEntity.has_value());
+	const auto loadedCollider = loadedEntity->get().GetCollider2DComponent();
+	ASSERT_TRUE(loadedCollider.has_value());
+	EXPECT_FALSE(loadedCollider->get().enabled);
+	EXPECT_TRUE(loadedCollider->get().isTrigger);
+	EXPECT_EQ(Xelqoria::Game::Collider2DShapeType::Box, loadedCollider->get().shapeType);
+	EXPECT_FLOAT_EQ(2.5f, loadedCollider->get().offset.x);
+	EXPECT_FLOAT_EQ(-3.5f, loadedCollider->get().offset.y);
+	EXPECT_FLOAT_EQ(4.0f, loadedCollider->get().size.x);
+	EXPECT_FLOAT_EQ(6.0f, loadedCollider->get().size.y);
+}
+
+TEST(TransformTests, SceneSerializerLoadVersion1KeepsCollider2DAbsent)
+{
+	const std::string source =
+		"magic=xelqoria.scene\n"
+		"version=1\n"
+		"entity.0.id=5\n"
+		"entity.0.name=\"Legacy\"\n"
+		"entity.0.transform.position=1.000000,2.000000,3.000000\n"
+		"entity.0.transform.rotation=0.000000,0.000000,0.000000\n"
+		"entity.0.transform.scale=1.000000,1.000000,1.000000\n"
+		"entity.0.hasSpriteComponent=false\n";
+
+	const auto loadResult = Xelqoria::Game::SceneSerializer::LoadFromText(source);
+
+	ASSERT_TRUE(loadResult.IsSuccess());
+	const auto loadedEntity = loadResult.scene->FindEntity(5);
+	ASSERT_TRUE(loadedEntity.has_value());
+	EXPECT_FALSE(loadedEntity->get().HasCollider2DComponent());
+}
+
+TEST(TransformTests, SceneSerializerLoadRejectsInvalidCollider2DFields)
+{
+	const auto loadInvalidColliderScene = [](std::string_view fieldLine)
+	{
+		const std::string source =
+			"magic=xelqoria.scene\n"
+			"version=2\n"
+			"entity.0.id=5\n"
+			"entity.0.name=\"Collider\"\n"
+			"entity.0.transform.position=1.000000,2.000000,3.000000\n"
+			"entity.0.transform.rotation=0.000000,0.000000,0.000000\n"
+			"entity.0.transform.scale=1.000000,1.000000,1.000000\n"
+			"entity.0.hasSpriteComponent=false\n"
+			"entity.0.hasCollider2DComponent=true\n"
+			+ std::string(fieldLine);
+		return Xelqoria::Game::SceneSerializer::LoadFromText(source);
+	};
+
+	const auto invalidBool = loadInvalidColliderScene("entity.0.collider2D.enabled=yes\n");
+	EXPECT_FALSE(invalidBool.IsSuccess());
+	ASSERT_TRUE(invalidBool.error.has_value());
+	EXPECT_EQ("entity.0.collider2D.enabled", invalidBool.error->fieldName);
+
+	const auto invalidShapeType = loadInvalidColliderScene("entity.0.collider2D.shapeType=Circle\n");
+	EXPECT_FALSE(invalidShapeType.IsSuccess());
+	ASSERT_TRUE(invalidShapeType.error.has_value());
+	EXPECT_EQ("entity.0.collider2D.shapeType", invalidShapeType.error->fieldName);
+
+	const auto invalidOffset = loadInvalidColliderScene("entity.0.collider2D.offset=1,2,3\n");
+	EXPECT_FALSE(invalidOffset.IsSuccess());
+	ASSERT_TRUE(invalidOffset.error.has_value());
+	EXPECT_EQ("entity.0.collider2D.offset", invalidOffset.error->fieldName);
+
+	const auto invalidSizeX = loadInvalidColliderScene("entity.0.collider2D.size=0,1\n");
+	EXPECT_FALSE(invalidSizeX.IsSuccess());
+	ASSERT_TRUE(invalidSizeX.error.has_value());
+	EXPECT_EQ("entity.0.collider2D.size", invalidSizeX.error->fieldName);
+
+	const auto invalidSizeY = loadInvalidColliderScene("entity.0.collider2D.size=1,-2\n");
+	EXPECT_FALSE(invalidSizeY.IsSuccess());
+	ASSERT_TRUE(invalidSizeY.error.has_value());
+	EXPECT_EQ("entity.0.collider2D.size", invalidSizeY.error->fieldName);
 }
 
 TEST(TransformTests, SpriteMaterialAssetLoaderReadsTextureColorAndOutline)

--- a/tests/Game/Xelqoria.Tests.Game.vcxproj
+++ b/tests/Game/Xelqoria.Tests.Game.vcxproj
@@ -19,6 +19,7 @@
     </ProjectConfiguration>
   </ItemGroup>
   <ItemGroup>
+    <ClCompile Include="Source\EntityTests.cpp" />
     <ClCompile Include="Source\Physics2DTests.cpp" />
     <ClCompile Include="Source\TransformTests.cpp" />
   </ItemGroup>

--- a/tests/Game/Xelqoria.Tests.Game.vcxproj.filters
+++ b/tests/Game/Xelqoria.Tests.Game.vcxproj.filters
@@ -6,6 +6,9 @@
     </Filter>
   </ItemGroup>
   <ItemGroup>
+    <ClCompile Include="Source\EntityTests.cpp">
+      <Filter>Source</Filter>
+    </ClCompile>
     <ClCompile Include="Source\Physics2DTests.cpp">
       <Filter>Source</Filter>
     </ClCompile>


### PR DESCRIPTION
## 概要
- 選択 Entity の Collider2DComponent を SceneView 補助表示として描画
- Transform / Collider2DComponent から AABB を作り、SceneView カメラでビュー座標に変換
- `enabled == false` は薄い表示、`isTrigger == true` は通常 Collider と異なる色/マーカーで区別
- Collider2DComponent 自身には描画処理を追加していません
- 関連テストと ExecPlan を追加

## 先行ブランチ取り込み
- `issue-293` は Collider2DComponent API、Scene 保存形式、Editor UI 対応を前提にしているため、ローカルで `issue-292` を取り込んでいます。

## 検証
- `MSBuild.exe tests\Editor\Xelqoria.Tests.Editor.vcxproj /m /p:Configuration=Debug /p:Platform=x64 /v:minimal`
- `MSBuild.exe Editor\Xelqoria.Editor.vcxproj /m /p:Configuration=Debug /p:Platform=x64 /v:minimal`
- `artifacts\x64\Debug\Xelqoria.Tests.Editor.exe`

Closes #293
Parent: #289
Depends on: #290, #291, #292