### PR TITLE
全体の見た目統一と受け入れ確認

### DIFF
--- a/Editor/Source/Application.cpp
+++ b/Editor/Source/Application.cpp
@@ -1254,7 +1254,8 @@ namespace Xelqoria::Editor
             canAddSpriteComponent,
             inputSnapshot,
             m_sceneDocument.GetSpriteAssetRegistry(),
-            m_sceneDocument.GetMaterialAssetRegistry());
+            m_sceneDocument.GetMaterialAssetRegistry(),
+            m_hierarchyPanelController.GetSelectedItemKind());
         if (true == inspectorResult.changed)
         {
             PersistSceneChanges(
@@ -1594,6 +1595,7 @@ namespace Xelqoria::Editor
             canAddSpriteComponent,
             m_sceneDocument.GetSpriteAssetRegistry(),
             m_sceneDocument.GetMaterialAssetRegistry(),
+            m_hierarchyPanelController.GetSelectedItemKind(),
             m_assetsPanelController.GetSelectedFilePath());
     }
 

--- a/Editor/Source/EditorShell.cpp
+++ b/Editor/Source/EditorShell.cpp
@@ -4995,22 +4995,30 @@ namespace Xelqoria::Editor
 
         const bool isPressed = 0 != (drawItem.itemState & ODS_SELECTED);
         const bool isDisabled = 0 != (drawItem.itemState & ODS_DISABLED);
+        const bool isDestructive =
+            nullptr != wcsstr(buttonText, L"Remove")
+            || nullptr != wcsstr(buttonText, L"Delete")
+            || nullptr != wcsstr(buttonText, L"Clear");
         const bool isDefaultAction =
             drawItem.hwndItem == m_topBarPlayButton
             || drawItem.hwndItem == m_buildAndPlayButton
-            || 0 == wcscmp(buttonText, L"すべて");
+            || 0 == wcscmp(buttonText, L"All")
+            || 0 == wcscmp(buttonText, L"Add Component")
+            || 0 == wcscmp(buttonText, L"New");
 
-        EditorColor backgroundColor = isDefaultAction
-            ? EditorThemes::XelqoriaDark.selection
-            : EditorThemes::XelqoriaDark.panelHeaderBackground;
+        EditorColor backgroundColor = isDestructive
+            ? EditorColor::FromRgb8(0x3A, 0x18, 0x24)
+            : (isDefaultAction ? EditorThemes::XelqoriaDark.selection : EditorThemes::XelqoriaDark.panelHeaderBackground);
         if (isPressed)
         {
             backgroundColor = EditorThemes::XelqoriaDark.accent;
         }
 
-        const EditorColor borderColor = isDefaultAction
+        const EditorColor borderColor = isDestructive
+            ? EditorThemes::XelqoriaDark.error
+            : (isDefaultAction
             ? EditorThemes::XelqoriaDark.accent
-            : EditorThemes::XelqoriaDark.panelBorder;
+            : EditorThemes::XelqoriaDark.panelBorder);
         const EditorColor textColor = isDisabled
             ? EditorThemes::XelqoriaDark.textSecondary
             : EditorThemes::XelqoriaDark.textPrimary;

--- a/Editor/Source/EditorShell.cpp
+++ b/Editor/Source/EditorShell.cpp
@@ -1848,7 +1848,7 @@ namespace Xelqoria::Editor
         }
         ConfigureEditorTabControl(m_logOutputTabControl);
 
-        const std::array<const wchar_t*, 4> tabNames{ L"すべて", L"ログ", L"警告", L"エラー" };
+        const std::array<const wchar_t*, 5> tabNames{ L"All", L"Info", L"Editor", L"Warn", L"Error" };
         for (std::size_t index = 0; index < tabNames.size(); ++index)
         {
             TCITEMW item{};

--- a/Editor/Source/EditorShell.cpp
+++ b/Editor/Source/EditorShell.cpp
@@ -5101,17 +5101,24 @@ namespace Xelqoria::Editor
             return false;
         }
 
+        wchar_t sectionText[128]{};
+        GetWindowTextW(drawItem.hwndItem, sectionText, static_cast<int>(std::size(sectionText)));
+        const bool isHighlighted = 0 == wcsncmp(sectionText, L"> ", 2);
+
         RECT sectionRect = drawItem.rcItem;
-        FillRectWithThemeColor(drawItem.hDC, sectionRect, EditorThemes::XelqoriaDark.panelHeaderBackground);
-        DrawRectBorder(drawItem.hDC, sectionRect, EditorThemes::XelqoriaDark.panelBorder);
+        FillRectWithThemeColor(
+            drawItem.hDC,
+            sectionRect,
+            isHighlighted ? EditorThemes::XelqoriaDark.selection : EditorThemes::XelqoriaDark.panelHeaderBackground);
+        DrawRectBorder(
+            drawItem.hDC,
+            sectionRect,
+            isHighlighted ? EditorThemes::XelqoriaDark.accent : EditorThemes::XelqoriaDark.panelBorder);
 
         RECT accentRect = sectionRect;
         const LONG accentWidth = static_cast<LONG>(ScaleMetric(4));
         accentRect.right = (std::min)(accentRect.right, accentRect.left + accentWidth);
         FillRectWithThemeColor(drawItem.hDC, accentRect, EditorThemes::XelqoriaDark.accent);
-
-        wchar_t sectionText[128]{};
-        GetWindowTextW(drawItem.hwndItem, sectionText, static_cast<int>(std::size(sectionText)));
 
         SetBkMode(drawItem.hDC, TRANSPARENT);
         SetTextColor(drawItem.hDC, ToColorRef(EditorThemes::XelqoriaDark.textPrimary));

--- a/Editor/Source/HierarchyPanelController.cpp
+++ b/Editor/Source/HierarchyPanelController.cpp
@@ -6,7 +6,8 @@
 #include "EditorStringUtils.h"
 #include <Windows.h>
 #include <cstdio>
-#include <cstdio>
+#include <filesystem>
+#include <fstream>
 #include <iterator>
 #include <optional>
 #include "EditorShell.h"
