### PR TITLE
Issue 316: Add editor panel view wrappers

### DIFF
--- a/Editor/Source/Panels/AssetsPanelView.cpp
+++ b/Editor/Source/Panels/AssetsPanelView.cpp
@@ -1,0 +1,17 @@
+#include "Panels/AssetsPanelView.h"
+
+#include "Shell/EditorShell.h"
+
+namespace Xelqoria::Editor
+{
+    AssetsPanelView::AssetsPanelView(EditorShell& shell)
+        : EditorPanelViewBase(
+            EditorPanelId::Assets,
+            L"Assets",
+            [&shell]() { return std::vector<HWND>{ shell.m_assetsPanel, shell.m_assetsSummaryLabel, shell.m_assetsListView }; },
+            [&shell]() { return std::vector<HWND>{ shell.m_assetsPanel, shell.m_assetsListView }; },
+            [&shell]() { return std::vector<HWND>{ shell.m_assetsSummaryLabel }; },
+            []() { return std::vector<HWND>{}; })
+    {
+    }
+}

--- a/Editor/Source/Panels/AssetsPanelView.h
+++ b/Editor/Source/Panels/AssetsPanelView.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include "Panels/EditorPanelViewBase.h"
+
+namespace Xelqoria::Editor
+{
+    class EditorShell;
+
+    /// <summary>
+    /// Assets Panel の HWND 群を管理する View。
+    /// </summary>
+    class AssetsPanelView final : public EditorPanelViewBase
+    {
+    public:
+        /// <summary>
+        /// EditorShell が生成した Assets control 群へ接続する。
+        /// </summary>
+        explicit AssetsPanelView(EditorShell& shell);
+    };
+}

--- a/Editor/Source/Panels/Collider2DPanelView.cpp
+++ b/Editor/Source/Panels/Collider2DPanelView.cpp
@@ -1,0 +1,34 @@
+#include "Panels/Collider2DPanelView.h"
+
+#include "Shell/EditorShell.h"
+
+namespace Xelqoria::Editor
+{
+    std::vector<HWND> Collider2DPanelView::GetCollider2DControls(EditorShell& shell)
+    {
+        std::vector<HWND> controls{
+            shell.m_collider2DPanel,
+            shell.m_collider2DSummaryLabel,
+            shell.m_collider2DComponentSectionLabel,
+            shell.m_collider2DEnabledCheckBox,
+            shell.m_collider2DTriggerCheckBox,
+            shell.m_collider2DShapeTypeLabel,
+            shell.m_collider2DShapeTypeEdit,
+            shell.m_collider2DOffsetLabel,
+            shell.m_collider2DSizeLabel
+        };
+        controls.insert(controls.end(), shell.m_collider2DEditControls.begin(), shell.m_collider2DEditControls.end());
+        return controls;
+    }
+
+    Collider2DPanelView::Collider2DPanelView(EditorShell& shell)
+        : EditorPanelViewBase(
+            EditorPanelId::Collider2D,
+            L"Collider2D",
+            [&shell]() { return GetCollider2DControls(shell); },
+            [&shell]() { return GetCollider2DControls(shell); },
+            []() { return std::vector<HWND>{}; },
+            []() { return std::vector<HWND>{}; })
+    {
+    }
+}

--- a/Editor/Source/Panels/Collider2DPanelView.h
+++ b/Editor/Source/Panels/Collider2DPanelView.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include "Panels/EditorPanelViewBase.h"
+
+namespace Xelqoria::Editor
+{
+    class EditorShell;
+
+    /// <summary>
+    /// Collider2D Panel の HWND 群を管理する View。
+    /// </summary>
+    class Collider2DPanelView final : public EditorPanelViewBase
+    {
+    public:
+        /// <summary>
+        /// EditorShell が生成した Collider2D control 群へ接続する。
+        /// </summary>
+        explicit Collider2DPanelView(EditorShell& shell);
+
+    private:
+        [[nodiscard]] static std::vector<HWND> GetCollider2DControls(EditorShell& shell);
+    };
+}

--- a/Editor/Source/Panels/EditorPanelViewBase.cpp
+++ b/Editor/Source/Panels/EditorPanelViewBase.cpp
@@ -1,0 +1,100 @@
+#include "Panels/EditorPanelViewBase.h"
+
+#include <utility>
+
+namespace Xelqoria::Editor
+{
+    EditorPanelViewBase::EditorPanelViewBase(
+        EditorPanelId panelId,
+        const wchar_t* title,
+        ControlProvider controls,
+        ControlProvider visibleControls,
+        ControlProvider alwaysHiddenControls,
+        ControlProvider hideWhenInvisibleControls)
+        : m_panelId(panelId)
+        , m_title(title)
+        , m_controls(std::move(controls))
+        , m_visibleControls(std::move(visibleControls))
+        , m_alwaysHiddenControls(std::move(alwaysHiddenControls))
+        , m_hideWhenInvisibleControls(std::move(hideWhenInvisibleControls))
+    {
+    }
+
+    EditorPanelId EditorPanelViewBase::GetPanelId() const
+    {
+        return m_panelId;
+    }
+
+    const wchar_t* EditorPanelViewBase::GetTitle() const
+    {
+        return m_title;
+    }
+
+    bool EditorPanelViewBase::Initialize(HWND parentWindow, HINSTANCE hInstance)
+    {
+        (void)parentWindow;
+        (void)hInstance;
+        return true;
+    }
+
+    void EditorPanelViewBase::Layout(const RECT& bounds)
+    {
+        (void)bounds;
+    }
+
+    void EditorPanelViewBase::Show(bool visible)
+    {
+        const int showCommand = visible ? SW_SHOW : SW_HIDE;
+        for (HWND control : GetControls(m_visibleControls))
+        {
+            ShowWindow(control, showCommand);
+        }
+
+        for (HWND control : GetControls(m_alwaysHiddenControls))
+        {
+            ShowWindow(control, SW_HIDE);
+        }
+
+        if (false == visible)
+        {
+            for (HWND control : GetControls(m_hideWhenInvisibleControls))
+            {
+                ShowWindow(control, SW_HIDE);
+            }
+        }
+    }
+
+    void EditorPanelViewBase::SetParent(HWND parentWindow)
+    {
+        if (nullptr == parentWindow)
+        {
+            return;
+        }
+
+        for (HWND control : GetControls(m_controls))
+        {
+            if (nullptr != control && GetParent(control) != parentWindow)
+            {
+                ::SetParent(control, parentWindow);
+            }
+        }
+    }
+
+    void EditorPanelViewBase::CollectControls(std::vector<HWND>& controls) const
+    {
+        for (HWND control : GetControls(m_controls))
+        {
+            controls.push_back(control);
+        }
+    }
+
+    std::vector<HWND> EditorPanelViewBase::GetControls(const ControlProvider& provider) const
+    {
+        if (false == static_cast<bool>(provider))
+        {
+            return {};
+        }
+
+        return provider();
+    }
+}

