### PR TITLE
共通UI状態永続化の基盤追加

### DIFF
--- a/Editor/Source/HierarchyPanelController.cpp
+++ b/Editor/Source/HierarchyPanelController.cpp
@@ -6,7 +6,8 @@
 #include "EditorStringUtils.h"
 #include <Windows.h>
 #include <cstdio>
-#include <cstdio>
+#include <filesystem>
+#include <fstream>
 #include <iterator>
 #include <optional>
 #include "EditorShell.h"
@@ -15,6 +16,16 @@
 
 namespace Xelqoria::Editor
 {
+    namespace
+    {
+        [[nodiscard]] std::filesystem::path GetHierarchyStatePath()
+        {
+            std::filesystem::path statePath = std::filesystem::temp_directory_path();
+            statePath /= L"XelqoriaEditorHierarchyState.txt";
+            return statePath;
+        }
+    }
+
     void HierarchyPanelController::Bind(const EditorShell& shell)
     {
         m_hierarchyListBox = shell.GetHierarchyListBox();
@@ -24,6 +35,7 @@ namespace Xelqoria::Editor
         m_hierarchyCreateButton = shell.GetHierarchyCreateButton();
         m_hierarchyDuplicateButton = shell.GetHierarchyDuplicateButton();
         m_hierarchyDeleteButton = shell.GetHierarchyDeleteButton();
+        LoadExpansionState();
     }
 
     void HierarchyPanelController::Refresh(const Game::Scene* scene)
@@ -300,6 +312,41 @@ namespace Xelqoria::Editor
             m_collapsedEntityIds.erase(collapsedIt);
         }
 
+        SaveExpansionState();
         return true;
+    }
+
+    void HierarchyPanelController::LoadExpansionState()
+    {
+        m_collapsedEntityIds.clear();
+        std::ifstream input(GetHierarchyStatePath());
+        if (false == input.is_open())
+        {
+            return;
+        }
+
+        std::string token{};
+        Game::EntityId entityId = 0;
+        while (input >> token >> entityId)
+        {
+            if ("collapsed" == token)
+            {
+                m_collapsedEntityIds.insert(entityId);
+            }
+        }
+    }
+
+    void HierarchyPanelController::SaveExpansionState() const
+    {
+        std::ofstream output(GetHierarchyStatePath(), std::ios::trunc);
+        if (false == output.is_open())
+        {
+            return;
+        }
+
+        for (Game::EntityId entityId : m_collapsedEntityIds)
+        {
+            output << "collapsed " << entityId << '\n';
+        }
     }
 }

--- a/Editor/Source/HierarchyPanelController.h
+++ b/Editor/Source/HierarchyPanelController.h
@@ -131,5 +131,15 @@ namespace Xelqoria::Editor
         /// <param name="scene">表示対象の Scene。</param>
         /// <returns>展開状態を変更した場合は true。</returns>
         bool ToggleSelectedEntityExpansion(const Game::Scene& scene);
+
+        /// <summary>
+        /// Hierarchy 展開状態をローカル UI 状態ファイルから復元する。
+        /// </summary>
+        void LoadExpansionState();
+
+        /// <summary>
+        /// Hierarchy 展開状態をローカル UI 状態ファイルへ保存する。
+        /// </summary>
+        void SaveExpansionState() const;
     };
 }

--- a/Editor/Source/InspectorPanelController.cpp
+++ b/Editor/Source/InspectorPanelController.cpp
@@ -8,6 +8,8 @@
 #include <cstdio>
 #include <cstdlib>
 #include <cwctype>
+#include <filesystem>
+#include <fstream>
 #include <iterator>
 #include <optional>
 #include <AssetId.h>
@@ -135,6 +137,13 @@ namespace Xelqoria::Editor
             SetWindowVisible(scriptAssignButton, visible);
             SetWindowVisible(scriptClearButton, visible);
         }
+
+        [[nodiscard]] std::filesystem::path GetInspectorStatePath()
+        {
+            std::filesystem::path statePath = std::filesystem::temp_directory_path();
+            statePath /= L"XelqoriaEditorInspectorState.txt";
+            return statePath;
+        }
     }
 
     void InspectorPanelController::Bind(const EditorShell& shell, Platform::ICursor& cursor)
@@ -184,6 +193,7 @@ namespace Xelqoria::Editor
         SetWindowTextW(m_materialTintColorButton, L"");
         SetWindowTextW(m_materialOutlineColorButton, L"");
         SetWindowTextW(m_addComponentButton, L"Add Component");