@@ -15,6 +16,16 @@
 
 namespace Xelqoria::Editor
 {
+    namespace
+    {
+        [[nodiscard]] std::filesystem::path GetHierarchyStatePath()
+        {
+            std::filesystem::path statePath = std::filesystem::temp_directory_path();
+            statePath /= L"XelqoriaEditorHierarchyState.txt";
+            return statePath;
+        }
+    }
+
     void HierarchyPanelController::Bind(const EditorShell& shell)
     {
         m_hierarchyListBox = shell.GetHierarchyListBox();
@@ -24,6 +35,7 @@ namespace Xelqoria::Editor
         m_hierarchyCreateButton = shell.GetHierarchyCreateButton();
         m_hierarchyDuplicateButton = shell.GetHierarchyDuplicateButton();
         m_hierarchyDeleteButton = shell.GetHierarchyDeleteButton();
+        LoadExpansionState();
     }
 
     void HierarchyPanelController::Refresh(const Game::Scene* scene)
@@ -300,6 +312,41 @@ namespace Xelqoria::Editor
             m_collapsedEntityIds.erase(collapsedIt);
         }
 
+        SaveExpansionState();
         return true;
+    }
+
+    void HierarchyPanelController::LoadExpansionState()
+    {
+        m_collapsedEntityIds.clear();
+        std::ifstream input(GetHierarchyStatePath());
+        if (false == input.is_open())
+        {
+            return;
+        }
+
+        std::string token{};
+        Game::EntityId entityId = 0;
+        while (input >> token >> entityId)
+        {
+            if ("collapsed" == token)
+            {
+                m_collapsedEntityIds.insert(entityId);
+            }
+        }
+    }
+
+    void HierarchyPanelController::SaveExpansionState() const
+    {
+        std::ofstream output(GetHierarchyStatePath(), std::ios::trunc);
+        if (false == output.is_open())
+        {
+            return;
+        }
+
+        for (Game::EntityId entityId : m_collapsedEntityIds)
+        {
+            output << "collapsed " << entityId << '\n';
+        }
     }
 }

--- a/Editor/Source/HierarchyPanelController.cpp
+++ b/Editor/Source/HierarchyPanelController.cpp
@@ -5,11 +5,13 @@
 #include "ButtonClickWin32Adapter.h"
 #include "EditorStringUtils.h"
 #include <Windows.h>
+#include <array>
 #include <cstdio>
 #include <filesystem>
 #include <fstream>
 #include <iterator>
 #include <optional>
+#include <utility>
 #include "EditorShell.h"
 #include <Entity.h>
 #include <Scene.h>
@@ -23,6 +25,21 @@ namespace Xelqoria::Editor
             std::filesystem::path statePath = std::filesystem::temp_directory_path();
             statePath /= L"XelqoriaEditorHierarchyState.txt";
             return statePath;
+        }
+
+        [[nodiscard]] const wchar_t* GetComponentRowLabel(HierarchyPanelController::VisibleItemKind kind)
+        {
+            switch (kind)
+            {
+            case HierarchyPanelController::VisibleItemKind::SpriteComponent:
+                return L"  |-- SpriteComponent";
+            case HierarchyPanelController::VisibleItemKind::Material:
+                return L"  |-- Material";
+            case HierarchyPanelController::VisibleItemKind::Collider2DComponent:
+                return L"  |-- Collider2D";
+            default:
+                return L"";
+            }
         }
     }
 
@@ -60,19 +77,36 @@ namespace Xelqoria::Editor
                     continue;
                 }
 
+                const bool hasSpriteComponent = entity.HasSpriteComponent();
+                const bool hasMaterialComponent = hasSpriteComponent;
                 const bool hasCollider2DComponent = entity.HasCollider2DComponent();
+                const bool hasChildComponent = hasSpriteComponent || hasMaterialComponent || hasCollider2DComponent;
                 const bool isExpanded = m_collapsedEntityIds.find(entity.GetId()) == m_collapsedEntityIds.end();
                 m_visibleEntityIds.push_back(entity.GetId());
                 m_visibleItemKinds.push_back(VisibleItemKind::Entity);
 
-                label = FormatEntityRowLabel(label, hasCollider2DComponent, isExpanded);
+                label = FormatEntityRowLabel(label, hasChildComponent, isExpanded);
                 SendMessageW(m_hierarchyListBox, LB_ADDSTRING, 0, reinterpret_cast<LPARAM>(label.c_str()));
 
-                if (ShouldShowCollider2DChildRow(hasCollider2DComponent, isExpanded))
+                const std::array<std::pair<bool, VisibleItemKind>, 3> componentRows{
+                    std::pair<bool, VisibleItemKind>{ hasSpriteComponent, VisibleItemKind::SpriteComponent },
+                    std::pair<bool, VisibleItemKind>{ hasMaterialComponent, VisibleItemKind::Material },
+                    std::pair<bool, VisibleItemKind>{ hasCollider2DComponent, VisibleItemKind::Collider2DComponent }
+                };
+                for (const auto& componentRow : componentRows)
                 {
+                    if (false == ShouldShowComponentChildRow(componentRow.first, isExpanded))
+                    {
+                        continue;
+                    }
+
                     m_visibleEntityIds.push_back(entity.GetId());
-                    m_visibleItemKinds.push_back(VisibleItemKind::Collider2DComponent);
-                    SendMessageW(m_hierarchyListBox, LB_ADDSTRING, 0, reinterpret_cast<LPARAM>(L"  Collider2DComponent"));
+                    m_visibleItemKinds.push_back(componentRow.second);
+                    SendMessageW(
+                        m_hierarchyListBox,
+                        LB_ADDSTRING,
+                        0,
+                        reinterpret_cast<LPARAM>(GetComponentRowLabel(componentRow.second)));
                 }
             }
         }
@@ -286,6 +320,11 @@ namespace Xelqoria::Editor
         return m_selectedEntityId;
     }
 
+    HierarchyPanelController::VisibleItemKind HierarchyPanelController::GetSelectedItemKind() const
+    {
+        return m_selectedItemKind;
+    }
+
     bool HierarchyPanelController::ToggleSelectedEntityExpansion(const Game::Scene& scene)
     {
         if (false == m_selectedEntityId.has_value()
@@ -296,7 +335,8 @@ namespace Xelqoria::Editor
 
         const auto selectedEntity = scene.FindEntity(*m_selectedEntityId);
         if (false == selectedEntity.has_value()
-            || false == selectedEntity->get().HasCollider2DComponent())
+            || (false == selectedEntity->get().HasSpriteComponent()
+                && false == selectedEntity->get().HasCollider2DComponent()))
         {
             return false;
         }

--- a/Editor/Source/HierarchyPanelController.h
+++ b/Editor/Source/HierarchyPanelController.h
@@ -131,5 +131,15 @@ namespace Xelqoria::Editor
         /// <param name="scene">表示対象の Scene。</param>
         /// <returns>展開状態を変更した場合は true。</returns>
         bool ToggleSelectedEntityExpansion(const Game::Scene& scene);
+
+        /// <summary>
+        /// Hierarchy 展開状態をローカル UI 状態ファイルから復元する。
+        /// </summary>
+        void LoadExpansionState();
+
+        /// <summary>
+        /// Hierarchy 展開状態をローカル UI 状態ファイルへ保存する。
+        /// </summary>
+        void SaveExpansionState() const;
     };
 }

