### PR TITLE
Log のフィルター、種別表示、Clear 表示制御改善

### DIFF
--- a/Editor/Source/EditorShell.cpp
+++ b/Editor/Source/EditorShell.cpp
@@ -1848,7 +1848,7 @@ namespace Xelqoria::Editor
         }
         ConfigureEditorTabControl(m_logOutputTabControl);
 
-        const std::array<const wchar_t*, 4> tabNames{ L"すべて", L"ログ", L"警告", L"エラー" };
+        const std::array<const wchar_t*, 5> tabNames{ L"All", L"Info", L"Editor", L"Warn", L"Error" };
         for (std::size_t index = 0; index < tabNames.size(); ++index)
         {
             TCITEMW item{};

--- a/Editor/Source/LogOutputPanelController.cpp
+++ b/Editor/Source/LogOutputPanelController.cpp
@@ -88,10 +88,27 @@ namespace Xelqoria::Editor
             return text;
         }
 
-        [[nodiscard]] std::wstring FormatLogLine(LogOutputCategory category, const std::wstring& message)
+        [[nodiscard]] std::wstring FormatLogLine(LogOutputCategory category, LogOutputSeverity severity, const std::wstring& message)
         {
             std::wstring line = L"[";
             line += BuildTimestampText();
+            line += L"] [";
+            if (LogOutputSeverity::Warning == severity)
+            {
+                line += L"Warn";
+            }
+            else if (LogOutputSeverity::Error == severity)
+            {
+                line += L"Error";
+            }
+            else if (LogOutputCategory::Editor == category)
+            {
+                line += L"Editor";
+            }
+            else
+            {
+                line += L"Info";
+            }
             line += L"] [";
             line += ToCategoryText(category);
             line += L"] ";
@@ -115,7 +132,7 @@ namespace Xelqoria::Editor
     void LogOutputPanelController::Append(LogOutputCategory category, std::wstring message, bool isError)
     {
         const LogOutputSeverity severity = InferSeverity(message, isError);
-        m_logs.push_back(LogOutputEntry{ FormatLogLine(category, message), severity });
+        m_logs.push_back(LogOutputEntry{ FormatLogLine(category, severity, message), category, severity });
         RefreshVisibleRows();
     }
 
@@ -150,7 +167,7 @@ namespace Xelqoria::Editor
         };
         if (TryConsumeButtonClick(BuildButtonClickTarget(m_clearButton), frameInput, m_buttonInputState))
         {
-            m_logs.clear();
+            m_visibleLogStartIndex = m_logs.size();
             RefreshVisibleRows();
             m_buttonInputState.pressedButtonId = 0;
         }
@@ -182,10 +199,11 @@ namespace Xelqoria::Editor
         }
 
         const bool isSelected = 0 != (drawItem->itemState & ODS_SELECTED);
-        const auto severity = static_cast<LogOutputSeverity>(drawItem->itemData);
+        const auto severity = static_cast<LogOutputSeverity>(drawItem->itemData % 10);
+        const auto category = static_cast<LogOutputCategory>(drawItem->itemData / 10);
         const EditorColor backgroundColor =
             isSelected ? EditorThemes::XelqoriaDark.selection : EditorThemes::XelqoriaDark.panelBackground;
-        EditorColor textColor = EditorThemes::XelqoriaDark.textPrimary;
+        EditorColor textColor = EditorColor::FromRgb8(0x78, 0xB7, 0xFF);
         if (LogOutputSeverity::Warning == severity)
         {
             textColor = EditorThemes::XelqoriaDark.warning;
@@ -193,6 +211,10 @@ namespace Xelqoria::Editor
         else if (LogOutputSeverity::Error == severity)
         {
             textColor = EditorThemes::XelqoriaDark.error;
+        }
+        else if (LogOutputCategory::Editor == category)
+        {
+            textColor = EditorThemes::XelqoriaDark.accent;
         }
 
         FillRectWithThemeColor(drawItem->hDC, drawItem->rcItem, backgroundColor);
@@ -250,11 +272,11 @@ namespace Xelqoria::Editor
             return;
         }
 