+        LoadCollapseState();
     }
 
     void InspectorPanelController::Refresh(
@@ -899,6 +909,52 @@ namespace Xelqoria::Editor
     void InspectorPanelController::ResetTrackedEntity()
     {
         m_lastInspectorEntityId.reset();
+    }
+
+    void InspectorPanelController::LoadCollapseState()
+    {
+        std::ifstream input(GetInspectorStatePath());
+        if (false == input.is_open())
+        {
+            return;
+        }
+
+        std::string key{};
+        int value = 0;
+        while (input >> key >> value)
+        {
+            const bool collapsed = 0 != value;
+            if ("transform" == key)
+            {
+                m_isTransformCollapsed = collapsed;
+            }
+            else if ("sprite" == key)
+            {
+                m_isSpriteComponentCollapsed = collapsed;
+            }
+            else if ("material" == key)
+            {
+                m_isMaterialCollapsed = collapsed;
+            }
+            else if ("collider2d" == key)
+            {
+                m_isCollider2DCollapsed = collapsed;
+            }
+        }
+    }
+
+    void InspectorPanelController::SaveCollapseState() const
+    {
+        std::ofstream output(GetInspectorStatePath(), std::ios::trunc);
+        if (false == output.is_open())
+        {
+            return;
+        }
+
+        output << "transform " << (m_isTransformCollapsed ? 1 : 0) << '\n';
+        output << "sprite " << (m_isSpriteComponentCollapsed ? 1 : 0) << '\n';
+        output << "material " << (m_isMaterialCollapsed ? 1 : 0) << '\n';
+        output << "collider2d " << (m_isCollider2DCollapsed ? 1 : 0) << '\n';
     }
 
     void InspectorPanelController::SetMaterialDetailsVisible(bool visible) const

--- a/Editor/Source/InspectorPanelController.h
+++ b/Editor/Source/InspectorPanelController.h
@@ -274,6 +274,16 @@ namespace Xelqoria::Editor
         void ResetTrackedEntity();
 
         /// <summary>
+        /// Inspector 折りたたみ状態をローカル UI 状態ファイルから復元する。
+        /// </summary>
+        void LoadCollapseState();
+
+        /// <summary>
+        /// Inspector 折りたたみ状態をローカル UI 状態ファイルへ保存する。
+        /// </summary>
+        void SaveCollapseState() const;
+
+        /// <summary>
         /// TextureAssetId から Texture 欄に表示するファイル名を取得する。
         /// </summary>
         /// <param name="textureAssetId">表示対象の TextureAssetId。</param>
@@ -546,5 +556,9 @@ namespace Xelqoria::Editor
         HWND m_pressedButtonHandle = nullptr;
         bool m_isDropHighlightVisible = false;
         HWND m_dropHighlightTargetEdit = nullptr;
+        bool m_isTransformCollapsed = false;
+        bool m_isSpriteComponentCollapsed = false;
+        bool m_isMaterialCollapsed = false;
+        bool m_isCollider2DCollapsed = false;
     };
 }

--- a/docs/plans/issue-300-ui-state-foundation.md
+++ b/docs/plans/issue-300-ui-state-foundation.md
@@ -1,0 +1,41 @@
+# ExecPlan: issue-300 共通UI定数とUI状態永続化の基盤追加
+
+## 目的
+
+Editor UI 改善の土台として、Inspector 折りたたみ状態と Hierarchy 展開状態を保持し、保存・復元できる基盤を追加する。
+
+## 対象範囲
+
+- 変更対象プロジェクト: `Editor`
+- 変更対象ファイル: `Editor/Source/HierarchyPanelController.*`, `Editor/Source/InspectorPanelController.*`
+- 変更対象クラス: `HierarchyPanelController`, `InspectorPanelController`
+- 影響する機能: Hierarchy 展開状態、Inspector 折りたたみ状態
+
+## 前提
+
+- parent issue: issue-299
+- parent issue ブランチ: `issue-299`
+- この child issue のブランチ: `issue-300`
+- PR の向き: `issue-300` -> `issue-299`
+
+## 実装方針
+
+Win32 描画処理とは切り離し、各 Controller が UI 状態を保持する。保存失敗時は通常操作を妨げない。
+
+## 作業手順
+
+1. Hierarchy 展開状態をローカル状態ファイルへ保存・復元する
+2. Inspector 折りたたみ状態を保持し、ローカル状態ファイルへ保存・復元する関数を追加する
+3. Editor ビルドと Editor テストを実行する
+
+## 検証方法
+
+- `Editor/Xelqoria.Editor.vcxproj` Debug x64 ビルド
+- `tests/Editor/Xelqoria.Tests.Editor.vcxproj` Debug x64 ビルド
+- `artifacts/x64/Debug/Xelqoria.Tests.Editor.exe`
+
+## 完了条件
+
+- Inspector 折りたたみ状態を Component 種別ごとに保持できる
+- Hierarchy 展開状態を GameObject ごとに保持できる
+- 保存失敗時に通常操作が妨げられない


### PR DESCRIPTION
## Summary
- Addresses #300 under parent #299.
- Adds local persistence foundation for Hierarchy expansion state and Inspector collapse state.

## Verification
- Editor Debug x64 build
- Editor tests Debug x64 build
- `artifacts/x64/Debug/Xelqoria.Tests.Editor.exe` (77 passed)