--- a/Editor/Source/HierarchyPanelController.h
+++ b/Editor/Source/HierarchyPanelController.h
@@ -28,6 +28,8 @@ namespace Xelqoria::Editor
         enum class VisibleItemKind
         {
             Entity,
+            SpriteComponent,
+            Material,
             Collider2DComponent
         };
 
@@ -57,6 +59,19 @@ namespace Xelqoria::Editor
         }
 
         /// <summary>
+        /// Component 子行を表示するかを判定する。
+        /// </summary>
+        /// <param name="hasComponent">Entity が対象 Component を保持しているか。</param>
+        /// <param name="isExpanded">Entity 行が展開中か。</param>
+        /// <returns>子行を表示する場合は true。</returns>
+        [[nodiscard]] static bool ShouldShowComponentChildRow(
+            bool hasComponent,
+            bool isExpanded)
+        {
+            return hasComponent && isExpanded;
+        }
+
+        /// <summary>
         /// Collider2DComponent 子行を表示するかを判定する。
         /// </summary>
         /// <param name="hasCollider2DComponent">Entity が Collider2DComponent を保持しているか。</param>
@@ -66,7 +81,7 @@ namespace Xelqoria::Editor
             bool hasCollider2DComponent,
             bool isExpanded)
         {
-            return hasCollider2DComponent && isExpanded;
+            return ShouldShowComponentChildRow(hasCollider2DComponent, isExpanded);
         }
 
         /// <summary>
@@ -106,6 +121,12 @@ namespace Xelqoria::Editor
         /// </summary>
         /// <returns>現在選択中の EntityId。</returns>
         [[nodiscard]] std::optional<Game::EntityId> GetSelectedEntityId() const;
+
+        /// <summary>
+        /// 現在選択中の Hierarchy 行種別を取得する。
+        /// </summary>
+        /// <returns>現在選択中の行種別。</returns>
+        [[nodiscard]] VisibleItemKind GetSelectedItemKind() const;
 
     private:
         HWND m_hierarchyListBox = nullptr;

--- a/Editor/Source/InspectorPanelController.cpp
+++ b/Editor/Source/InspectorPanelController.cpp
@@ -144,6 +144,19 @@ namespace Xelqoria::Editor
             statePath /= L"XelqoriaEditorInspectorState.txt";
             return statePath;
         }
+
+        [[nodiscard]] bool HitTestWindow(HWND window, Platform::Point cursorPoint)
+        {
+            if (nullptr == window || FALSE == IsWindowVisible(window))
+            {
+                return false;
+            }
+
+            RECT rect{};
+            GetWindowRect(window, &rect);
+            const POINT point{ static_cast<LONG>(cursorPoint.x), static_cast<LONG>(cursorPoint.y) };
+            return PtInRect(&rect, point) != FALSE;
+        }
     }
 
     void InspectorPanelController::Bind(const EditorShell& shell, Platform::ICursor& cursor)
@@ -202,9 +215,11 @@ namespace Xelqoria::Editor
         bool canAddSpriteComponent,
         const Game::Assets::ISpriteAssetResolver& spriteAssetResolver,
         const Game::Assets::IMaterialAssetResolver& materialAssetResolver,
+        HierarchyPanelController::VisibleItemKind selectedItemKind,
         const std::filesystem::path& selectedAssetPath)
     {
         (void)materialAssetResolver;
+        UpdateSectionLabels(selectedItemKind);
 
         if (false == selectedEntityId.has_value() || nullptr == scene)
         {
@@ -259,6 +274,7 @@ namespace Xelqoria::Editor
             m_lastSpriteRefDisplayText.clear();
             m_lastScriptAssetId = {};
             m_lastScriptDisplayText.clear();
+            ApplyCardVisibility(false, false, false);
             return;
         }
 
@@ -306,6 +322,7 @@ namespace Xelqoria::Editor
             m_lastSpriteRefDisplayText.clear();
             m_lastScriptAssetId = {};
             m_lastScriptDisplayText.clear();
+            ApplyCardVisibility(false, false, false);
             return;
         }
 
@@ -461,6 +478,8 @@ namespace Xelqoria::Editor
             SetEditFloat(m_collider2DEditControls[3], collider.size.y);
             SetWindowTextW(m_collider2DRotationEdit, L"0.000");
         }
+        ApplyCardVisibility(hasSpriteComponent, hasSpriteComponent, collider2DComponent.has_value());
+        UpdateSectionLabels(selectedItemKind);
 
         std::wstring summaryText = L"Inspector: ";
         summaryText += ToWideString(entity->get().GetName());
@@ -474,9 +493,14 @@ namespace Xelqoria::Editor
         bool canAddSpriteComponent,
         const Core::InputSnapshot& inputSnapshot,
         const Game::Assets::ISpriteAssetResolver& spriteAssetResolver,