--- a/Editor/Source/Panels/EditorPanelViewBase.h
+++ b/Editor/Source/Panels/EditorPanelViewBase.h
@@ -1,0 +1,47 @@
+#pragma once
+
+#include <functional>
+#include <vector>
+
+#include "Panels/IEditorPanelView.h"
+
+namespace Xelqoria::Editor
+{
+    /// <summary>
+    /// 既存 HWND 群を PanelView 契約へ接続する共通基底。
+    /// </summary>
+    class EditorPanelViewBase : public IEditorPanelView
+    {
+    public:
+        using ControlProvider = std::function<std::vector<HWND>()>;
+
+        /// <summary>
+        /// Panel 識別子、表示名、対象 control 群を指定して View 境界を作成する。
+        /// </summary>
+        EditorPanelViewBase(
+            EditorPanelId panelId,
+            const wchar_t* title,
+            ControlProvider controls,
+            ControlProvider visibleControls,
+            ControlProvider alwaysHiddenControls,
+            ControlProvider hideWhenInvisibleControls);
+
+        [[nodiscard]] EditorPanelId GetPanelId() const override;
+        [[nodiscard]] const wchar_t* GetTitle() const override;
+        bool Initialize(HWND parentWindow, HINSTANCE hInstance) override;
+        void Layout(const RECT& bounds) override;
+        void Show(bool visible) override;
+        void SetParent(HWND parentWindow) override;
+        void CollectControls(std::vector<HWND>& controls) const override;
+
+    private:
+        [[nodiscard]] std::vector<HWND> GetControls(const ControlProvider& provider) const;
+
+        EditorPanelId m_panelId;
+        const wchar_t* m_title = L"";
+        ControlProvider m_controls;
+        ControlProvider m_visibleControls;
+        ControlProvider m_alwaysHiddenControls;
+        ControlProvider m_hideWhenInvisibleControls;
+    };
+}

--- a/Editor/Source/Panels/HierarchyPanelView.cpp
+++ b/Editor/Source/Panels/HierarchyPanelView.cpp
@@ -1,0 +1,17 @@
+#include "Panels/HierarchyPanelView.h"
+
+#include "Shell/EditorShell.h"
+
+namespace Xelqoria::Editor
+{
+    HierarchyPanelView::HierarchyPanelView(EditorShell& shell)
+        : EditorPanelViewBase(
+            EditorPanelId::Hierarchy,
+            L"Hierarchy",
+            [&shell]() { return std::vector<HWND>{ shell.m_hierarchyPanel, shell.m_hierarchySummaryLabel, shell.m_hierarchyListBox, shell.m_hierarchySearchEdit, shell.m_hierarchyNameEdit, shell.m_hierarchyCreateButton, shell.m_hierarchyDuplicateButton, shell.m_hierarchyDeleteButton }; },
+            [&shell]() { return std::vector<HWND>{ shell.m_hierarchyPanel, shell.m_hierarchyListBox, shell.m_hierarchySearchEdit, shell.m_hierarchyNameEdit, shell.m_hierarchyCreateButton, shell.m_hierarchyDuplicateButton, shell.m_hierarchyDeleteButton }; },
+            [&shell]() { return std::vector<HWND>{ shell.m_hierarchySummaryLabel }; },
+            []() { return std::vector<HWND>{}; })
+    {
+    }
+}

--- a/Editor/Source/Panels/HierarchyPanelView.h
+++ b/Editor/Source/Panels/HierarchyPanelView.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include "Panels/EditorPanelViewBase.h"
+
+namespace Xelqoria::Editor
+{
+    class EditorShell;
+
+    /// <summary>
+    /// Hierarchy Panel の HWND 群を管理する View。
+    /// </summary>
+    class HierarchyPanelView final : public EditorPanelViewBase
+    {
+    public:
+        /// <summary>
+        /// EditorShell が生成した Hierarchy control 群へ接続する。
+        /// </summary>
+        explicit HierarchyPanelView(EditorShell& shell);
+    };
+}

--- a/Editor/Source/Panels/InspectorPanelView.cpp
+++ b/Editor/Source/Panels/InspectorPanelView.cpp
@@ -1,0 +1,113 @@
+#include "Panels/InspectorPanelView.h"
+
+#include <algorithm>
+
+#include "Shell/EditorShell.h"
+
+namespace Xelqoria::Editor
+{
+    namespace
+    {
+        void AppendArrayControls(std::vector<HWND>& controls, const std::array<HWND, 3>& values)
+        {
+            controls.insert(controls.end(), values.begin(), values.end());
+        }
+
+        void AppendArrayControls(std::vector<HWND>& controls, const std::array<HWND, 4>& values)
+        {
+            controls.insert(controls.end(), values.begin(), values.end());
+        }
+
+        void AppendArrayControls(std::vector<HWND>& controls, const std::array<HWND, 5>& values)
+        {
+            controls.insert(controls.end(), values.begin(), values.end());
+        }
+
+        void AppendArrayControls(std::vector<HWND>& controls, const std::array<HWND, 9>& values)
+        {
+            controls.insert(controls.end(), values.begin(), values.end());
+        }
+
+    }
+
+    std::vector<HWND> InspectorPanelView::GetInspectorControls(EditorShell& shell)
+    {
+        std::vector<HWND> controls{
+            shell.m_inspectorPanel,
+            shell.m_inspectorSummaryLabel,
+            shell.m_transformSectionLabel
+        };
+        AppendArrayControls(controls, shell.m_transformLabels);
+        AppendArrayControls(controls, shell.m_transformEditControls);
+        controls.insert(
+            controls.end(),
+            {
+                shell.m_spriteComponentSectionLabel,
+                shell.m_spriteRefLabel,
+                shell.m_spriteRefDropHighlight,
+                shell.m_spriteRefEdit,
+                shell.m_materialOpenButton,
+                shell.m_scriptAssetLabel,
+                shell.m_scriptAssetEdit,
+                shell.m_scriptCreateButton,
+                shell.m_scriptAssignButton,
+                shell.m_scriptClearButton,
+                shell.m_spriteComponentActionButton,
+                shell.m_materialSharedNoticeLabel,
+                shell.m_materialDetailsSectionLabel
+            });
+        AppendArrayControls(controls, shell.m_materialDetailLabels);
+        AppendArrayControls(controls, shell.m_materialDetailEditControls);
+        controls.insert(
+            controls.end(),
+            {
+                shell.m_materialTextureDropHighlight,
+                shell.m_materialTextureBrowseButton,
+                shell.m_materialTintColorButton,
+                shell.m_materialOutlineEnabledCheckBox,
+                shell.m_materialOutlineColorButton,
+                shell.m_collider2DComponentSectionLabel,
+                shell.m_collider2DSummaryLabel,
+                shell.m_collider2DEnabledCheckBox,
+                shell.m_collider2DTriggerCheckBox,
+                shell.m_collider2DShapeTypeLabel,
+                shell.m_collider2DShapeTypeEdit,
+                shell.m_collider2DOffsetLabel,
+                shell.m_collider2DSizeLabel,
+                shell.m_collider2DRotationLabel,
+                shell.m_collider2DRotationEdit
+            });
+        AppendArrayControls(controls, shell.m_collider2DEditControls);
+        controls.insert(
+            controls.end(),
+            {
+                shell.m_collider2DEditButton,
+                shell.m_collider2DComponentActionButton,
+                shell.m_addComponentButton
+            });
+        return controls;
+    }
+
+    std::vector<HWND> InspectorPanelView::GetInspectorVisibleControls(EditorShell& shell)
+    {
+        std::vector<HWND> controls = GetInspectorControls(shell);
+        controls.erase(
+            std::remove(controls.begin(), controls.end(), shell.m_spriteRefDropHighlight),
+            controls.end());
+        controls.erase(
+            std::remove(controls.begin(), controls.end(), shell.m_materialTextureDropHighlight),
+            controls.end());
+        return controls;
+    }
+
+    InspectorPanelView::InspectorPanelView(EditorShell& shell)
+        : EditorPanelViewBase(
+            EditorPanelId::Inspector,
+            L"Inspector",
+            [&shell]() { return GetInspectorControls(shell); },
+            [&shell]() { return GetInspectorVisibleControls(shell); },
+            []() { return std::vector<HWND>{}; },
+            [&shell]() { return std::vector<HWND>{ shell.m_spriteRefDropHighlight, shell.m_materialTextureDropHighlight }; })
+    {
+    }
+}

