### PR TITLE
Hierarchy の GameObject / Component ツリー表示改善

### DIFF
--- a/Editor/Source/HierarchyPanelController.cpp
+++ b/Editor/Source/HierarchyPanelController.cpp
@@ -6,7 +6,8 @@
 #include "EditorStringUtils.h"
 #include <Windows.h>
 #include <cstdio>
-#include <cstdio>
+#include <filesystem>
+#include <fstream>
 #include <iterator>
 #include <optional>
 #include "EditorShell.h"
@@ -15,6 +16,16 @@
 
 namespace Xelqoria::Editor
 {
+    namespace
+    {
+        [[nodiscard]] std::filesystem::path GetHierarchyStatePath()
+        {
+            std::filesystem::path statePath = std::filesystem::temp_directory_path();
+            statePath /= L"XelqoriaEditorHierarchyState.txt";
+            return statePath;
+        }
+    }
+
     void HierarchyPanelController::Bind(const EditorShell& shell)
     {
         m_hierarchyListBox = shell.GetHierarchyListBox();
@@ -24,6 +35,7 @@ namespace Xelqoria::Editor
         m_hierarchyCreateButton = shell.GetHierarchyCreateButton();
         m_hierarchyDuplicateButton = shell.GetHierarchyDuplicateButton();
         m_hierarchyDeleteButton = shell.GetHierarchyDeleteButton();
+        LoadExpansionState();
     }
 
     void HierarchyPanelController::Refresh(const Game::Scene* scene)
@@ -300,6 +312,41 @@ namespace Xelqoria::Editor
             m_collapsedEntityIds.erase(collapsedIt);
         }
 
+        SaveExpansionState();
         return true;
+    }
+
+    void HierarchyPanelController::LoadExpansionState()
+    {
+        m_collapsedEntityIds.clear();
+        std::ifstream input(GetHierarchyStatePath());
+        if (false == input.is_open())
+        {
+            return;
+        }
+
+        std::string token{};
+        Game::EntityId entityId = 0;
+        while (input >> token >> entityId)
+        {
+            if ("collapsed" == token)
+            {
+                m_collapsedEntityIds.insert(entityId);
+            }
+        }
+    }
+
+    void HierarchyPanelController::SaveExpansionState() const
+    {
+        std::ofstream output(GetHierarchyStatePath(), std::ios::trunc);
+        if (false == output.is_open())
+        {
+            return;
+        }
+
+        for (Game::EntityId entityId : m_collapsedEntityIds)
+        {
+            output << "collapsed " << entityId << '\n';
+        }
     }
 }

--- a/Editor/Source/HierarchyPanelController.cpp
+++ b/Editor/Source/HierarchyPanelController.cpp
@@ -5,11 +5,13 @@
 #include "ButtonClickWin32Adapter.h"
 #include "EditorStringUtils.h"
 #include <Windows.h>
+#include <array>
 #include <cstdio>
 #include <filesystem>
 #include <fstream>
 #include <iterator>
 #include <optional>
+#include <utility>
 #include "EditorShell.h"
 #include <Entity.h>
 #include <Scene.h>
@@ -23,6 +25,21 @@ namespace Xelqoria::Editor
             std::filesystem::path statePath = std::filesystem::temp_directory_path();
             statePath /= L"XelqoriaEditorHierarchyState.txt";
             return statePath;
+        }
+
+        [[nodiscard]] const wchar_t* GetComponentRowLabel(HierarchyPanelController::VisibleItemKind kind)
+        {
+            switch (kind)
+            {
+            case HierarchyPanelController::VisibleItemKind::SpriteComponent:
+                return L"  |-- SpriteComponent";
+            case HierarchyPanelController::VisibleItemKind::Material:
+                return L"  |-- Material";
+            case HierarchyPanelController::VisibleItemKind::Collider2DComponent:
+                return L"  |-- Collider2D";
+            default:
+                return L"";
+            }
         }
     }
 
@@ -60,19 +77,36 @@ namespace Xelqoria::Editor
                     continue;
                 }
 
+                const bool hasSpriteComponent = entity.HasSpriteComponent();
+                const bool hasMaterialComponent = hasSpriteComponent;
                 const bool hasCollider2DComponent = entity.HasCollider2DComponent();
+                const bool hasChildComponent = hasSpriteComponent || hasMaterialComponent || hasCollider2DComponent;
                 const bool isExpanded = m_collapsedEntityIds.find(entity.GetId()) == m_collapsedEntityIds.end();
                 m_visibleEntityIds.push_back(entity.GetId());
                 m_visibleItemKinds.push_back(VisibleItemKind::Entity);
 