-        const Game::Assets::IMaterialAssetResolver& materialAssetResolver)
+        const Game::Assets::IMaterialAssetResolver& materialAssetResolver,
+        HierarchyPanelController::VisibleItemKind selectedItemKind)
     {
         InspectorApplyResult result{};
+        if (ToggleSectionCollapseFromInput(inputSnapshot))
+        {
+            Refresh(scene, selectedEntityId, canAddSpriteComponent, spriteAssetResolver, materialAssetResolver, selectedItemKind);
+        }
         if (false == selectedEntityId.has_value() || nullptr == scene)
         {
             return result;
@@ -484,7 +508,7 @@ namespace Xelqoria::Editor
 
         if (m_lastInspectorEntityId != selectedEntityId)
         {
-            Refresh(scene, selectedEntityId, canAddSpriteComponent, spriteAssetResolver, materialAssetResolver);
+            Refresh(scene, selectedEntityId, canAddSpriteComponent, spriteAssetResolver, materialAssetResolver, selectedItemKind);
         }
 
         const auto entity = scene->FindEntity(*selectedEntityId);
@@ -720,7 +744,7 @@ namespace Xelqoria::Editor
 
         if (result.changed)
         {
-            Refresh(scene, selectedEntityId, canAddSpriteComponent, spriteAssetResolver, materialAssetResolver);
+            Refresh(scene, selectedEntityId, canAddSpriteComponent, spriteAssetResolver, materialAssetResolver, selectedItemKind);
         }
 
         FinishButtonClickTracking(inputSnapshot);
@@ -765,7 +789,13 @@ namespace Xelqoria::Editor
         spriteComponent->get().materialAssetRef = droppedMaterialAssetId;
         result.changed = true;
         result.operationName = "Change Sprite Material";
-        Refresh(scene, selectedEntityId, true, spriteAssetResolver, materialAssetResolver);
+        Refresh(
+            scene,
+            selectedEntityId,
+            true,
+            spriteAssetResolver,
+            materialAssetResolver,
+            HierarchyPanelController::VisibleItemKind::SpriteComponent);
         return result;
     }
 
@@ -991,6 +1021,110 @@ namespace Xelqoria::Editor
         EnableWindow(m_materialTextureBrowseButton, FALSE);
         EnableWindow(m_materialTintColorButton, FALSE);
         EnableWindow(m_materialOutlineColorButton, FALSE);
+    }
+
+    void InspectorPanelController::ApplyCardVisibility(
+        bool hasSpriteComponent,
+        bool hasMaterialDetails,
+        bool hasCollider2DComponent) const
+    {
+        for (HWND transformEdit : m_transformEditControls)
+        {
+            ShowWindow(transformEdit, m_isTransformCollapsed ? SW_HIDE : SW_SHOW);
+        }
+
+        const bool showSprite = hasSpriteComponent && false == m_isSpriteComponentCollapsed;
+        ShowWindow(m_spriteRefLabel, showSprite ? SW_SHOW : SW_HIDE);
+        ShowWindow(m_spriteRefEdit, showSprite ? SW_SHOW : SW_HIDE);
+        ShowWindow(m_materialOpenButton, showSprite ? SW_SHOW : SW_HIDE);
+        ShowWindow(m_scriptAssetLabel, showSprite ? SW_SHOW : SW_HIDE);
+        ShowWindow(m_scriptAssetEdit, showSprite ? SW_SHOW : SW_HIDE);
+        ShowWindow(m_scriptCreateButton, showSprite ? SW_SHOW : SW_HIDE);
+        ShowWindow(m_scriptAssignButton, showSprite ? SW_SHOW : SW_HIDE);
+        ShowWindow(m_scriptClearButton, showSprite ? SW_SHOW : SW_HIDE);
+        ShowWindow(m_spriteComponentActionButton, m_isSpriteComponentCollapsed ? SW_HIDE : SW_SHOW);
+
+        const bool showMaterialBody = hasMaterialDetails && false == m_isMaterialCollapsed;
+        SetMaterialDetailsVisible(showMaterialBody);
+        ShowWindow(m_materialDetailsSectionLabel, hasMaterialDetails ? SW_SHOW : SW_HIDE);
+
+        SetCollider2DControlsVisible(
+            m_collider2DEnabledCheckBox,
+            m_collider2DTriggerCheckBox,
+            m_collider2DShapeTypeLabel,
+            m_collider2DShapeTypeEdit,
+            m_collider2DOffsetLabel,
+            m_collider2DSizeLabel,
+            m_collider2DEditControls,
+            m_collider2DRotationLabel,
+            m_collider2DRotationEdit,
+            m_collider2DEditButton,
+            hasCollider2DComponent && false == m_isCollider2DCollapsed);
+        ShowWindow(m_collider2DComponentActionButton, m_isCollider2DCollapsed ? SW_HIDE : SW_SHOW);
+    }
+
+    void InspectorPanelController::UpdateSectionLabels(HierarchyPanelController::VisibleItemKind selectedItemKind)
+    {
+        const auto makeLabel =
+            [](bool collapsed, bool selected, const wchar_t* name)
+            {
+                std::wstring label = selected ? L"> " : L"";
+                label += collapsed ? L"+ " : L"- ";
+                label += name;
+                return label;
+            };
+
+        SetWindowTextW(
+            m_transformSectionLabel,
+            makeLabel(m_isTransformCollapsed, HierarchyPanelController::VisibleItemKind::Entity == selectedItemKind, L"Transform").c_str());
+        SetWindowTextW(
+            m_spriteComponentSectionLabel,
+            makeLabel(m_isSpriteComponentCollapsed, HierarchyPanelController::VisibleItemKind::SpriteComponent == selectedItemKind, L"SpriteComponent").c_str());
+        SetWindowTextW(
+            m_materialDetailsSectionLabel,
+            makeLabel(m_isMaterialCollapsed, HierarchyPanelController::VisibleItemKind::Material == selectedItemKind, L"Material").c_str());
+        SetWindowTextW(
+            m_collider2DComponentSectionLabel,
+            makeLabel(m_isCollider2DCollapsed, HierarchyPanelController::VisibleItemKind::Collider2DComponent == selectedItemKind, L"Collider2D").c_str());
+    }
+
+    bool InspectorPanelController::ToggleSectionCollapseFromInput(const Core::InputSnapshot& inputSnapshot)
+    {
+        const bool isLeftMouseButtonDown = inputSnapshot.IsMouseButtonDown(Core::MouseButton::Left);
+        if (false == isLeftMouseButtonDown || true == m_wasLeftMouseButtonDown)
+        {
+            return false;
+        }
+
+        if (HitTestWindow(m_transformSectionLabel, inputSnapshot.GetCursorScreenPoint()))
+        {
+            m_isTransformCollapsed = false == m_isTransformCollapsed;
+            SaveCollapseState();
+            return true;
+        }
+
+        if (HitTestWindow(m_spriteComponentSectionLabel, inputSnapshot.GetCursorScreenPoint()))
+        {
+            m_isSpriteComponentCollapsed = false == m_isSpriteComponentCollapsed;
+            SaveCollapseState();
+            return true;
+        }
+
+        if (HitTestWindow(m_materialDetailsSectionLabel, inputSnapshot.GetCursorScreenPoint()))
+        {
+            m_isMaterialCollapsed = false == m_isMaterialCollapsed;
+            SaveCollapseState();
+            return true;
+        }
+
+        if (HitTestWindow(m_collider2DComponentSectionLabel, inputSnapshot.GetCursorScreenPoint()))
+        {
+            m_isCollider2DCollapsed = false == m_isCollider2DCollapsed;
+            SaveCollapseState();
+            return true;
+        }
+
+        return false;
     }
 
     bool InspectorPanelController::ConsumeButtonClick(

--- a/Editor/Source/InspectorPanelController.cpp
+++ b/Editor/Source/InspectorPanelController.cpp
@@ -8,6 +8,8 @@
 #include <cstdio>
 #include <cstdlib>
 #include <cwctype>
+#include <filesystem>
+#include <fstream>
 #include <iterator>
 #include <optional>
 #include <AssetId.h>
@@ -135,6 +137,13 @@ namespace Xelqoria::Editor
             SetWindowVisible(scriptAssignButton, visible);
             SetWindowVisible(scriptClearButton, visible);
         }