-        m_logs.push_back(LogOutputEntry{ FormatLogLine(LogOutputCategory::Editor, L"Xelqoria Editor started"), LogOutputSeverity::Normal });
-        m_logs.push_back(LogOutputEntry{ FormatLogLine(LogOutputCategory::Editor, L"Project loaded"), LogOutputSeverity::Normal });
-        m_logs.push_back(LogOutputEntry{ FormatLogLine(LogOutputCategory::Editor, L"Assets scan completed"), LogOutputSeverity::Normal });
-        m_logs.push_back(LogOutputEntry{ FormatLogLine(LogOutputCategory::Game, L"Scene initialized"), LogOutputSeverity::Warning });
-        m_logs.push_back(LogOutputEntry{ FormatLogLine(LogOutputCategory::Build, L"Renderer ready"), LogOutputSeverity::Error });
+        m_logs.push_back(LogOutputEntry{ FormatLogLine(LogOutputCategory::Editor, LogOutputSeverity::Normal, L"Xelqoria Editor started"), LogOutputCategory::Editor, LogOutputSeverity::Normal });
+        m_logs.push_back(LogOutputEntry{ FormatLogLine(LogOutputCategory::Editor, LogOutputSeverity::Normal, L"Project loaded"), LogOutputCategory::Editor, LogOutputSeverity::Normal });
+        m_logs.push_back(LogOutputEntry{ FormatLogLine(LogOutputCategory::Editor, LogOutputSeverity::Normal, L"Assets scan completed"), LogOutputCategory::Editor, LogOutputSeverity::Normal });
+        m_logs.push_back(LogOutputEntry{ FormatLogLine(LogOutputCategory::Game, LogOutputSeverity::Warning, L"Scene initialized"), LogOutputCategory::Game, LogOutputSeverity::Warning });
+        m_logs.push_back(LogOutputEntry{ FormatLogLine(LogOutputCategory::Build, LogOutputSeverity::Error, L"Renderer ready"), LogOutputCategory::Build, LogOutputSeverity::Error });
     }
 
     void LogOutputPanelController::RefreshVisibleRows()
@@ -267,10 +289,18 @@ namespace Xelqoria::Editor
         SendMessageW(m_listBox, LB_RESETCONTENT, 0, 0);
         const std::wstring filterText = GetFilterText();
         const std::optional<LogOutputSeverity> severityFilter = GetActiveSeverityFilter();
-        for (const LogOutputEntry& log : m_logs)
+        const int activeTab = nullptr != m_tabControl ? TabCtrl_GetCurSel(m_tabControl) : 0;
+        for (std::size_t index = m_visibleLogStartIndex; index < m_logs.size(); ++index)
         {
+            const LogOutputEntry& log = m_logs[index];
             const bool severityMatched = false == severityFilter.has_value() || log.severity == *severityFilter;
-            if (severityMatched && ContainsFilter(log.message, filterText))
+            const bool categoryMatched =
+                0 == activeTab
+                || (1 == activeTab && LogOutputSeverity::Normal == log.severity && LogOutputCategory::Editor != log.category)
+                || (2 == activeTab && LogOutputCategory::Editor == log.category)
+                || (3 == activeTab && LogOutputSeverity::Warning == log.severity)
+                || (4 == activeTab && LogOutputSeverity::Error == log.severity);
+            if (severityMatched && categoryMatched && ContainsFilter(log.message, filterText))
             {
                 const LRESULT itemIndex =
                     SendMessageW(m_listBox, LB_ADDSTRING, 0, reinterpret_cast<LPARAM>(log.message.c_str()));
@@ -280,7 +310,7 @@ namespace Xelqoria::Editor
                         m_listBox,
                         LB_SETITEMDATA,
                         static_cast<WPARAM>(itemIndex),
-                        static_cast<LPARAM>(log.severity));
+                        static_cast<LPARAM>(static_cast<int>(log.category) * 10 + static_cast<int>(log.severity)));
                 }
             }
         }