-                label = FormatEntityRowLabel(label, hasCollider2DComponent, isExpanded);
+                label = FormatEntityRowLabel(label, hasChildComponent, isExpanded);
                 SendMessageW(m_hierarchyListBox, LB_ADDSTRING, 0, reinterpret_cast<LPARAM>(label.c_str()));
 
-                if (ShouldShowCollider2DChildRow(hasCollider2DComponent, isExpanded))
+                const std::array<std::pair<bool, VisibleItemKind>, 3> componentRows{
+                    std::pair<bool, VisibleItemKind>{ hasSpriteComponent, VisibleItemKind::SpriteComponent },
+                    std::pair<bool, VisibleItemKind>{ hasMaterialComponent, VisibleItemKind::Material },
+                    std::pair<bool, VisibleItemKind>{ hasCollider2DComponent, VisibleItemKind::Collider2DComponent }
+                };
+                for (const auto& componentRow : componentRows)
                 {
+                    if (false == ShouldShowComponentChildRow(componentRow.first, isExpanded))
+                    {
+                        continue;
+                    }
+
                     m_visibleEntityIds.push_back(entity.GetId());
-                    m_visibleItemKinds.push_back(VisibleItemKind::Collider2DComponent);
-                    SendMessageW(m_hierarchyListBox, LB_ADDSTRING, 0, reinterpret_cast<LPARAM>(L"  Collider2DComponent"));
+                    m_visibleItemKinds.push_back(componentRow.second);
+                    SendMessageW(
+                        m_hierarchyListBox,
+                        LB_ADDSTRING,
+                        0,
+                        reinterpret_cast<LPARAM>(GetComponentRowLabel(componentRow.second)));
                 }
             }
         }
@@ -286,6 +320,11 @@ namespace Xelqoria::Editor
         return m_selectedEntityId;
     }
 
+    HierarchyPanelController::VisibleItemKind HierarchyPanelController::GetSelectedItemKind() const
+    {
+        return m_selectedItemKind;
+    }
+
     bool HierarchyPanelController::ToggleSelectedEntityExpansion(const Game::Scene& scene)
     {
         if (false == m_selectedEntityId.has_value()
@@ -296,7 +335,8 @@ namespace Xelqoria::Editor
 
         const auto selectedEntity = scene.FindEntity(*m_selectedEntityId);
         if (false == selectedEntity.has_value()
-            || false == selectedEntity->get().HasCollider2DComponent())
+            || (false == selectedEntity->get().HasSpriteComponent()
+                && false == selectedEntity->get().HasCollider2DComponent()))
         {
             return false;
         }

--- a/Editor/Source/HierarchyPanelController.h
+++ b/Editor/Source/HierarchyPanelController.h
@@ -131,5 +131,15 @@ namespace Xelqoria::Editor
         /// <param name="scene">表示対象の Scene。</param>
         /// <returns>展開状態を変更した場合は true。</returns>
         bool ToggleSelectedEntityExpansion(const Game::Scene& scene);
+
+        /// <summary>
+        /// Hierarchy 展開状態をローカル UI 状態ファイルから復元する。
+        /// </summary>
+        void LoadExpansionState();
+
+        /// <summary>
+        /// Hierarchy 展開状態をローカル UI 状態ファイルへ保存する。
+        /// </summary>
+        void SaveExpansionState() const;
     };
 }

--- a/Editor/Source/HierarchyPanelController.h
+++ b/Editor/Source/HierarchyPanelController.h
@@ -28,6 +28,8 @@ namespace Xelqoria::Editor
         enum class VisibleItemKind
         {
             Entity,
+            SpriteComponent,
+            Material,
             Collider2DComponent
         };
 
@@ -57,6 +59,19 @@ namespace Xelqoria::Editor
         }
 
         /// <summary>
+        /// Component 子行を表示するかを判定する。
+        /// </summary>
+        /// <param name="hasComponent">Entity が対象 Component を保持しているか。</param>
+        /// <param name="isExpanded">Entity 行が展開中か。</param>
+        /// <returns>子行を表示する場合は true。</returns>
+        [[nodiscard]] static bool ShouldShowComponentChildRow(
+            bool hasComponent,
+            bool isExpanded)
+        {
+            return hasComponent && isExpanded;
+        }
+
+        /// <summary>
         /// Collider2DComponent 子行を表示するかを判定する。
         /// </summary>
         /// <param name="hasCollider2DComponent">Entity が Collider2DComponent を保持しているか。</param>
@@ -66,7 +81,7 @@ namespace Xelqoria::Editor
             bool hasCollider2DComponent,
             bool isExpanded)
         {
-            return hasCollider2DComponent && isExpanded;
+            return ShouldShowComponentChildRow(hasCollider2DComponent, isExpanded);
         }
 
         /// <summary>