+
+        [[nodiscard]] std::filesystem::path GetInspectorStatePath()
+        {
+            std::filesystem::path statePath = std::filesystem::temp_directory_path();
+            statePath /= L"XelqoriaEditorInspectorState.txt";
+            return statePath;
+        }
     }
 
     void InspectorPanelController::Bind(const EditorShell& shell, Platform::ICursor& cursor)
@@ -184,6 +193,7 @@ namespace Xelqoria::Editor
         SetWindowTextW(m_materialTintColorButton, L"");
         SetWindowTextW(m_materialOutlineColorButton, L"");
         SetWindowTextW(m_addComponentButton, L"Add Component");
+        LoadCollapseState();
     }
 
     void InspectorPanelController::Refresh(
@@ -899,6 +909,52 @@ namespace Xelqoria::Editor
     void InspectorPanelController::ResetTrackedEntity()
     {
         m_lastInspectorEntityId.reset();
+    }
+
+    void InspectorPanelController::LoadCollapseState()
+    {
+        std::ifstream input(GetInspectorStatePath());
+        if (false == input.is_open())
+        {
+            return;
+        }
+
+        std::string key{};
+        int value = 0;
+        while (input >> key >> value)
+        {
+            const bool collapsed = 0 != value;
+            if ("transform" == key)
+            {
+                m_isTransformCollapsed = collapsed;
+            }
+            else if ("sprite" == key)
+            {
+                m_isSpriteComponentCollapsed = collapsed;
+            }
+            else if ("material" == key)
+            {
+                m_isMaterialCollapsed = collapsed;
+            }
+            else if ("collider2d" == key)
+            {
+                m_isCollider2DCollapsed = collapsed;
+            }
+        }
+    }
+
+    void InspectorPanelController::SaveCollapseState() const
+    {
+        std::ofstream output(GetInspectorStatePath(), std::ios::trunc);
+        if (false == output.is_open())
+        {
+            return;
+        }
+
+        output << "transform " << (m_isTransformCollapsed ? 1 : 0) << '\n';
+        output << "sprite " << (m_isSpriteComponentCollapsed ? 1 : 0) << '\n';
+        output << "material " << (m_isMaterialCollapsed ? 1 : 0) << '\n';
+        output << "collider2d " << (m_isCollider2DCollapsed ? 1 : 0) << '\n';
     }
 
     void InspectorPanelController::SetMaterialDetailsVisible(bool visible) const

--- a/Editor/Source/InspectorPanelController.h
+++ b/Editor/Source/InspectorPanelController.h
@@ -13,6 +13,7 @@
 #include "Assets/SpriteAsset.h"
 #include "Assets/SpriteMaterialAsset.h"
 #include "EditorStringUtils.h"
+#include "HierarchyPanelController.h"
 #include "EditorShell.h"
 #include "ICursor.h"
 #include "InputSystem.h"
@@ -199,6 +200,7 @@ namespace Xelqoria::Editor
             bool canAddSpriteComponent,
             const Game::Assets::ISpriteAssetResolver& spriteAssetResolver,
             const Game::Assets::IMaterialAssetResolver& materialAssetResolver,
+            HierarchyPanelController::VisibleItemKind selectedItemKind,
             const std::filesystem::path& selectedAssetPath = {});
 
         /// <summary>
@@ -215,7 +217,8 @@ namespace Xelqoria::Editor
             bool canAddSpriteComponent,
             const Core::InputSnapshot& inputSnapshot,
             const Game::Assets::ISpriteAssetResolver& spriteAssetResolver,
-            const Game::Assets::IMaterialAssetResolver& materialAssetResolver);
+            const Game::Assets::IMaterialAssetResolver& materialAssetResolver,
+            HierarchyPanelController::VisibleItemKind selectedItemKind);
 
         /// <summary>
         /// Assets から Material 欄へドロップされた Material を SpriteComponent へ反映する。
@@ -508,6 +511,12 @@ namespace Xelqoria::Editor
         void SetMaterialDetailsVisible(bool visible) const;
 
         void SetMaterialDetailsEnabled(bool enabled) const;
+
+        void ApplyCardVisibility(bool hasSpriteComponent, bool hasMaterialDetails, bool hasCollider2DComponent) const;
+
+        void UpdateSectionLabels(HierarchyPanelController::VisibleItemKind selectedItemKind);
+
+        bool ToggleSectionCollapseFromInput(const Core::InputSnapshot& inputSnapshot);
 
         HWND m_inspectorSummaryLabel = nullptr;
         HWND m_transformSectionLabel = nullptr;

--- a/Editor/Source/InspectorPanelController.h
+++ b/Editor/Source/InspectorPanelController.h
@@ -274,6 +274,16 @@ namespace Xelqoria::Editor
         void ResetTrackedEntity();
 
         /// <summary>
+        /// Inspector 折りたたみ状態をローカル UI 状態ファイルから復元する。
+        /// </summary>
+        void LoadCollapseState();
+
+        /// <summary>
+        /// Inspector 折りたたみ状態をローカル UI 状態ファイルへ保存する。
+        /// </summary>
+        void SaveCollapseState() const;
+
+        /// <summary>
         /// TextureAssetId から Texture 欄に表示するファイル名を取得する。
         /// </summary>
         /// <param name="textureAssetId">表示対象の TextureAssetId。</param>
@@ -546,5 +556,9 @@ namespace Xelqoria::Editor
         HWND m_pressedButtonHandle = nullptr;
         bool m_isDropHighlightVisible = false;
         HWND m_dropHighlightTargetEdit = nullptr;