--- a/Editor/Source/Panels/InspectorPanelView.h
+++ b/Editor/Source/Panels/InspectorPanelView.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include "Panels/EditorPanelViewBase.h"
+
+namespace Xelqoria::Editor
+{
+    class EditorShell;
+
+    /// <summary>
+    /// Inspector Panel の HWND 群を管理する View。
+    /// </summary>
+    class InspectorPanelView final : public EditorPanelViewBase
+    {
+    public:
+        /// <summary>
+        /// EditorShell が生成した Inspector control 群へ接続する。
+        /// </summary>
+        explicit InspectorPanelView(EditorShell& shell);
+
+    private:
+        [[nodiscard]] static std::vector<HWND> GetInspectorControls(EditorShell& shell);
+        [[nodiscard]] static std::vector<HWND> GetInspectorVisibleControls(EditorShell& shell);
+    };
+}

--- a/Editor/Source/Panels/LogOutputPanelView.cpp
+++ b/Editor/Source/Panels/LogOutputPanelView.cpp
@@ -1,0 +1,17 @@
+#include "Panels/LogOutputPanelView.h"
+
+#include "Shell/EditorShell.h"
+
+namespace Xelqoria::Editor
+{
+    LogOutputPanelView::LogOutputPanelView(EditorShell& shell)
+        : EditorPanelViewBase(
+            EditorPanelId::LogOutput,
+            L"Console",
+            [&shell]() { return std::vector<HWND>{ shell.m_logOutputPanel, shell.m_logOutputTabControl, shell.m_logClearButton, shell.m_logCopyButton, shell.m_logFilterEdit, shell.m_logListBox }; },
+            [&shell]() { return std::vector<HWND>{ shell.m_logOutputPanel, shell.m_logOutputTabControl, shell.m_logClearButton, shell.m_logFilterEdit, shell.m_logListBox }; },
+            [&shell]() { return std::vector<HWND>{ shell.m_logCopyButton }; },
+            []() { return std::vector<HWND>{}; })
+    {
+    }
+}

--- a/Editor/Source/Panels/LogOutputPanelView.h
+++ b/Editor/Source/Panels/LogOutputPanelView.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include "Panels/EditorPanelViewBase.h"
+
+namespace Xelqoria::Editor
+{
+    class EditorShell;
+
+    /// <summary>
+    /// LogOutput Panel の HWND 群を管理する View。
+    /// </summary>
+    class LogOutputPanelView final : public EditorPanelViewBase
+    {
+    public:
+        /// <summary>
+        /// EditorShell が生成した LogOutput control 群へ接続する。
+        /// </summary>
+        explicit LogOutputPanelView(EditorShell& shell);
+    };
+}

--- a/Editor/Source/Panels/MaterialPanelView.cpp
+++ b/Editor/Source/Panels/MaterialPanelView.cpp
@@ -1,0 +1,43 @@
+#include "Panels/MaterialPanelView.h"
+
+#include "Shell/EditorShell.h"
+
+namespace Xelqoria::Editor
+{
+    std::vector<HWND> MaterialPanelView::GetMaterialControls(EditorShell& shell)
+    {
+        std::vector<HWND> controls{
+            shell.m_materialPanel,
+            shell.m_materialSummaryLabel,
+            shell.m_materialSharedNoticeLabel,
+            shell.m_materialDetailsSectionLabel
+        };
+        controls.insert(controls.end(), shell.m_materialDetailLabels.begin(), shell.m_materialDetailLabels.end());
+        controls.insert(controls.end(), shell.m_materialDetailEditControls.begin(), shell.m_materialDetailEditControls.end());
+        controls.push_back(shell.m_materialTextureDropHighlight);
+        return controls;
+    }
+
+    std::vector<HWND> MaterialPanelView::GetMaterialVisibleControls(EditorShell& shell)
+    {
+        std::vector<HWND> controls{
+            shell.m_materialPanel,
+            shell.m_materialSharedNoticeLabel,
+            shell.m_materialDetailsSectionLabel
+        };
+        controls.insert(controls.end(), shell.m_materialDetailLabels.begin(), shell.m_materialDetailLabels.end());
+        controls.insert(controls.end(), shell.m_materialDetailEditControls.begin(), shell.m_materialDetailEditControls.end());
+        return controls;
+    }
+
+    MaterialPanelView::MaterialPanelView(EditorShell& shell)
+        : EditorPanelViewBase(
+            EditorPanelId::Material,
+            L"Material",
+            [&shell]() { return GetMaterialControls(shell); },
+            [&shell]() { return GetMaterialVisibleControls(shell); },
+            [&shell]() { return std::vector<HWND>{ shell.m_materialSummaryLabel }; },
+            [&shell]() { return std::vector<HWND>{ shell.m_materialTextureDropHighlight }; })
+    {
+    }
+}

--- a/Editor/Source/Panels/MaterialPanelView.h
+++ b/Editor/Source/Panels/MaterialPanelView.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include "Panels/EditorPanelViewBase.h"
+
+namespace Xelqoria::Editor
+{
+    class EditorShell;
+
+    /// <summary>
+    /// Material Panel の HWND 群を管理する View。
+    /// </summary>
+    class MaterialPanelView final : public EditorPanelViewBase
+    {
+    public:
+        /// <summary>
+        /// EditorShell が生成した Material control 群へ接続する。
+        /// </summary>
+        explicit MaterialPanelView(EditorShell& shell);
+
+    private:
+        [[nodiscard]] static std::vector<HWND> GetMaterialControls(EditorShell& shell);
+        [[nodiscard]] static std::vector<HWND> GetMaterialVisibleControls(EditorShell& shell);
+    };
+}

--- a/Editor/Source/Panels/SceneViewPanelView.cpp
+++ b/Editor/Source/Panels/SceneViewPanelView.cpp
@@ -1,0 +1,17 @@
+#include "Panels/SceneViewPanelView.h"
+
+#include "Shell/EditorShell.h"
+
+namespace Xelqoria::Editor
+{
+    SceneViewPanelView::SceneViewPanelView(EditorShell& shell)
+        : EditorPanelViewBase(
+            EditorPanelId::SceneView,
+            L"Scene",
+            [&shell]() { return std::vector<HWND>{ shell.m_sceneViewPanel, shell.m_sceneViewPlanLabel, shell.m_projectSummaryLabel, shell.m_projectSceneListBox, shell.m_projectSceneDetailLabel, shell.m_sceneViewHost, shell.m_sceneViewSizeLabel, shell.m_buildAndPlayButton, shell.m_pauseResumePlayButton, shell.m_endPlayButton }; },
+            [&shell]() { return std::vector<HWND>{ shell.m_sceneViewPanel, shell.m_sceneViewHost, shell.m_buildAndPlayButton, shell.m_pauseResumePlayButton, shell.m_endPlayButton }; },
+            [&shell]() { return std::vector<HWND>{ shell.m_sceneViewPlanLabel, shell.m_projectSummaryLabel, shell.m_projectSceneListBox, shell.m_projectSceneDetailLabel, shell.m_sceneViewSizeLabel }; },
+            []() { return std::vector<HWND>{}; })
+    {
+    }
+}

--- a/Editor/Source/Panels/SceneViewPanelView.h
+++ b/Editor/Source/Panels/SceneViewPanelView.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include "Panels/EditorPanelViewBase.h"
+
+namespace Xelqoria::Editor
+{
+    class EditorShell;
+
+    /// <summary>
+    /// SceneView Panel の HWND 群を管理する View。
+    /// </summary>
+    class SceneViewPanelView final : public EditorPanelViewBase
+    {
+    public:
+        /// <summary>
+        /// EditorShell が生成した SceneView control 群へ接続する。
+        /// </summary>
+        explicit SceneViewPanelView(EditorShell& shell);
+    };
+}