@@ -106,6 +121,12 @@ namespace Xelqoria::Editor
         /// </summary>
         /// <returns>現在選択中の EntityId。</returns>
         [[nodiscard]] std::optional<Game::EntityId> GetSelectedEntityId() const;
+
+        /// <summary>
+        /// 現在選択中の Hierarchy 行種別を取得する。
+        /// </summary>
+        /// <returns>現在選択中の行種別。</returns>
+        [[nodiscard]] VisibleItemKind GetSelectedItemKind() const;
 
     private:
         HWND m_hierarchyListBox = nullptr;

--- a/Editor/Source/InspectorPanelController.cpp
+++ b/Editor/Source/InspectorPanelController.cpp
@@ -8,6 +8,8 @@
 #include <cstdio>
 #include <cstdlib>
 #include <cwctype>
+#include <filesystem>
+#include <fstream>
 #include <iterator>
 #include <optional>
 #include <AssetId.h>
@@ -135,6 +137,13 @@ namespace Xelqoria::Editor
             SetWindowVisible(scriptAssignButton, visible);
             SetWindowVisible(scriptClearButton, visible);
         }
+
+        [[nodiscard]] std::filesystem::path GetInspectorStatePath()
+        {
+            std::filesystem::path statePath = std::filesystem::temp_directory_path();
+            statePath /= L"XelqoriaEditorInspectorState.txt";
+            return statePath;
+        }
     }
 
     void InspectorPanelController::Bind(const EditorShell& shell, Platform::ICursor& cursor)
@@ -184,6 +193,7 @@ namespace Xelqoria::Editor
         SetWindowTextW(m_materialTintColorButton, L"");
         SetWindowTextW(m_materialOutlineColorButton, L"");
         SetWindowTextW(m_addComponentButton, L"Add Component");
+        LoadCollapseState();
     }
 
     void InspectorPanelController::Refresh(
@@ -899,6 +909,52 @@ namespace Xelqoria::Editor
     void InspectorPanelController::ResetTrackedEntity()
     {
         m_lastInspectorEntityId.reset();
+    }
+
+    void InspectorPanelController::LoadCollapseState()
+    {
+        std::ifstream input(GetInspectorStatePath());
+        if (false == input.is_open())
+        {
+            return;
+        }
+
+        std::string key{};
+        int value = 0;
+        while (input >> key >> value)
+        {
+            const bool collapsed = 0 != value;
+            if ("transform" == key)
+            {
+                m_isTransformCollapsed = collapsed;
+            }
+            else if ("sprite" == key)
+            {
+                m_isSpriteComponentCollapsed = collapsed;
+            }
+            else if ("material" == key)
+            {
+                m_isMaterialCollapsed = collapsed;
+            }
+            else if ("collider2d" == key)
+            {
+                m_isCollider2DCollapsed = collapsed;
+            }
+        }
+    }
+
+    void InspectorPanelController::SaveCollapseState() const
+    {
+        std::ofstream output(GetInspectorStatePath(), std::ios::trunc);
+        if (false == output.is_open())
+        {
+            return;
+        }
+
+        output << "transform " << (m_isTransformCollapsed ? 1 : 0) << '\n';
+        output << "sprite " << (m_isSpriteComponentCollapsed ? 1 : 0) << '\n';
+        output << "material " << (m_isMaterialCollapsed ? 1 : 0) << '\n';
+        output << "collider2d " << (m_isCollider2DCollapsed ? 1 : 0) << '\n';
     }
 
     void InspectorPanelController::SetMaterialDetailsVisible(bool visible) const

--- a/Editor/Source/InspectorPanelController.h
+++ b/Editor/Source/InspectorPanelController.h
@@ -274,6 +274,16 @@ namespace Xelqoria::Editor
         void ResetTrackedEntity();
 
         /// <summary>
+        /// Inspector 折りたたみ状態をローカル UI 状態ファイルから復元する。
+        /// </summary>
+        void LoadCollapseState();
+
+        /// <summary>
+        /// Inspector 折りたたみ状態をローカル UI 状態ファイルへ保存する。
+        /// </summary>
+        void SaveCollapseState() const;
+
+        /// <summary>
         /// TextureAssetId から Texture 欄に表示するファイル名を取得する。
         /// </summary>
         /// <param name="textureAssetId">表示対象の TextureAssetId。</param>
@@ -546,5 +556,9 @@ namespace Xelqoria::Editor
         HWND m_pressedButtonHandle = nullptr;
         bool m_isDropHighlightVisible = false;
         HWND m_dropHighlightTargetEdit = nullptr;
+        bool m_isTransformCollapsed = false;
+        bool m_isSpriteComponentCollapsed = false;
+        bool m_isMaterialCollapsed = false;
+        bool m_isCollider2DCollapsed = false;
     };
 }