+        bool m_isTransformCollapsed = false;
+        bool m_isSpriteComponentCollapsed = false;
+        bool m_isMaterialCollapsed = false;
+        bool m_isCollider2DCollapsed = false;
     };
 }

--- a/Editor/Source/LogOutputPanelController.cpp
+++ b/Editor/Source/LogOutputPanelController.cpp
@@ -88,10 +88,27 @@ namespace Xelqoria::Editor
             return text;
         }
 
-        [[nodiscard]] std::wstring FormatLogLine(LogOutputCategory category, const std::wstring& message)
+        [[nodiscard]] std::wstring FormatLogLine(LogOutputCategory category, LogOutputSeverity severity, const std::wstring& message)
         {
             std::wstring line = L"[";
             line += BuildTimestampText();
+            line += L"] [";
+            if (LogOutputSeverity::Warning == severity)
+            {
+                line += L"Warn";
+            }
+            else if (LogOutputSeverity::Error == severity)
+            {
+                line += L"Error";
+            }
+            else if (LogOutputCategory::Editor == category)
+            {
+                line += L"Editor";
+            }
+            else
+            {
+                line += L"Info";
+            }
             line += L"] [";
             line += ToCategoryText(category);
             line += L"] ";
@@ -115,7 +132,7 @@ namespace Xelqoria::Editor
     void LogOutputPanelController::Append(LogOutputCategory category, std::wstring message, bool isError)
     {
         const LogOutputSeverity severity = InferSeverity(message, isError);
-        m_logs.push_back(LogOutputEntry{ FormatLogLine(category, message), severity });
+        m_logs.push_back(LogOutputEntry{ FormatLogLine(category, severity, message), category, severity });
         RefreshVisibleRows();
     }
 
@@ -150,7 +167,7 @@ namespace Xelqoria::Editor
         };
         if (TryConsumeButtonClick(BuildButtonClickTarget(m_clearButton), frameInput, m_buttonInputState))
         {
-            m_logs.clear();
+            m_visibleLogStartIndex = m_logs.size();
             RefreshVisibleRows();
             m_buttonInputState.pressedButtonId = 0;
         }
@@ -182,10 +199,11 @@ namespace Xelqoria::Editor
         }
 
         const bool isSelected = 0 != (drawItem->itemState & ODS_SELECTED);
-        const auto severity = static_cast<LogOutputSeverity>(drawItem->itemData);
+        const auto severity = static_cast<LogOutputSeverity>(drawItem->itemData % 10);
+        const auto category = static_cast<LogOutputCategory>(drawItem->itemData / 10);
         const EditorColor backgroundColor =
             isSelected ? EditorThemes::XelqoriaDark.selection : EditorThemes::XelqoriaDark.panelBackground;
-        EditorColor textColor = EditorThemes::XelqoriaDark.textPrimary;
+        EditorColor textColor = EditorColor::FromRgb8(0x78, 0xB7, 0xFF);
         if (LogOutputSeverity::Warning == severity)
         {
             textColor = EditorThemes::XelqoriaDark.warning;
@@ -193,6 +211,10 @@ namespace Xelqoria::Editor
         else if (LogOutputSeverity::Error == severity)
         {
             textColor = EditorThemes::XelqoriaDark.error;
+        }
+        else if (LogOutputCategory::Editor == category)
+        {
+            textColor = EditorThemes::XelqoriaDark.accent;
         }
 
         FillRectWithThemeColor(drawItem->hDC, drawItem->rcItem, backgroundColor);
@@ -250,11 +272,11 @@ namespace Xelqoria::Editor
             return;
         }
 
-        m_logs.push_back(LogOutputEntry{ FormatLogLine(LogOutputCategory::Editor, L"Xelqoria Editor started"), LogOutputSeverity::Normal });
-        m_logs.push_back(LogOutputEntry{ FormatLogLine(LogOutputCategory::Editor, L"Project loaded"), LogOutputSeverity::Normal });
-        m_logs.push_back(LogOutputEntry{ FormatLogLine(LogOutputCategory::Editor, L"Assets scan completed"), LogOutputSeverity::Normal });
-        m_logs.push_back(LogOutputEntry{ FormatLogLine(LogOutputCategory::Game, L"Scene initialized"), LogOutputSeverity::Warning });
-        m_logs.push_back(LogOutputEntry{ FormatLogLine(LogOutputCategory::Build, L"Renderer ready"), LogOutputSeverity::Error });
+        m_logs.push_back(LogOutputEntry{ FormatLogLine(LogOutputCategory::Editor, LogOutputSeverity::Normal, L"Xelqoria Editor started"), LogOutputCategory::Editor, LogOutputSeverity::Normal });
+        m_logs.push_back(LogOutputEntry{ FormatLogLine(LogOutputCategory::Editor, LogOutputSeverity::Normal, L"Project loaded"), LogOutputCategory::Editor, LogOutputSeverity::Normal });
+        m_logs.push_back(LogOutputEntry{ FormatLogLine(LogOutputCategory::Editor, LogOutputSeverity::Normal, L"Assets scan completed"), LogOutputCategory::Editor, LogOutputSeverity::Normal });
+        m_logs.push_back(LogOutputEntry{ FormatLogLine(LogOutputCategory::Game, LogOutputSeverity::Warning, L"Scene initialized"), LogOutputCategory::Game, LogOutputSeverity::Warning });
+        m_logs.push_back(LogOutputEntry{ FormatLogLine(LogOutputCategory::Build, LogOutputSeverity::Error, L"Renderer ready"), LogOutputCategory::Build, LogOutputSeverity::Error });
     }
 
     void LogOutputPanelController::RefreshVisibleRows()
@@ -267,10 +289,18 @@ namespace Xelqoria::Editor
         SendMessageW(m_listBox, LB_RESETCONTENT, 0, 0);
         const std::wstring filterText = GetFilterText();
         const std::optional<LogOutputSeverity> severityFilter = GetActiveSeverityFilter();