--- a/Editor/Source/Panels/SpritePanelView.cpp
+++ b/Editor/Source/Panels/SpritePanelView.cpp
@@ -1,0 +1,40 @@
+#include "Panels/SpritePanelView.h"
+
+#include "Shell/EditorShell.h"
+
+namespace Xelqoria::Editor
+{
+    std::vector<HWND> SpritePanelView::GetSpriteControls(EditorShell& shell)
+    {
+        std::vector<HWND> controls{
+            shell.m_spritePanel,
+            shell.m_spriteSummaryLabel,
+            shell.m_spriteDetailsSectionLabel
+        };
+        controls.insert(controls.end(), shell.m_spriteDetailLabels.begin(), shell.m_spriteDetailLabels.end());
+        controls.insert(controls.end(), shell.m_spriteDetailEditControls.begin(), shell.m_spriteDetailEditControls.end());
+        return controls;
+    }
+
+    std::vector<HWND> SpritePanelView::GetSpriteVisibleControls(EditorShell& shell)
+    {
+        std::vector<HWND> controls{
+            shell.m_spritePanel,
+            shell.m_spriteDetailsSectionLabel
+        };
+        controls.insert(controls.end(), shell.m_spriteDetailLabels.begin(), shell.m_spriteDetailLabels.end());
+        controls.insert(controls.end(), shell.m_spriteDetailEditControls.begin(), shell.m_spriteDetailEditControls.end());
+        return controls;
+    }
+
+    SpritePanelView::SpritePanelView(EditorShell& shell)
+        : EditorPanelViewBase(
+            EditorPanelId::Sprite,
+            L"Sprite",
+            [&shell]() { return GetSpriteControls(shell); },
+            [&shell]() { return GetSpriteVisibleControls(shell); },
+            [&shell]() { return std::vector<HWND>{ shell.m_spriteSummaryLabel }; },
+            []() { return std::vector<HWND>{}; })
+    {
+    }
+}

--- a/Editor/Source/Panels/SpritePanelView.h
+++ b/Editor/Source/Panels/SpritePanelView.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include "Panels/EditorPanelViewBase.h"
+
+namespace Xelqoria::Editor
+{
+    class EditorShell;
+
+    /// <summary>
+    /// Sprite Panel の HWND 群を管理する View。
+    /// </summary>
+    class SpritePanelView final : public EditorPanelViewBase
+    {
+    public:
+        /// <summary>
+        /// EditorShell が生成した Sprite control 群へ接続する。
+        /// </summary>
+        explicit SpritePanelView(EditorShell& shell);
+
+    private:
+        [[nodiscard]] static std::vector<HWND> GetSpriteControls(EditorShell& shell);
+        [[nodiscard]] static std::vector<HWND> GetSpriteVisibleControls(EditorShell& shell);
+    };
+}

--- a/Editor/Source/Shell/EditorShell.cpp
+++ b/Editor/Source/Shell/EditorShell.cpp
@@ -16,11 +16,21 @@
 #include <UxTheme.h>
 
 #include "EditorTheme.h"