--- a/docs/plans/issue-300-ui-state-foundation.md
+++ b/docs/plans/issue-300-ui-state-foundation.md
@@ -1,0 +1,41 @@
+# ExecPlan: issue-300 共通UI定数とUI状態永続化の基盤追加
+
+## 目的
+
+Editor UI 改善の土台として、Inspector 折りたたみ状態と Hierarchy 展開状態を保持し、保存・復元できる基盤を追加する。
+
+## 対象範囲
+
+- 変更対象プロジェクト: `Editor`
+- 変更対象ファイル: `Editor/Source/HierarchyPanelController.*`, `Editor/Source/InspectorPanelController.*`
+- 変更対象クラス: `HierarchyPanelController`, `InspectorPanelController`
+- 影響する機能: Hierarchy 展開状態、Inspector 折りたたみ状態
+
+## 前提
+
+- parent issue: issue-299
+- parent issue ブランチ: `issue-299`
+- この child issue のブランチ: `issue-300`
+- PR の向き: `issue-300` -> `issue-299`
+
+## 実装方針
+
+Win32 描画処理とは切り離し、各 Controller が UI 状態を保持する。保存失敗時は通常操作を妨げない。
+
+## 作業手順
+
+1. Hierarchy 展開状態をローカル状態ファイルへ保存・復元する
+2. Inspector 折りたたみ状態を保持し、ローカル状態ファイルへ保存・復元する関数を追加する
+3. Editor ビルドと Editor テストを実行する
+
+## 検証方法
+
+- `Editor/Xelqoria.Editor.vcxproj` Debug x64 ビルド
+- `tests/Editor/Xelqoria.Tests.Editor.vcxproj` Debug x64 ビルド
+- `artifacts/x64/Debug/Xelqoria.Tests.Editor.exe`
+
+## 完了条件
+
+- Inspector 折りたたみ状態を Component 種別ごとに保持できる
+- Hierarchy 展開状態を GameObject ごとに保持できる
+- 保存失敗時に通常操作が妨げられない

--- a/docs/plans/issue-302-hierarchy-component-tree.md
+++ b/docs/plans/issue-302-hierarchy-component-tree.md
@@ -1,0 +1,44 @@
+# ExecPlan: issue-302 Hierarchy の GameObject / Component ツリー表示改善
+
+## 目的
+
+Hierarchy で GameObject と Component の親子関係を明確にし、Component 行を選択できるようにする。
+
+## 対象範囲
+
+- 変更対象プロジェクト: `Editor`
+- 変更対象ファイル: `Editor/Source/HierarchyPanelController.*`
+- 変更対象クラス: `HierarchyPanelController`
+- 影響する機能: Hierarchy 表示、Hierarchy 選択状態
+
+## 前提
+
+- parent issue: issue-299
+- 先行 child issue: issue-300
+- parent issue ブランチ: `issue-299`
+- この child issue のブランチ: `issue-302`
+- PR の向き: `issue-302` -> `issue-299`
+
+## 実装方針
+
+GameObject を親行として表示し、SpriteComponent、Material、Collider2D を Component 子行として表示する。Material は SpriteComponent の Material 参照を独立 Component として扱う。
+
+## 作業手順
+
+1. Hierarchy の表示行種別へ Component 種別を追加する
+2. GameObject 行の展開状態に応じて Component 子行を表示する
+3. 選択中行種別を外部から取得できるようにする
+4. Editor ビルドと Editor テストを実行する
+
+## 検証方法
+
+- `Editor/Xelqoria.Editor.vcxproj` Debug x64 ビルド
+- `tests/Editor/Xelqoria.Tests.Editor.vcxproj` Debug x64 ビルド
+- `artifacts/x64/Debug/Xelqoria.Tests.Editor.exe`
+
+## 完了条件
+
+- GameObject が親ノードとして表示される
+- SpriteComponent / Material / Collider2D が GameObject の子として表示される
+- Component を選択できる
+- 展開状態が保持される


### PR DESCRIPTION
## Summary
- Addresses #302 under parent #299.
- Builds on #300.
- Shows GameObject rows with SpriteComponent / Material / Collider2D child rows and exposes the selected row kind.

## Verification
- Editor Debug x64 build
- Editor tests Debug x64 build
- `artifacts/x64/Debug/Xelqoria.Tests.Editor.exe` (77 passed)