-        for (const LogOutputEntry& log : m_logs)
+        const int activeTab = nullptr != m_tabControl ? TabCtrl_GetCurSel(m_tabControl) : 0;
+        for (std::size_t index = m_visibleLogStartIndex; index < m_logs.size(); ++index)
         {
+            const LogOutputEntry& log = m_logs[index];
             const bool severityMatched = false == severityFilter.has_value() || log.severity == *severityFilter;
-            if (severityMatched && ContainsFilter(log.message, filterText))
+            const bool categoryMatched =
+                0 == activeTab
+                || (1 == activeTab && LogOutputSeverity::Normal == log.severity && LogOutputCategory::Editor != log.category)
+                || (2 == activeTab && LogOutputCategory::Editor == log.category)
+                || (3 == activeTab && LogOutputSeverity::Warning == log.severity)
+                || (4 == activeTab && LogOutputSeverity::Error == log.severity);
+            if (severityMatched && categoryMatched && ContainsFilter(log.message, filterText))
             {
                 const LRESULT itemIndex =
                     SendMessageW(m_listBox, LB_ADDSTRING, 0, reinterpret_cast<LPARAM>(log.message.c_str()));
@@ -280,7 +310,7 @@ namespace Xelqoria::Editor
                         m_listBox,
                         LB_SETITEMDATA,
                         static_cast<WPARAM>(itemIndex),
-                        static_cast<LPARAM>(log.severity));
+                        static_cast<LPARAM>(static_cast<int>(log.category) * 10 + static_cast<int>(log.severity)));
                 }
             }
         }
@@ -329,9 +359,13 @@ namespace Xelqoria::Editor
         }
         if (2 == activeTab)
         {
-            return LogOutputSeverity::Warning;
+            return std::nullopt;
         }
         if (3 == activeTab)
+        {
+            return LogOutputSeverity::Warning;
+        }
+        if (4 == activeTab)
         {
             return LogOutputSeverity::Error;
         }

--- a/Editor/Source/LogOutputPanelController.h
+++ b/Editor/Source/LogOutputPanelController.h
@@ -78,6 +78,7 @@ namespace Xelqoria::Editor
         struct LogOutputEntry
         {
             std::wstring message{};
+            LogOutputCategory category = LogOutputCategory::Game;
             LogOutputSeverity severity = LogOutputSeverity::Normal;
         };
 
@@ -116,6 +117,7 @@ namespace Xelqoria::Editor
         HWND m_listBox = nullptr;
         Platform::IClipboard* m_clipboard = nullptr;
         std::vector<LogOutputEntry> m_logs{};
+        std::size_t m_visibleLogStartIndex = 0;
         ButtonClickInputState m_buttonInputState{};
         int m_lastActiveTab = 0;
         std::wstring m_lastFilterText{};

--- a/docs/plans/issue-300-ui-state-foundation.md
+++ b/docs/plans/issue-300-ui-state-foundation.md
@@ -1,0 +1,41 @@
+# ExecPlan: issue-300 共通UI定数とUI状態永続化の基盤追加
+
+## 目的
+
+Editor UI 改善の土台として、Inspector 折りたたみ状態と Hierarchy 展開状態を保持し、保存・復元できる基盤を追加する。
+
+## 対象範囲
+
+- 変更対象プロジェクト: `Editor`
+- 変更対象ファイル: `Editor/Source/HierarchyPanelController.*`, `Editor/Source/InspectorPanelController.*`
+- 変更対象クラス: `HierarchyPanelController`, `InspectorPanelController`
+- 影響する機能: Hierarchy 展開状態、Inspector 折りたたみ状態
+
+## 前提
+
+- parent issue: issue-299
+- parent issue ブランチ: `issue-299`
+- この child issue のブランチ: `issue-300`
+- PR の向き: `issue-300` -> `issue-299`
+
+## 実装方針
+
+Win32 描画処理とは切り離し、各 Controller が UI 状態を保持する。保存失敗時は通常操作を妨げない。
+
+## 作業手順
+
+1. Hierarchy 展開状態をローカル状態ファイルへ保存・復元する
+2. Inspector 折りたたみ状態を保持し、ローカル状態ファイルへ保存・復元する関数を追加する
+3. Editor ビルドと Editor テストを実行する
+
+## 検証方法
+
+- `Editor/Xelqoria.Editor.vcxproj` Debug x64 ビルド
+- `tests/Editor/Xelqoria.Tests.Editor.vcxproj` Debug x64 ビルド
+- `artifacts/x64/Debug/Xelqoria.Tests.Editor.exe`
+
+## 完了条件
+
+- Inspector 折りたたみ状態を Component 種別ごとに保持できる
+- Hierarchy 展開状態を GameObject ごとに保持できる
+- 保存失敗時に通常操作が妨げられない

--- a/docs/plans/issue-301-inspector-component-cards.md
+++ b/docs/plans/issue-301-inspector-component-cards.md
@@ -1,0 +1,45 @@
+# ExecPlan: issue-301 Inspector の Component カードUI改善
+
+## 目的
+
+Inspector を Component カード単位に整理し、Hierarchy の Component 選択時に対応カードを強調表示する。
+
+## 対象範囲
+
+- 変更対象プロジェクト: `Editor`
+- 変更対象ファイル: `Editor/Source/Application.cpp`, `Editor/Source/EditorShell.cpp`, `Editor/Source/InspectorPanelController.*`
+- 変更対象クラス: `Application`, `EditorShell`, `InspectorPanelController`
+- 影響する機能: Inspector 表示、Component カード折りたたみ、選択 Component 強調
+
+## 前提
+
+- parent issue: issue-299
+- 先行 child issue: issue-300, issue-302
+- parent issue ブランチ: `issue-299`
+- この child issue のブランチ: `issue-301`
+- PR の向き: `issue-301` -> `issue-299`
+
+## 実装方針
+
+既存 Inspector コントロールを維持しつつ、カード見出しのラベル、折りたたみ、表示制御、選択中 Component の強調表示を Controller へ追加する。
+
+## 作業手順
+
+1. Hierarchy の選択行種別を Inspector Refresh/ApplyEdits へ渡す
+2. Inspector の各 Component カード見出しに折りたたみ状態と選択状態を反映する
+3. 見出しクリックで折りたたみ状態を変更し、保存する
+4. 選択中カードの見出しを紫系アクセントで強調する
+5. Editor ビルドと Editor テストを実行する
+
+## 検証方法
+
+- `Editor/Xelqoria.Editor.vcxproj` Debug x64 ビルド
+- `tests/Editor/Xelqoria.Tests.Editor.vcxproj` Debug x64 ビルド
+- `artifacts/x64/Debug/Xelqoria.Tests.Editor.exe`
+
+## 完了条件
+
+- Inspector 上部に選択中オブジェクト名が表示される
+- Component カードを折りたためる
+- Component 選択時に該当カードが強調表示される
+- Component 選択時も他 Component のカードが非表示にならない