+#include "Panels/AssetsPanelView.h"
+#include "Panels/Collider2DPanelView.h"
+#include "Panels/HierarchyPanelView.h"
+#include "Panels/InspectorPanelView.h"
+#include "Panels/LogOutputPanelView.h"
+#include "Panels/MaterialPanelView.h"
+#include "Panels/SceneViewPanelView.h"
+#include "Panels/SpritePanelView.h"
 
 #pragma comment(lib, "uxtheme.lib")
 
 namespace Xelqoria::Editor
 {
+    EditorShell::EditorShell() = default;
+
     namespace
     {
         constexpr UINT_PTR ParentWindowSubclassId = 1;
@@ -983,6 +993,14 @@ namespace Xelqoria::Editor
             && InitializeLogOutputPanel(parentWindow, hInstance);
         if (initialized)
         {
+            m_hierarchyPanelView = std::make_unique<HierarchyPanelView>(*this);
+            m_assetsPanelView = std::make_unique<AssetsPanelView>(*this);
+            m_inspectorPanelView = std::make_unique<InspectorPanelView>(*this);
+            m_materialPanelView = std::make_unique<MaterialPanelView>(*this);
+            m_spritePanelView = std::make_unique<SpritePanelView>(*this);
+            m_collider2DPanelView = std::make_unique<Collider2DPanelView>(*this);
+            m_sceneViewPanelView = std::make_unique<SceneViewPanelView>(*this);
+            m_logOutputPanelView = std::make_unique<LogOutputPanelView>(*this);
             SyncDockTabs();
         }
 
@@ -3460,152 +3478,39 @@ namespace Xelqoria::Editor
         return DrawHierarchyListBoxItem(*drawItem);
     }
 
-    void EditorShell::ShowPanelControls(EditorPanelId panelId, bool visible) const
+    IEditorPanelView& EditorShell::GetPanelView(EditorPanelId panelId) const
     {
-        const int showCommand = visible ? SW_SHOW : SW_HIDE;
         switch (panelId)
         {
         case EditorPanelId::Hierarchy:
-            for (HWND control : { m_hierarchyPanel, m_hierarchyListBox, m_hierarchyNameEdit, m_hierarchyCreateButton, m_hierarchyDuplicateButton, m_hierarchyDeleteButton })
-            {
-                ShowWindow(control, showCommand);
-            }
-            ShowWindow(m_hierarchySummaryLabel, SW_HIDE);
-            break;
+            return GetHierarchyPanelView();
         case EditorPanelId::Assets:
-            for (HWND control : { m_assetsPanel, m_assetsListView })
-            {
-                ShowWindow(control, showCommand);
-            }
-            ShowWindow(m_assetsSummaryLabel, SW_HIDE);
-            break;
+            return GetAssetsPanelView();
         case EditorPanelId::SceneView:
-            for (HWND control : { m_sceneViewPanel, m_sceneViewHost, m_buildAndPlayButton, m_pauseResumePlayButton, m_endPlayButton })
-            {
-                ShowWindow(control, showCommand);
-            }
-            ShowWindow(m_sceneViewPlanLabel, SW_HIDE);
-            ShowWindow(m_projectSummaryLabel, SW_HIDE);
-            ShowWindow(m_projectSceneListBox, SW_HIDE);
-            ShowWindow(m_projectSceneDetailLabel, SW_HIDE);
-            ShowWindow(m_sceneViewSizeLabel, SW_HIDE);
-            break;
+            return GetSceneViewPanelView();
         case EditorPanelId::Inspector:
-            for (HWND control : { m_inspectorPanel, m_inspectorSummaryLabel, m_transformSectionLabel, m_transformLabels[0], m_transformLabels[1], m_transformLabels[2], m_transformEditControls[0], m_transformEditControls[1], m_transformEditControls[2], m_transformEditControls[3], m_transformEditControls[4], m_transformEditControls[5], m_transformEditControls[6], m_transformEditControls[7], m_transformEditControls[8], m_spriteComponentSectionLabel, m_spriteRefLabel, m_spriteRefEdit, m_materialOpenButton, m_scriptAssetLabel, m_scriptAssetEdit, m_scriptCreateButton, m_scriptAssignButton, m_scriptClearButton, m_spriteComponentActionButton, m_materialSharedNoticeLabel, m_materialDetailsSectionLabel, m_materialDetailLabels[0], m_materialDetailLabels[1], m_materialDetailLabels[2], m_materialDetailLabels[3], m_materialDetailLabels[4], m_materialDetailEditControls[0], m_materialDetailEditControls[1], m_materialDetailEditControls[2], m_materialDetailEditControls[3], m_materialDetailEditControls[4], m_materialTextureBrowseButton, m_materialTintColorButton, m_materialOutlineEnabledCheckBox, m_materialOutlineColorButton, m_collider2DComponentSectionLabel, m_collider2DSummaryLabel, m_collider2DEnabledCheckBox, m_collider2DTriggerCheckBox, m_collider2DShapeTypeLabel, m_collider2DShapeTypeEdit, m_collider2DOffsetLabel, m_collider2DSizeLabel, m_collider2DRotationLabel, m_collider2DRotationEdit, m_collider2DEditControls[0], m_collider2DEditControls[1], m_collider2DEditControls[2], m_collider2DEditControls[3], m_collider2DEditButton, m_collider2DComponentActionButton, m_addComponentButton })
-            {
-                ShowWindow(control, showCommand);
-            }
-            if (false == visible)
-            {
-                ShowWindow(m_spriteRefDropHighlight, SW_HIDE);
-                ShowWindow(m_materialTextureDropHighlight, SW_HIDE);
-            }
-            break;
-        case EditorPanelId::Material:
-            for (HWND control : { m_materialPanel, m_materialSharedNoticeLabel, m_materialDetailsSectionLabel, m_materialDetailLabels[0], m_materialDetailLabels[1], m_materialDetailLabels[2], m_materialDetailLabels[3], m_materialDetailLabels[4], m_materialDetailEditControls[0], m_materialDetailEditControls[1], m_materialDetailEditControls[2], m_materialDetailEditControls[3], m_materialDetailEditControls[4] })
-            {
-                ShowWindow(control, showCommand);
-            }
-            ShowWindow(m_materialSummaryLabel, SW_HIDE);
-            if (false == visible)
-            {
-                ShowWindow(m_materialTextureDropHighlight, SW_HIDE);
-            }
-            break;
+            return GetInspectorPanelView();
         case EditorPanelId::Sprite:
-            for (HWND control : { m_spritePanel, m_spriteDetailsSectionLabel, m_spriteDetailLabels[0], m_spriteDetailLabels[1], m_spriteDetailLabels[2], m_spriteDetailLabels[3], m_spriteDetailEditControls[0], m_spriteDetailEditControls[1], m_spriteDetailEditControls[2], m_spriteDetailEditControls[3] })
-            {
-                ShowWindow(control, showCommand);
-            }
-            ShowWindow(m_spriteSummaryLabel, SW_HIDE);
-            break;
+            return GetSpritePanelView();
+        case EditorPanelId::Material:
+            return GetMaterialPanelView();
         case EditorPanelId::Collider2D:
-            for (HWND control : { m_collider2DPanel, m_collider2DSummaryLabel, m_collider2DComponentSectionLabel, m_collider2DEnabledCheckBox, m_collider2DTriggerCheckBox, m_collider2DShapeTypeLabel, m_collider2DShapeTypeEdit, m_collider2DOffsetLabel, m_collider2DSizeLabel, m_collider2DEditControls[0], m_collider2DEditControls[1], m_collider2DEditControls[2], m_collider2DEditControls[3] })
-            {
-                ShowWindow(control, showCommand);
-            }
-            break;
+            return GetCollider2DPanelView();
         case EditorPanelId::LogOutput:
-            for (HWND control : { m_logOutputPanel, m_logOutputTabControl, m_logClearButton, m_logFilterEdit, m_logListBox })
-            {
-                ShowWindow(control, showCommand);
-            }
-            ShowWindow(m_logCopyButton, SW_HIDE);
-            break;
+            return GetLogOutputPanelView();
         default:
-            break;
+            return GetSceneViewPanelView();
         }
+    }
+
+    void EditorShell::ShowPanelControls(EditorPanelId panelId, bool visible) const
+    {
+        GetPanelView(panelId).Show(visible);
     }
 
     void EditorShell::SetPanelParent(EditorPanelId panelId, HWND parentWindow) const
     {
-        if (nullptr == parentWindow)
-        {
-            return;
-        }
-
-        const auto setParent =
-            [parentWindow](HWND control)
-            {
-                if (nullptr != control && GetParent(control) != parentWindow)
-                {
-                    SetParent(control, parentWindow);
-                }
-            };
-
-        switch (panelId)
-        {
-        case EditorPanelId::Hierarchy:
-            for (HWND control : { m_hierarchyPanel, m_hierarchySummaryLabel, m_hierarchyListBox, m_hierarchyNameEdit, m_hierarchyCreateButton, m_hierarchyDuplicateButton, m_hierarchyDeleteButton })
-            {
-                setParent(control);
-            }
-            break;
-        case EditorPanelId::Assets:
-            for (HWND control : { m_assetsPanel, m_assetsSummaryLabel, m_assetsListView })
-            {
-                setParent(control);
-            }
-            break;
-        case EditorPanelId::SceneView:
-            for (HWND control : { m_sceneViewPanel, m_sceneViewPlanLabel, m_projectSummaryLabel, m_projectSceneListBox, m_projectSceneDetailLabel, m_sceneViewHost, m_sceneViewSizeLabel, m_buildAndPlayButton, m_pauseResumePlayButton, m_endPlayButton })
-            {
-                setParent(control);
-            }
-            break;
-        case EditorPanelId::Inspector:
-            for (HWND control : { m_inspectorPanel, m_inspectorSummaryLabel, m_transformSectionLabel, m_transformLabels[0], m_transformLabels[1], m_transformLabels[2], m_transformEditControls[0], m_transformEditControls[1], m_transformEditControls[2], m_transformEditControls[3], m_transformEditControls[4], m_transformEditControls[5], m_transformEditControls[6], m_transformEditControls[7], m_transformEditControls[8], m_spriteComponentSectionLabel, m_spriteRefLabel, m_spriteRefDropHighlight, m_spriteRefEdit, m_materialOpenButton, m_scriptAssetLabel, m_scriptAssetEdit, m_scriptCreateButton, m_scriptAssignButton, m_scriptClearButton, m_spriteComponentActionButton, m_materialSharedNoticeLabel, m_materialDetailsSectionLabel, m_materialDetailLabels[0], m_materialDetailLabels[1], m_materialDetailLabels[2], m_materialDetailLabels[3], m_materialDetailLabels[4], m_materialDetailEditControls[0], m_materialDetailEditControls[1], m_materialDetailEditControls[2], m_materialDetailEditControls[3], m_materialDetailEditControls[4], m_materialTextureDropHighlight, m_materialTextureBrowseButton, m_materialTintColorButton, m_materialOutlineEnabledCheckBox, m_materialOutlineColorButton, m_collider2DComponentSectionLabel, m_collider2DSummaryLabel, m_collider2DEnabledCheckBox, m_collider2DTriggerCheckBox, m_collider2DShapeTypeLabel, m_collider2DShapeTypeEdit, m_collider2DOffsetLabel, m_collider2DSizeLabel, m_collider2DRotationLabel, m_collider2DRotationEdit, m_collider2DEditControls[0], m_collider2DEditControls[1], m_collider2DEditControls[2], m_collider2DEditControls[3], m_collider2DEditButton, m_collider2DComponentActionButton, m_addComponentButton })
-            {
-                setParent(control);
-            }
-            break;
-        case EditorPanelId::Material:
-            for (HWND control : { m_materialPanel, m_materialSummaryLabel, m_materialSharedNoticeLabel, m_materialDetailsSectionLabel, m_materialDetailLabels[0], m_materialDetailLabels[1], m_materialDetailLabels[2], m_materialDetailLabels[3], m_materialDetailLabels[4], m_materialDetailEditControls[0], m_materialDetailEditControls[1], m_materialDetailEditControls[2], m_materialDetailEditControls[3], m_materialDetailEditControls[4], m_materialTextureDropHighlight })
-            {
-                setParent(control);
-            }
-            break;
-        case EditorPanelId::Sprite:
-            for (HWND control : { m_spritePanel, m_spriteSummaryLabel, m_spriteDetailsSectionLabel, m_spriteDetailLabels[0], m_spriteDetailLabels[1], m_spriteDetailLabels[2], m_spriteDetailLabels[3], m_spriteDetailEditControls[0], m_spriteDetailEditControls[1], m_spriteDetailEditControls[2], m_spriteDetailEditControls[3] })
-            {
-                setParent(control);
-            }
-            break;
-        case EditorPanelId::Collider2D:
-            for (HWND control : { m_collider2DPanel, m_collider2DSummaryLabel, m_collider2DComponentSectionLabel, m_collider2DEnabledCheckBox, m_collider2DTriggerCheckBox, m_collider2DShapeTypeLabel, m_collider2DShapeTypeEdit, m_collider2DOffsetLabel, m_collider2DSizeLabel, m_collider2DEditControls[0], m_collider2DEditControls[1], m_collider2DEditControls[2], m_collider2DEditControls[3] })
-            {
-                setParent(control);
-            }
-            break;
-        case EditorPanelId::LogOutput:
-            for (HWND control : { m_logOutputPanel, m_logOutputTabControl, m_logClearButton, m_logCopyButton, m_logFilterEdit, m_logListBox })
-            {
-                setParent(control);
-            }
-            break;
-        default:
-            break;
-        }
+        GetPanelView(panelId).SetParent(parentWindow);
     }
 
     RECT EditorShell::GetPanelCaptionRect(EditorPanelId panelId) const
@@ -6540,6 +6445,46 @@ namespace Xelqoria::Editor
     HWND EditorShell::GetLogListBox() const
     {
         return m_logListBox;
+    }
+
+    HierarchyPanelView& EditorShell::GetHierarchyPanelView() const
+    {
+        return *m_hierarchyPanelView;
+    }
+
+    AssetsPanelView& EditorShell::GetAssetsPanelView() const
+    {
+        return *m_assetsPanelView;
+    }
+
+    InspectorPanelView& EditorShell::GetInspectorPanelView() const
+    {
+        return *m_inspectorPanelView;
+    }
+
+    MaterialPanelView& EditorShell::GetMaterialPanelView() const
+    {
+        return *m_materialPanelView;
+    }
+
+    SpritePanelView& EditorShell::GetSpritePanelView() const
+    {
+        return *m_spritePanelView;
+    }
+
+    Collider2DPanelView& EditorShell::GetCollider2DPanelView() const
+    {
+        return *m_collider2DPanelView;
+    }
+
+    SceneViewPanelView& EditorShell::GetSceneViewPanelView() const
+    {
+        return *m_sceneViewPanelView;
+    }
+
+    LogOutputPanelView& EditorShell::GetLogOutputPanelView() const
+    {
+        return *m_logOutputPanelView;
     }
 
     HWND EditorShell::CreateChildWindow(

--- a/Editor/Source/Shell/EditorShell.h
+++ b/Editor/Source/Shell/EditorShell.h
@@ -4,6 +4,7 @@
 #include <array>
 #include <cstdint>
 #include <filesystem>
+#include <memory>
 #include <optional>
 #include <string>
 #include <vector>
@@ -15,12 +16,27 @@
 
 namespace Xelqoria::Editor
 {
+    class AssetsPanelView;
+    class Collider2DPanelView;
+    class HierarchyPanelView;
+    class InspectorPanelView;
+    class IEditorPanelView;
+    class LogOutputPanelView;
+    class MaterialPanelView;
+    class SceneViewPanelView;
+    class SpritePanelView;
+
     /// <summary>
     /// Editor 固定 UI の Win32 child window 群とレイアウトを管理する。
     /// </summary>
     class EditorShell
     {
     public:
+        /// <summary>
+        /// EditorShell を生成する。
+        /// </summary>
+        EditorShell();
+
         /// <summary>
         /// EditorShell 用 child window 群を生成する。
         /// </summary>
@@ -447,6 +463,54 @@ namespace Xelqoria::Editor
         /// </summary>
         /// <returns>LogOutput ListBox の HWND。</returns>
         [[nodiscard]] HWND GetLogListBox() const;
+
+        /// <summary>
+        /// Hierarchy Panel View を取得する。
+        /// </summary>
+        /// <returns>Hierarchy Panel View。</returns>
+        [[nodiscard]] HierarchyPanelView& GetHierarchyPanelView() const;
+
+        /// <summary>
+        /// Assets Panel View を取得する。
+        /// </summary>
+        /// <returns>Assets Panel View。</returns>
+        [[nodiscard]] AssetsPanelView& GetAssetsPanelView() const;
+
+        /// <summary>
+        /// Inspector Panel View を取得する。
+        /// </summary>
+        /// <returns>Inspector Panel View。</returns>
+        [[nodiscard]] InspectorPanelView& GetInspectorPanelView() const;
+
+        /// <summary>
+        /// Material Panel View を取得する。
+        /// </summary>
+        /// <returns>Material Panel View。</returns>
+        [[nodiscard]] MaterialPanelView& GetMaterialPanelView() const;
+
+        /// <summary>
+        /// Sprite Panel View を取得する。
+        /// </summary>
+        /// <returns>Sprite Panel View。</returns>
+        [[nodiscard]] SpritePanelView& GetSpritePanelView() const;
+
+        /// <summary>
+        /// Collider2D Panel View を取得する。
+        /// </summary>
+        /// <returns>Collider2D Panel View。</returns>
+        [[nodiscard]] Collider2DPanelView& GetCollider2DPanelView() const;
+
+        /// <summary>
+        /// SceneView Panel View を取得する。
+        /// </summary>
+        /// <returns>SceneView Panel View。</returns>
+        [[nodiscard]] SceneViewPanelView& GetSceneViewPanelView() const;
+
+        /// <summary>
+        /// LogOutput Panel View を取得する。
+        /// </summary>
+        /// <returns>LogOutput Panel View。</returns>
+        [[nodiscard]] LogOutputPanelView& GetLogOutputPanelView() const;
 
         /// <summary>
         /// Dock UI のフレーム入力を処理する。
@@ -1006,6 +1070,11 @@ namespace Xelqoria::Editor
         [[nodiscard]] static const wchar_t* GetPanelTitle(EditorPanelId panelId);
 
         /// <summary>
+        /// 指定 Panel の View 境界を返す。
+        /// </summary>
+        [[nodiscard]] IEditorPanelView& GetPanelView(EditorPanelId panelId) const;
+
+        /// <summary>
         /// DockArea の有効なアクティブタブ index を返す。
         /// </summary>
         [[nodiscard]] int ClampActiveTabIndex(DockAreaId dockAreaId) const;
@@ -1213,6 +1282,15 @@ namespace Xelqoria::Editor
             int height = 0;
         };
 
+        friend class AssetsPanelView;
+        friend class Collider2DPanelView;
+        friend class HierarchyPanelView;
+        friend class InspectorPanelView;
+        friend class LogOutputPanelView;
+        friend class MaterialPanelView;
+        friend class SceneViewPanelView;
+        friend class SpritePanelView;
+
         HFONT m_defaultFont = nullptr;
         HBRUSH m_windowBackgroundBrush = nullptr;
         HBRUSH m_panelBackgroundBrush = nullptr;
@@ -1265,6 +1343,14 @@ namespace Xelqoria::Editor
         HWND m_logCopyButton = nullptr;
         HWND m_logFilterEdit = nullptr;
         HWND m_logListBox = nullptr;
+        std::unique_ptr<HierarchyPanelView> m_hierarchyPanelView{};
+        std::unique_ptr<AssetsPanelView> m_assetsPanelView{};
+        std::unique_ptr<InspectorPanelView> m_inspectorPanelView{};
+        std::unique_ptr<MaterialPanelView> m_materialPanelView{};
+        std::unique_ptr<SpritePanelView> m_spritePanelView{};
+        std::unique_ptr<Collider2DPanelView> m_collider2DPanelView{};
+        std::unique_ptr<SceneViewPanelView> m_sceneViewPanelView{};
+        std::unique_ptr<LogOutputPanelView> m_logOutputPanelView{};
         HWND m_assetsListView = nullptr;
         HWND m_assetsSummaryLabel = nullptr;
         HWND m_hierarchySummaryLabel = nullptr;

--- a/Editor/Xelqoria.Editor.vcxproj
+++ b/Editor/Xelqoria.Editor.vcxproj
@@ -21,16 +21,23 @@
   <ItemGroup>
     <ClCompile Include="Source\App\Application.cpp" />
     <ClCompile Include="Source\Panels\AssetsPanelController.cpp" />
+    <ClCompile Include="Source\Panels\AssetsPanelView.cpp" />
+    <ClCompile Include="Source\Panels\Collider2DPanelView.cpp" />
     <ClCompile Include="Source\Commands\EditorCommandController.cpp" />
+    <ClCompile Include="Source\Panels\EditorPanelViewBase.cpp" />
     <ClCompile Include="Source\Assets\EditorAssetPathUtils.cpp" />
     <ClCompile Include="Source\Project\EditorProject.cpp" />
     <ClCompile Include="Source\Project\EditorSceneDocument.cpp" />
     <ClCompile Include="Source\Shell\EditorShell.cpp" />
     <ClCompile Include="Source\App\Entry.cpp" />
     <ClCompile Include="Source\Panels\HierarchyPanelController.cpp" />
+    <ClCompile Include="Source\Panels\HierarchyPanelView.cpp" />
     <ClCompile Include="Source\Panels\InspectorPanelController.cpp" />
+    <ClCompile Include="Source\Panels\InspectorPanelView.cpp" />
     <ClCompile Include="Source\Panels\LogOutputPanelController.cpp" />
+    <ClCompile Include="Source\Panels\LogOutputPanelView.cpp" />
     <ClCompile Include="Source\Panels\MaterialPanelController.cpp" />
+    <ClCompile Include="Source\Panels\MaterialPanelView.cpp" />
     <ClCompile Include="Source\Project\ProjectPanelController.cpp" />
     <ClCompile Include="Source\Project\RecentProjectsStore.cpp" />
     <ClCompile Include="Source\Rendering\RenderBackendBootstrap.cpp" />
@@ -38,17 +45,21 @@
     <ClCompile Include="Source\Commands\SceneCommandHistory.cpp" />
     <ClCompile Include="Source\Commands\SceneEditingOperations.cpp" />
     <ClCompile Include="Source\SceneView\SceneViewController.cpp" />
+    <ClCompile Include="Source\Panels\SceneViewPanelView.cpp" />
     <ClCompile Include="Source\SceneView\SceneViewInputTracker.cpp" />
     <ClCompile Include="Source\SceneView\SceneViewRenderer.cpp" />
     <ClCompile Include="Source\SceneView\SceneViewStatusPresenter.cpp" />
     <ClCompile Include="Source\Assets\ScriptAssetService.cpp" />
     <ClCompile Include="Source\Script\ScriptRuntimeSession.cpp" />
     <ClCompile Include="Source\Panels\SpritePanelController.cpp" />
+    <ClCompile Include="Source\Panels\SpritePanelView.cpp" />
     <ClCompile Include="Source\App\StartupScreenController.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="Source\App\Application.h" />
     <ClInclude Include="Source\Panels\AssetsPanelController.h" />
+    <ClInclude Include="Source\Panels\AssetsPanelView.h" />
+    <ClInclude Include="Source\Panels\Collider2DPanelView.h" />
     <ClInclude Include="Source\PlatformAdapters\ButtonClickWin32Adapter.h" />
     <ClInclude Include="Source\Commands\EditorCommandController.h" />
     <ClInclude Include="Source\Assets\EditorAssetPathUtils.h" />
@@ -60,10 +71,15 @@
     <ClInclude Include="Source\Utils\EditorStringUtils.h" />
     <ClInclude Include="Source\SceneView\EditorCamera2D.h" />
     <ClInclude Include="Source\Panels\HierarchyPanelController.h" />
+    <ClInclude Include="Source\Panels\HierarchyPanelView.h" />
     <ClInclude Include="Source\Panels\InspectorPanelController.h" />
+    <ClInclude Include="Source\Panels\InspectorPanelView.h" />
     <ClInclude Include="Source\Panels\IEditorPanelView.h" />
+    <ClInclude Include="Source\Panels\EditorPanelViewBase.h" />
     <ClInclude Include="Source\Panels\LogOutputPanelController.h" />
+    <ClInclude Include="Source\Panels\LogOutputPanelView.h" />
     <ClInclude Include="Source\Panels\MaterialPanelController.h" />
+    <ClInclude Include="Source\Panels\MaterialPanelView.h" />
     <ClInclude Include="Source\Project\ProjectPanelController.h" />
     <ClInclude Include="Source\Project\RecentProjectsStore.h" />
     <ClInclude Include="Source\Rendering\RenderBackendBootstrap.h" />
@@ -72,6 +88,7 @@
     <ClInclude Include="Source\Commands\SceneCommandHistory.h" />
     <ClInclude Include="Source\Commands\SceneEditingOperations.h" />
     <ClInclude Include="Source\SceneView\SceneViewController.h" />
+    <ClInclude Include="Source\Panels\SceneViewPanelView.h" />
     <ClInclude Include="Source\SceneView\SceneViewInputTracker.h" />
     <ClInclude Include="Source\SceneView\SceneViewInteractionTypes.h" />
     <ClInclude Include="Source\SceneView\SceneViewOverlay.h" />
@@ -80,6 +97,7 @@
     <ClInclude Include="Source\Assets\ScriptAssetService.h" />
     <ClInclude Include="Source\Script\ScriptRuntimeSession.h" />
     <ClInclude Include="Source\Panels\SpritePanelController.h" />
+    <ClInclude Include="Source\Panels\SpritePanelView.h" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Core\Xelqoria.Core.vcxproj">

--- a/Editor/Xelqoria.Editor.vcxproj.filters
+++ b/Editor/Xelqoria.Editor.vcxproj.filters
@@ -12,8 +12,17 @@
     <ClCompile Include="Source\Panels\AssetsPanelController.cpp">
       <Filter>Source\Panels</Filter>
     </ClCompile>
+    <ClCompile Include="Source\Panels\AssetsPanelView.cpp">
+      <Filter>Source\Panels</Filter>
+    </ClCompile>
+    <ClCompile Include="Source\Panels\Collider2DPanelView.cpp">
+      <Filter>Source\Panels</Filter>
+    </ClCompile>
     <ClCompile Include="Source\Commands\EditorCommandController.cpp">
       <Filter>Source\Commands</Filter>
+    </ClCompile>
+    <ClCompile Include="Source\Panels\EditorPanelViewBase.cpp">
+      <Filter>Source\Panels</Filter>
     </ClCompile>
     <ClCompile Include="Source\Assets\EditorAssetPathUtils.cpp">
       <Filter>Source\Assets</Filter>
@@ -33,13 +42,25 @@
     <ClCompile Include="Source\Panels\HierarchyPanelController.cpp">
       <Filter>Source\Panels</Filter>
     </ClCompile>
+    <ClCompile Include="Source\Panels\HierarchyPanelView.cpp">
+      <Filter>Source\Panels</Filter>
+    </ClCompile>
     <ClCompile Include="Source\Panels\InspectorPanelController.cpp">
+      <Filter>Source\Panels</Filter>
+    </ClCompile>
+    <ClCompile Include="Source\Panels\InspectorPanelView.cpp">
       <Filter>Source\Panels</Filter>
     </ClCompile>
     <ClCompile Include="Source\Panels\LogOutputPanelController.cpp">
       <Filter>Source\Panels</Filter>
     </ClCompile>
+    <ClCompile Include="Source\Panels\LogOutputPanelView.cpp">
+      <Filter>Source\Panels</Filter>
+    </ClCompile>
     <ClCompile Include="Source\Panels\MaterialPanelController.cpp">
+      <Filter>Source\Panels</Filter>
+    </ClCompile>
+    <ClCompile Include="Source\Panels\MaterialPanelView.cpp">
       <Filter>Source\Panels</Filter>
     </ClCompile>
     <ClCompile Include="Source\Project\ProjectPanelController.cpp">
@@ -66,6 +87,9 @@
     <ClCompile Include="Source\SceneView\SceneViewController.cpp">
       <Filter>Source\SceneView</Filter>
     </ClCompile>
+    <ClCompile Include="Source\Panels\SceneViewPanelView.cpp">
+      <Filter>Source\Panels</Filter>
+    </ClCompile>
     <ClCompile Include="Source\SceneView\SceneViewInputTracker.cpp">
       <Filter>Source\SceneView</Filter>
     </ClCompile>
@@ -84,12 +108,21 @@
     <ClCompile Include="Source\Panels\SpritePanelController.cpp">
       <Filter>Source\Panels</Filter>
     </ClCompile>
+    <ClCompile Include="Source\Panels\SpritePanelView.cpp">
+      <Filter>Source\Panels</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="Source\App\Application.h">
       <Filter>Source\App</Filter>
     </ClInclude>
     <ClInclude Include="Source\Panels\AssetsPanelController.h">
+      <Filter>Source\Panels</Filter>
+    </ClInclude>
+    <ClInclude Include="Source\Panels\AssetsPanelView.h">
+      <Filter>Source\Panels</Filter>
+    </ClInclude>
+    <ClInclude Include="Source\Panels\Collider2DPanelView.h">
       <Filter>Source\Panels</Filter>
     </ClInclude>
     <ClInclude Include="Source\PlatformAdapters\ButtonClickWin32Adapter.h">
@@ -125,16 +158,31 @@
     <ClInclude Include="Source\Panels\HierarchyPanelController.h">
       <Filter>Source\Panels</Filter>
     </ClInclude>
+    <ClInclude Include="Source\Panels\HierarchyPanelView.h">
+      <Filter>Source\Panels</Filter>
+    </ClInclude>
     <ClInclude Include="Source\Panels\InspectorPanelController.h">
+      <Filter>Source\Panels</Filter>
+    </ClInclude>
+    <ClInclude Include="Source\Panels\InspectorPanelView.h">
       <Filter>Source\Panels</Filter>
     </ClInclude>
     <ClInclude Include="Source\Panels\IEditorPanelView.h">
       <Filter>Source\Panels</Filter>
     </ClInclude>
+    <ClInclude Include="Source\Panels\EditorPanelViewBase.h">
+      <Filter>Source\Panels</Filter>
+    </ClInclude>
     <ClInclude Include="Source\Panels\LogOutputPanelController.h">
       <Filter>Source\Panels</Filter>
     </ClInclude>
+    <ClInclude Include="Source\Panels\LogOutputPanelView.h">
+      <Filter>Source\Panels</Filter>
+    </ClInclude>
     <ClInclude Include="Source\Panels\MaterialPanelController.h">
+      <Filter>Source\Panels</Filter>
+    </ClInclude>
+    <ClInclude Include="Source\Panels\MaterialPanelView.h">
       <Filter>Source\Panels</Filter>
     </ClInclude>
     <ClInclude Include="Source\Project\ProjectPanelController.h">
@@ -161,6 +209,9 @@
     <ClInclude Include="Source\SceneView\SceneViewController.h">
       <Filter>Source\SceneView</Filter>
     </ClInclude>
+    <ClInclude Include="Source\Panels\SceneViewPanelView.h">
+      <Filter>Source\Panels</Filter>
+    </ClInclude>
     <ClInclude Include="Source\SceneView\SceneViewInputTracker.h">
       <Filter>Source\SceneView</Filter>
     </ClInclude>
@@ -183,6 +234,9 @@
       <Filter>Source\Script</Filter>
     </ClInclude>
     <ClInclude Include="Source\Panels\SpritePanelController.h">
+      <Filter>Source\Panels</Filter>
+    </ClInclude>
+    <ClInclude Include="Source\Panels\SpritePanelView.h">
       <Filter>Source\Panels</Filter>
     </ClInclude>
   </ItemGroup>

--- a/docs/plans/issue-316-panel-views.md
+++ b/docs/plans/issue-316-panel-views.md
@@ -1,0 +1,51 @@
+# ExecPlan: issue-316 PanelView 実装と EditorShell からの Panel 固有 View 処理分離
+
+## 目的
+
+各 Panel の HWND 群を `XXXPanelView` 境界から扱えるようにし、`EditorShell` の Dock / Floating / Tab 処理から Panel 固有の表示・親変更処理を分離する。
+
+## 対象範囲
+
+- 変更対象プロジェクト: `Editor`
+- 変更対象ファイル: `Editor/Source/Panels/*PanelView.*`, `Editor/Source/Shell/EditorShell.*`, `Editor/Xelqoria.Editor.vcxproj`, `Editor/Xelqoria.Editor.vcxproj.filters`
+- 変更対象クラス: `EditorShell`, 各 `XXXPanelView`
+- 影響する機能: Dock 初期配置、Floating、Tab 切り替え、Panel 表示・非表示、Panel 親ウィンドウ変更
+
+## 前提
+
+- parent issue: issue-313
+- 先行 issue: issue-314, issue-315
+- ブランチ運用ルール: `docs/agents/branch-rules.md`
+- parent issue ブランチ: `issue-313`
+- この child issue のブランチ: `issue-316`
+- PR の向き: `issue-313`
+
+## 実装方針
+
+既存 UI の見た目と操作を維持するため、まず PanelView を既存 HWND 群へ接続する View 境界として実装する。Dock / Floating / Tab の状態は引き続き `EditorShell` が保持し、PanelView は表示・親変更・control 列挙だけを担当する。
+
+## 作業手順
+
+1. 各 `XXXPanelView.h` / `.cpp` を追加する
+2. `EditorShell` に各 PanelView メンバーを追加する
+3. 既存 Panel 初期化後に PanelView を生成する
+4. `ShowPanelControls` と `SetPanelParent` を PanelView 呼び出しへ変更する
+5. project/filter を更新する
+6. 依存チェックと静的確認を実行する
+7. `issue-313` 向け PR を作成する
+
+## 検証方法
+
+- 実行するビルド: `msbuild Xelqoria.sln /t:Xelqoria.Editor /p:Configuration=Debug /p:Platform=x64`
+- 実行するテスト: LayerDependencyChecker
+- 手動確認項目: PanelView が Dock / Floating / Tab 状態を持たないこと、`ShowPanelControls` / `SetPanelParent` が PanelView 経由になっていること
+
+## 完了条件
+
+- 対象 Panel すべてに `XXXPanelView.h` / `XXXPanelView.cpp` が追加されている
+- 各 `XXXPanelView` が `IEditorPanelView` を実装している
+- `EditorShell` が各 PanelView を保持している
+- `ShowPanelControls` と `SetPanelParent` 相当の処理が PanelView の `Show` / `SetParent` を呼ぶ形になっている
+- Dock / Floating / Tab の仕様を変更していない
+- レイヤー責務に違反していない
+- `issue-313` に向けた PR が作成されている


### PR DESCRIPTION
## Summary
- Merge dependent `issue-315` work into `issue-316`.
- Add concrete `IEditorPanelView` wrappers for each Editor panel.
- Route `EditorShell` show/reparent operations through panel view instances while keeping existing HWND ownership in place.
- Add/update project files and ExecPlan for issue 316.

## Verification
- `git diff --check`
- XML parse for `Editor/Xelqoria.Editor.vcxproj` and `.filters`
- `dotnet run --project Tools/LayerDependencyChecker/LayerDependencyChecker.csproj -- .`
- `MSBuild.exe Editor\Xelqoria.Editor.vcxproj /p:Configuration=Debug /p:Platform=x64`

Part of #313. Implements #316.