@@ -329,9 +359,13 @@ namespace Xelqoria::Editor
         }
         if (2 == activeTab)
         {
-            return LogOutputSeverity::Warning;
+            return std::nullopt;
         }
         if (3 == activeTab)
+        {
+            return LogOutputSeverity::Warning;
+        }
+        if (4 == activeTab)
         {
             return LogOutputSeverity::Error;
         }

--- a/Editor/Source/LogOutputPanelController.h
+++ b/Editor/Source/LogOutputPanelController.h
@@ -78,6 +78,7 @@ namespace Xelqoria::Editor
         struct LogOutputEntry
         {
             std::wstring message{};
+            LogOutputCategory category = LogOutputCategory::Game;
             LogOutputSeverity severity = LogOutputSeverity::Normal;
         };
 
@@ -116,6 +117,7 @@ namespace Xelqoria::Editor
         HWND m_listBox = nullptr;
         Platform::IClipboard* m_clipboard = nullptr;
         std::vector<LogOutputEntry> m_logs{};
+        std::size_t m_visibleLogStartIndex = 0;
         ButtonClickInputState m_buttonInputState{};
         int m_lastActiveTab = 0;
         std::wstring m_lastFilterText{};

--- a/docs/plans/issue-303-log-filter-display.md
+++ b/docs/plans/issue-303-log-filter-display.md
@@ -1,0 +1,44 @@
+# ExecPlan: issue-303 Log のフィルター、種別表示、Clear 表示制御改善
+
+## 目的
+
+Log パネルの種別フィルターと表示色を整理し、Clear 操作を内部ログ保持と画面表示クリアに分離する。
+
+## 対象範囲
+
+- 変更対象プロジェクト: `Editor`
+- 変更対象ファイル: `Editor/Source/EditorShell.cpp`, `Editor/Source/LogOutputPanelController.*`
+- 変更対象クラス: `EditorShell`, `LogOutputPanelController`
+- 影響する機能: Log パネル表示、フィルター、Clear 操作
+
+## 前提
+
+- parent issue: issue-299
+- parent issue ブランチ: `issue-299`
+- この child issue のブランチ: `issue-303`
+- PR の向き: `issue-303` -> `issue-299`
+
+## 実装方針
+
+LogEntry に category を保持し、TabControl のフィルターで `All / Info / Editor / Warn / Error` を切り替える。Clear はログ配列を消さず、表示開始位置だけを進める。
+
+## 作業手順
+
+1. Log タブ名を用途別に変更する
+2. LogEntry に category を追加する
+3. Log 表示行へ severity/category ラベルと色分けを追加する
+4. Clear を表示クリア動作へ変更する
+5. Editor ビルドと Editor テストを実行する
+
+## 検証方法
+
+- `Editor/Xelqoria.Editor.vcxproj` Debug x64 ビルド
+- `tests/Editor/Xelqoria.Tests.Editor.vcxproj` Debug x64 ビルド
+- `artifacts/x64/Debug/Xelqoria.Tests.Editor.exe`
+
+## 完了条件
+
+- All / Info / Editor / Warn / Error のフィルターがある
+- ログ行に種別が表示される
+- severity ごとの色分けがある
+- Clear 後も内部ログデータは保持される


### PR DESCRIPTION
## Summary
- Addresses #303 under parent #299.
- Adds All / Info / Editor / Warn / Error filters and category/severity labeling.
- Makes Clear hide current rows while preserving internal log entries.

## Verification
- Editor Debug x64 build
- Editor tests Debug x64 build
- `artifacts/x64/Debug/Xelqoria.Tests.Editor.exe` (77 passed)