--- a/docs/plans/issue-302-hierarchy-component-tree.md
+++ b/docs/plans/issue-302-hierarchy-component-tree.md
@@ -1,0 +1,44 @@
+# ExecPlan: issue-302 Hierarchy の GameObject / Component ツリー表示改善
+
+## 目的
+
+Hierarchy で GameObject と Component の親子関係を明確にし、Component 行を選択できるようにする。
+
+## 対象範囲
+
+- 変更対象プロジェクト: `Editor`
+- 変更対象ファイル: `Editor/Source/HierarchyPanelController.*`
+- 変更対象クラス: `HierarchyPanelController`
+- 影響する機能: Hierarchy 表示、Hierarchy 選択状態
+
+## 前提
+
+- parent issue: issue-299
+- 先行 child issue: issue-300
+- parent issue ブランチ: `issue-299`
+- この child issue のブランチ: `issue-302`
+- PR の向き: `issue-302` -> `issue-299`
+
+## 実装方針
+
+GameObject を親行として表示し、SpriteComponent、Material、Collider2D を Component 子行として表示する。Material は SpriteComponent の Material 参照を独立 Component として扱う。
+
+## 作業手順
+
+1. Hierarchy の表示行種別へ Component 種別を追加する
+2. GameObject 行の展開状態に応じて Component 子行を表示する
+3. 選択中行種別を外部から取得できるようにする
+4. Editor ビルドと Editor テストを実行する
+
+## 検証方法
+
+- `Editor/Xelqoria.Editor.vcxproj` Debug x64 ビルド
+- `tests/Editor/Xelqoria.Tests.Editor.vcxproj` Debug x64 ビルド
+- `artifacts/x64/Debug/Xelqoria.Tests.Editor.exe`
+
+## 完了条件
+
+- GameObject が親ノードとして表示される
+- SpriteComponent / Material / Collider2D が GameObject の子として表示される
+- Component を選択できる
+- 展開状態が保持される

--- a/docs/plans/issue-303-log-filter-display.md
+++ b/docs/plans/issue-303-log-filter-display.md
@@ -1,0 +1,44 @@
+# ExecPlan: issue-303 Log のフィルター、種別表示、Clear 表示制御改善
+
+## 目的
+
+Log パネルの種別フィルターと表示色を整理し、Clear 操作を内部ログ保持と画面表示クリアに分離する。
+
+## 対象範囲
+
+- 変更対象プロジェクト: `Editor`
+- 変更対象ファイル: `Editor/Source/EditorShell.cpp`, `Editor/Source/LogOutputPanelController.*`
+- 変更対象クラス: `EditorShell`, `LogOutputPanelController`
+- 影響する機能: Log パネル表示、フィルター、Clear 操作
+
+## 前提
+
+- parent issue: issue-299
+- parent issue ブランチ: `issue-299`
+- この child issue のブランチ: `issue-303`
+- PR の向き: `issue-303` -> `issue-299`
+
+## 実装方針
+
+LogEntry に category を保持し、TabControl のフィルターで `All / Info / Editor / Warn / Error` を切り替える。Clear はログ配列を消さず、表示開始位置だけを進める。
+
+## 作業手順
+
+1. Log タブ名を用途別に変更する
+2. LogEntry に category を追加する
+3. Log 表示行へ severity/category ラベルと色分けを追加する
+4. Clear を表示クリア動作へ変更する
+5. Editor ビルドと Editor テストを実行する
+
+## 検証方法
+
+- `Editor/Xelqoria.Editor.vcxproj` Debug x64 ビルド
+- `tests/Editor/Xelqoria.Tests.Editor.vcxproj` Debug x64 ビルド
+- `artifacts/x64/Debug/Xelqoria.Tests.Editor.exe`
+
+## 完了条件
+
+- All / Info / Editor / Warn / Error のフィルターがある
+- ログ行に種別が表示される
+- severity ごとの色分けがある
+- Clear 後も内部ログデータは保持される

--- a/docs/plans/issue-304-editor-ui-final-polish.md
+++ b/docs/plans/issue-304-editor-ui-final-polish.md
@@ -1,0 +1,44 @@
+# ExecPlan: issue-304 全体の見た目統一と受け入れ確認
+
+## 目的
+
+issue-300 から issue-303 の変更を統合し、完成図に近い一貫した見た目へ整える。
+
+## 対象範囲
+
+- 変更対象プロジェクト: `Editor`
+- 変更対象ファイル: `Editor/Source/EditorShell.cpp`
+- 変更対象クラス: `EditorShell`
+- 影響する機能: Editor 共通ボタン表示、Inspector / Hierarchy / Log の統合表示
+
+## 前提
+
+- parent issue: issue-299
+- 先行 child issue: issue-300, issue-301, issue-302, issue-303
+- parent issue ブランチ: `issue-299`
+- この child issue のブランチ: `issue-304`
+- PR の向き: `issue-304` -> `issue-299`
+
+## 実装方針
+
+各パネルの個別機能は先行 issue に置き、ここでは全体統一の見た目調整と統合確認に限定する。
+
+## 作業手順
+
+1. 先行 child issue ブランチを取り込む
+2. 主要アクションと削除系アクションのボタン表示を区別する
+3. Editor ビルドと Editor テストを実行する
+4. 差分が親 issue の目的を満たすことを確認する
+
+## 検証方法
+
+- `Editor/Xelqoria.Editor.vcxproj` Debug x64 ビルド
+- `tests/Editor/Xelqoria.Tests.Editor.vcxproj` Debug x64 ビルド
+- `artifacts/x64/Debug/Xelqoria.Tests.Editor.exe`
+
+## 完了条件
+
+- Inspector / Hierarchy / Log の変更が同時に成立する
+- 削除系操作が通常操作と見分けやすい
+- レイヤー責務に違反していない
+- Editor ビルドと Editor テストが通る


### PR DESCRIPTION
## Summary
- Addresses #304 under parent #299.
- Integrates prior child issue work and polishes shared Editor UI button styling.
- Distinguishes destructive actions from primary/normal actions.

## Verification
- Editor Debug x64 build
- Editor tests Debug x64 build
- `artifacts/x64/Debug/Xelqoria.Tests.Editor.exe` (77 passed)
