### PR TITLE
Issue 317: Bind editor controllers to panel views

### DIFF
--- a/Editor/Source/App/Application.cpp
+++ b/Editor/Source/App/Application.cpp
@@ -366,13 +366,13 @@ namespace Xelqoria::Editor
         }
         (void)m_editorShell.LoadLayout(GetEditorLayoutFilePath());
 
-        m_assetsPanelController.Bind(m_editorShell, m_cursor);
-        m_hierarchyPanelController.Bind(m_editorShell);
-        m_inspectorPanelController.Bind(m_editorShell, m_cursor);
-        m_materialPanelController.Bind(m_editorShell, m_cursor);
-        m_logOutputPanelController.Bind(m_editorShell, m_clipboard);
-        m_projectPanelController.Bind(m_editorShell);
-        m_sceneViewController.Bind(m_editorShell);
+        m_assetsPanelController.Bind(m_editorShell.GetAssetsPanelView(), m_cursor);
+        m_hierarchyPanelController.Bind(m_editorShell.GetHierarchyPanelView());
+        m_inspectorPanelController.Bind(m_editorShell.GetInspectorPanelView(), m_cursor);
+        m_materialPanelController.Bind(m_editorShell.GetMaterialPanelView(), m_cursor);
+        m_logOutputPanelController.Bind(m_editorShell.GetLogOutputPanelView(), m_clipboard);
+        m_projectPanelController.Bind(m_editorShell.GetSceneViewPanelView());
+        m_sceneViewController.Bind(m_editorShell.GetSceneViewPanelView());
         m_buildAndPlayButton = m_editorShell.GetBuildAndPlayButton();
         m_pauseResumePlayButton = m_editorShell.GetPauseResumePlayButton();
         m_endPlayButton = m_editorShell.GetEndPlayButton();

--- a/Editor/Source/Panels/AssetsPanelController.cpp
+++ b/Editor/Source/Panels/AssetsPanelController.cpp
@@ -17,6 +17,7 @@
 #include <wrl/client.h>
 
 #include "Assets/EditorAssetPathUtils.h"
+#include "Panels/AssetsPanelView.h"
 #include "Utils/EditorPathSecurity.h"
 #include "Assets/ScriptAssetService.h"
 
@@ -576,13 +577,13 @@ namespace Xelqoria::Editor
         }
     }
 
-    void AssetsPanelController::Bind(const EditorShell& shell, Platform::ICursor& cursor)
+    void AssetsPanelController::Bind(const AssetsPanelView& view, Platform::ICursor& cursor)
     {
-        m_assetsListView = shell.GetAssetsListView();
-        m_assetsSummaryLabel = shell.GetAssetsSummaryLabel();
+        m_assetsListView = view.GetListView();
+        m_assetsSummaryLabel = view.GetSummaryLabel();
         m_cursor = &cursor;
         InitializeListView();
-        shell.ConfigureAssetsListHeaderTheme();
+        view.ConfigureListHeaderTheme();
     }
 
     void AssetsPanelController::Refresh(const std::optional<EditorProjectInfo>& projectInfo)

--- a/Editor/Source/Panels/AssetsPanelController.h
+++ b/Editor/Source/Panels/AssetsPanelController.h
@@ -10,12 +10,13 @@
 
 #include "AssetId.h"
 #include "Project/EditorProject.h"
-#include "Shell/EditorShell.h"
 #include "InputSystem.h"
 #include "ICursor.h"
 
 namespace Xelqoria::Editor
 {
+    class AssetsPanelView;
+
     /// <summary>
     /// Assets 詳細リストに表示するファイルシステム項目を表す。
     /// </summary>
@@ -74,11 +75,11 @@ namespace Xelqoria::Editor
         ~AssetsPanelController();
 
         /// <summary>
-        /// EditorShell の HWND 群へ接続する。
+        /// Assets Panel View の HWND 群へ接続する。
         /// </summary>
-        /// <param name="shell">接続先の EditorShell。</param>
+        /// <param name="view">接続先の Panel View。</param>
         /// <param name="cursor">カーソル位置を取得する Platform 実装。</param>
-        void Bind(const EditorShell& shell, Platform::ICursor& cursor);
+        void Bind(const AssetsPanelView& view, Platform::ICursor& cursor);
 
         /// <summary>
         /// Assets パネルのファイル詳細リスト表示を更新する。

--- a/Editor/Source/Panels/AssetsPanelView.cpp
+++ b/Editor/Source/Panels/AssetsPanelView.cpp
@@ -1,0 +1,17 @@
+#include "Panels/AssetsPanelView.h"
+
+#include "Shell/EditorShell.h"
+
+namespace Xelqoria::Editor
+{
+    AssetsPanelView::AssetsPanelView(EditorShell& shell)
+        : EditorPanelViewBase(
+            EditorPanelId::Assets,
+            L"Assets",
+            [&shell]() { return std::vector<HWND>{ shell.m_assetsPanel, shell.m_assetsSummaryLabel, shell.m_assetsListView }; },
+            [&shell]() { return std::vector<HWND>{ shell.m_assetsPanel, shell.m_assetsListView }; },
+            [&shell]() { return std::vector<HWND>{ shell.m_assetsSummaryLabel }; },
+            []() { return std::vector<HWND>{}; })
+    {
+    }
+}

--- a/Editor/Source/Panels/AssetsPanelView.cpp
+++ b/Editor/Source/Panels/AssetsPanelView.cpp
@@ -11,7 +11,23 @@ namespace Xelqoria::Editor
             [&shell]() { return std::vector<HWND>{ shell.m_assetsPanel, shell.m_assetsSummaryLabel, shell.m_assetsListView }; },
             [&shell]() { return std::vector<HWND>{ shell.m_assetsPanel, shell.m_assetsListView }; },
             [&shell]() { return std::vector<HWND>{ shell.m_assetsSummaryLabel }; },
-            []() { return std::vector<HWND>{}; })
+            []() { return std::vector<HWND>{}; }),
+          m_shell(shell)
     {
+    }
+
+    HWND AssetsPanelView::GetListView() const
+    {
+        return m_shell.m_assetsListView;
+    }
+
+    HWND AssetsPanelView::GetSummaryLabel() const
+    {
+        return m_shell.m_assetsSummaryLabel;
+    }
+
+    void AssetsPanelView::ConfigureListHeaderTheme() const
+    {
+        m_shell.ConfigureAssetsListHeaderTheme();
     }
 }

--- a/Editor/Source/Panels/AssetsPanelView.h
+++ b/Editor/Source/Panels/AssetsPanelView.h
@@ -16,5 +16,12 @@ namespace Xelqoria::Editor
         /// EditorShell が生成した Assets control 群へ接続する。
         /// </summary>
         explicit AssetsPanelView(EditorShell& shell);
+
+        [[nodiscard]] HWND GetListView() const;
+        [[nodiscard]] HWND GetSummaryLabel() const;
+        void ConfigureListHeaderTheme() const;
+
+    private:
+        EditorShell& m_shell;
     };
 }

--- a/Editor/Source/Panels/AssetsPanelView.h
+++ b/Editor/Source/Panels/AssetsPanelView.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include "Panels/EditorPanelViewBase.h"
+
+namespace Xelqoria::Editor
+{
+    class EditorShell;
+
+    /// <summary>
+    /// Assets Panel の HWND 群を管理する View。
+    /// </summary>
+    class AssetsPanelView final : public EditorPanelViewBase
+    {
+    public:
+        /// <summary>
+        /// EditorShell が生成した Assets control 群へ接続する。
+        /// </summary>
+        explicit AssetsPanelView(EditorShell& shell);
+    };
+}

--- a/Editor/Source/Panels/Collider2DPanelView.cpp
+++ b/Editor/Source/Panels/Collider2DPanelView.cpp
@@ -1,0 +1,34 @@
+#include "Panels/Collider2DPanelView.h"
+
+#include "Shell/EditorShell.h"
+
+namespace Xelqoria::Editor
+{
+    std::vector<HWND> Collider2DPanelView::GetCollider2DControls(EditorShell& shell)
+    {
+        std::vector<HWND> controls{
+            shell.m_collider2DPanel,
+            shell.m_collider2DSummaryLabel,
+            shell.m_collider2DComponentSectionLabel,
+            shell.m_collider2DEnabledCheckBox,
+            shell.m_collider2DTriggerCheckBox,
+            shell.m_collider2DShapeTypeLabel,
+            shell.m_collider2DShapeTypeEdit,
+            shell.m_collider2DOffsetLabel,
+            shell.m_collider2DSizeLabel
+        };
+        controls.insert(controls.end(), shell.m_collider2DEditControls.begin(), shell.m_collider2DEditControls.end());
+        return controls;
+    }
+
+    Collider2DPanelView::Collider2DPanelView(EditorShell& shell)
+        : EditorPanelViewBase(
+            EditorPanelId::Collider2D,
+            L"Collider2D",
+            [&shell]() { return GetCollider2DControls(shell); },
+            [&shell]() { return GetCollider2DControls(shell); },
+            []() { return std::vector<HWND>{}; },
+            []() { return std::vector<HWND>{}; })
+    {
+    }
+}

--- a/Editor/Source/Panels/Collider2DPanelView.h
+++ b/Editor/Source/Panels/Collider2DPanelView.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include "Panels/EditorPanelViewBase.h"
+
+namespace Xelqoria::Editor
+{
+    class EditorShell;
+
+    /// <summary>
+    /// Collider2D Panel の HWND 群を管理する View。
+    /// </summary>
+    class Collider2DPanelView final : public EditorPanelViewBase
+    {
+    public:
+        /// <summary>
+        /// EditorShell が生成した Collider2D control 群へ接続する。
+        /// </summary>
+        explicit Collider2DPanelView(EditorShell& shell);
+
+    private:
+        [[nodiscard]] static std::vector<HWND> GetCollider2DControls(EditorShell& shell);
+    };
+}

--- a/Editor/Source/Panels/EditorPanelViewBase.cpp
+++ b/Editor/Source/Panels/EditorPanelViewBase.cpp
@@ -1,0 +1,100 @@
+#include "Panels/EditorPanelViewBase.h"
+
+#include <utility>
+
+namespace Xelqoria::Editor
+{
+    EditorPanelViewBase::EditorPanelViewBase(
+        EditorPanelId panelId,
+        const wchar_t* title,
+        ControlProvider controls,
+        ControlProvider visibleControls,
+        ControlProvider alwaysHiddenControls,
+        ControlProvider hideWhenInvisibleControls)
+        : m_panelId(panelId)
+        , m_title(title)
+        , m_controls(std::move(controls))
+        , m_visibleControls(std::move(visibleControls))
+        , m_alwaysHiddenControls(std::move(alwaysHiddenControls))
+        , m_hideWhenInvisibleControls(std::move(hideWhenInvisibleControls))
+    {
+    }
+
+    EditorPanelId EditorPanelViewBase::GetPanelId() const
+    {
+        return m_panelId;
+    }
+
+    const wchar_t* EditorPanelViewBase::GetTitle() const
+    {
+        return m_title;
+    }
+
+    bool EditorPanelViewBase::Initialize(HWND parentWindow, HINSTANCE hInstance)
+    {
+        (void)parentWindow;
+        (void)hInstance;
+        return true;
+    }
+
+    void EditorPanelViewBase::Layout(const RECT& bounds)
+    {
+        (void)bounds;
+    }
+
+    void EditorPanelViewBase::Show(bool visible)
+    {
+        const int showCommand = visible ? SW_SHOW : SW_HIDE;
+        for (HWND control : GetControls(m_visibleControls))
+        {
+            ShowWindow(control, showCommand);
+        }
+
+        for (HWND control : GetControls(m_alwaysHiddenControls))
+        {
+            ShowWindow(control, SW_HIDE);
+        }
+
+        if (false == visible)
+        {
+            for (HWND control : GetControls(m_hideWhenInvisibleControls))
+            {
+                ShowWindow(control, SW_HIDE);
+            }
+        }
+    }
+
+    void EditorPanelViewBase::SetParent(HWND parentWindow)
+    {
+        if (nullptr == parentWindow)
+        {
+            return;
+        }
+
+        for (HWND control : GetControls(m_controls))
+        {
+            if (nullptr != control && GetParent(control) != parentWindow)
+            {
+                ::SetParent(control, parentWindow);
+            }
+        }
+    }
+
+    void EditorPanelViewBase::CollectControls(std::vector<HWND>& controls) const
+    {
+        for (HWND control : GetControls(m_controls))
+        {
+            controls.push_back(control);
+        }
+    }
+
+    std::vector<HWND> EditorPanelViewBase::GetControls(const ControlProvider& provider) const
+    {
+        if (false == static_cast<bool>(provider))
+        {
+            return {};
+        }
+
+        return provider();
+    }
+}

--- a/Editor/Source/Panels/EditorPanelViewBase.h
+++ b/Editor/Source/Panels/EditorPanelViewBase.h
@@ -1,0 +1,47 @@
+#pragma once
+
+#include <functional>
+#include <vector>
+
+#include "Panels/IEditorPanelView.h"
+
+namespace Xelqoria::Editor
+{
+    /// <summary>
+    /// 既存 HWND 群を PanelView 契約へ接続する共通基底。
+    /// </summary>
+    class EditorPanelViewBase : public IEditorPanelView
+    {
+    public:
+        using ControlProvider = std::function<std::vector<HWND>()>;
+
+        /// <summary>
+        /// Panel 識別子、表示名、対象 control 群を指定して View 境界を作成する。
+        /// </summary>
+        EditorPanelViewBase(
+            EditorPanelId panelId,
+            const wchar_t* title,
+            ControlProvider controls,
+            ControlProvider visibleControls,
+            ControlProvider alwaysHiddenControls,
+            ControlProvider hideWhenInvisibleControls);
+
+        [[nodiscard]] EditorPanelId GetPanelId() const override;
+        [[nodiscard]] const wchar_t* GetTitle() const override;
+        bool Initialize(HWND parentWindow, HINSTANCE hInstance) override;
+        void Layout(const RECT& bounds) override;
+        void Show(bool visible) override;
+        void SetParent(HWND parentWindow) override;
+        void CollectControls(std::vector<HWND>& controls) const override;
+
+    private:
+        [[nodiscard]] std::vector<HWND> GetControls(const ControlProvider& provider) const;
+
+        EditorPanelId m_panelId;
+        const wchar_t* m_title = L"";
+        ControlProvider m_controls;
+        ControlProvider m_visibleControls;
+        ControlProvider m_alwaysHiddenControls;
+        ControlProvider m_hideWhenInvisibleControls;
+    };
+}

--- a/Editor/Source/Panels/HierarchyPanelController.cpp
+++ b/Editor/Source/Panels/HierarchyPanelController.cpp
@@ -3,6 +3,7 @@
 #include <string>
 
 #include "PlatformAdapters/ButtonClickWin32Adapter.h"
+#include "Panels/HierarchyPanelView.h"
 #include "Utils/EditorStringUtils.h"
 #include <Windows.h>
 #include <array>
@@ -12,7 +13,6 @@
 #include <iterator>
 #include <optional>
 #include <utility>
-#include "Shell/EditorShell.h"
 #include <Entity.h>
 #include <Scene.h>
 
@@ -43,15 +43,15 @@ namespace Xelqoria::Editor
         }
     }
 
-    void HierarchyPanelController::Bind(const EditorShell& shell)
+    void HierarchyPanelController::Bind(const HierarchyPanelView& view)
     {
-        m_hierarchyListBox = shell.GetHierarchyListBox();
-        m_hierarchySummaryLabel = shell.GetHierarchySummaryLabel();
-        m_hierarchySearchEdit = shell.GetHierarchySearchEdit();
-        m_hierarchyNameEdit = shell.GetHierarchyNameEdit();
-        m_hierarchyCreateButton = shell.GetHierarchyCreateButton();
-        m_hierarchyDuplicateButton = shell.GetHierarchyDuplicateButton();
-        m_hierarchyDeleteButton = shell.GetHierarchyDeleteButton();
+        m_hierarchyListBox = view.GetListBox();
+        m_hierarchySummaryLabel = view.GetSummaryLabel();
+        m_hierarchySearchEdit = view.GetSearchEdit();
+        m_hierarchyNameEdit = view.GetNameEdit();
+        m_hierarchyCreateButton = view.GetCreateButton();
+        m_hierarchyDuplicateButton = view.GetDuplicateButton();
+        m_hierarchyDeleteButton = view.GetDeleteButton();
         LoadExpansionState();
     }
 

--- a/Editor/Source/Panels/HierarchyPanelController.h
+++ b/Editor/Source/Panels/HierarchyPanelController.h
@@ -9,13 +9,14 @@
 
 #include "ButtonClickInput.h"
 #include "Commands/SceneEditingOperations.h"
-#include "Shell/EditorShell.h"
 #include "InputSystem.h"
 #include "Scene.h"
 #include <Entity.h>
 
 namespace Xelqoria::Editor
 {
+    class HierarchyPanelView;
+
     /// <summary>
     /// Hierarchy パネルの表示一覧と選択状態を管理する。
     /// </summary>
@@ -85,10 +86,10 @@ namespace Xelqoria::Editor
         }
 
         /// <summary>
-        /// EditorShell の HWND 群へ接続する。
+        /// Hierarchy Panel View の HWND 群へ接続する。
         /// </summary>
-        /// <param name="shell">接続先の EditorShell。</param>
-        void Bind(const EditorShell& shell);
+        /// <param name="view">接続先の Panel View。</param>
+        void Bind(const HierarchyPanelView& view);
 
         /// <summary>
         /// 現在の Scene に合わせて Hierarchy 表示を更新する。

--- a/Editor/Source/Panels/HierarchyPanelView.cpp
+++ b/Editor/Source/Panels/HierarchyPanelView.cpp
@@ -1,0 +1,17 @@
+#include "Panels/HierarchyPanelView.h"
+
+#include "Shell/EditorShell.h"
+
+namespace Xelqoria::Editor
+{
+    HierarchyPanelView::HierarchyPanelView(EditorShell& shell)
+        : EditorPanelViewBase(
+            EditorPanelId::Hierarchy,
+            L"Hierarchy",
+            [&shell]() { return std::vector<HWND>{ shell.m_hierarchyPanel, shell.m_hierarchySummaryLabel, shell.m_hierarchyListBox, shell.m_hierarchySearchEdit, shell.m_hierarchyNameEdit, shell.m_hierarchyCreateButton, shell.m_hierarchyDuplicateButton, shell.m_hierarchyDeleteButton }; },
+            [&shell]() { return std::vector<HWND>{ shell.m_hierarchyPanel, shell.m_hierarchyListBox, shell.m_hierarchySearchEdit, shell.m_hierarchyNameEdit, shell.m_hierarchyCreateButton, shell.m_hierarchyDuplicateButton, shell.m_hierarchyDeleteButton }; },
+            [&shell]() { return std::vector<HWND>{ shell.m_hierarchySummaryLabel }; },
+            []() { return std::vector<HWND>{}; })
+    {
+    }
+}

--- a/Editor/Source/Panels/HierarchyPanelView.cpp
+++ b/Editor/Source/Panels/HierarchyPanelView.cpp
@@ -11,7 +11,43 @@ namespace Xelqoria::Editor
             [&shell]() { return std::vector<HWND>{ shell.m_hierarchyPanel, shell.m_hierarchySummaryLabel, shell.m_hierarchyListBox, shell.m_hierarchySearchEdit, shell.m_hierarchyNameEdit, shell.m_hierarchyCreateButton, shell.m_hierarchyDuplicateButton, shell.m_hierarchyDeleteButton }; },
             [&shell]() { return std::vector<HWND>{ shell.m_hierarchyPanel, shell.m_hierarchyListBox, shell.m_hierarchySearchEdit, shell.m_hierarchyNameEdit, shell.m_hierarchyCreateButton, shell.m_hierarchyDuplicateButton, shell.m_hierarchyDeleteButton }; },
             [&shell]() { return std::vector<HWND>{ shell.m_hierarchySummaryLabel }; },
-            []() { return std::vector<HWND>{}; })
+            []() { return std::vector<HWND>{}; }),
+          m_shell(shell)
     {
+    }
+
+    HWND HierarchyPanelView::GetListBox() const
+    {
+        return m_shell.m_hierarchyListBox;
+    }
+
+    HWND HierarchyPanelView::GetSummaryLabel() const
+    {
+        return m_shell.m_hierarchySummaryLabel;
+    }
+
+    HWND HierarchyPanelView::GetSearchEdit() const
+    {
+        return m_shell.m_hierarchySearchEdit;
+    }
+
+    HWND HierarchyPanelView::GetNameEdit() const
+    {
+        return m_shell.m_hierarchyNameEdit;
+    }
+
+    HWND HierarchyPanelView::GetCreateButton() const
+    {
+        return m_shell.m_hierarchyCreateButton;
+    }
+
+    HWND HierarchyPanelView::GetDuplicateButton() const
+    {
+        return m_shell.m_hierarchyDuplicateButton;
+    }
+
+    HWND HierarchyPanelView::GetDeleteButton() const
+    {
+        return m_shell.m_hierarchyDeleteButton;
     }
 }

--- a/Editor/Source/Panels/HierarchyPanelView.h
+++ b/Editor/Source/Panels/HierarchyPanelView.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include "Panels/EditorPanelViewBase.h"
+
+namespace Xelqoria::Editor
+{
+    class EditorShell;
+
+    /// <summary>
+    /// Hierarchy Panel の HWND 群を管理する View。
+    /// </summary>
+    class HierarchyPanelView final : public EditorPanelViewBase
+    {
+    public:
+        /// <summary>
+        /// EditorShell が生成した Hierarchy control 群へ接続する。
+        /// </summary>
+        explicit HierarchyPanelView(EditorShell& shell);
+    };
+}

--- a/Editor/Source/Panels/HierarchyPanelView.h
+++ b/Editor/Source/Panels/HierarchyPanelView.h
@@ -16,5 +16,16 @@ namespace Xelqoria::Editor
         /// EditorShell が生成した Hierarchy control 群へ接続する。
         /// </summary>
         explicit HierarchyPanelView(EditorShell& shell);
+
+        [[nodiscard]] HWND GetListBox() const;
+        [[nodiscard]] HWND GetSummaryLabel() const;
+        [[nodiscard]] HWND GetSearchEdit() const;
+        [[nodiscard]] HWND GetNameEdit() const;
+        [[nodiscard]] HWND GetCreateButton() const;
+        [[nodiscard]] HWND GetDuplicateButton() const;
+        [[nodiscard]] HWND GetDeleteButton() const;
+
+    private:
+        EditorShell& m_shell;
     };
 }

--- a/Editor/Source/Panels/InspectorPanelController.cpp
+++ b/Editor/Source/Panels/InspectorPanelController.cpp
@@ -15,7 +15,7 @@
 #include <AssetId.h>
 #include <Collider2DComponent.h>
 #include "Panels/AssetsPanelController.h"
-#include "Shell/EditorShell.h"
+#include "Panels/InspectorPanelView.h"
 #include <Entity.h>
 #include "Panels/MaterialPanelController.h"
 #include <Scene.h>
@@ -225,45 +225,45 @@ namespace Xelqoria::Editor
         }
     }
 
-    void InspectorPanelController::Bind(const EditorShell& shell, Platform::ICursor& cursor)
+    void InspectorPanelController::Bind(const InspectorPanelView& view, Platform::ICursor& cursor)
     {
-        m_inspectorSummaryLabel = shell.GetInspectorSummaryLabel();
-        m_transformSectionLabel = shell.GetTransformSectionLabel();
-        m_transformEditControls = shell.GetTransformEditControls();
-        m_spriteComponentSectionLabel = shell.GetSpriteComponentSectionLabel();
-        m_spriteRefLabel = shell.GetSpriteRefLabel();
-        m_spriteRefDropHighlight = shell.GetSpriteRefDropHighlight();
-        m_spriteRefEdit = shell.GetSpriteRefEdit();
-        m_scriptAssetLabel = shell.GetScriptAssetLabel();
-        m_scriptAssetEdit = shell.GetScriptAssetEdit();
-        m_scriptCreateButton = shell.GetScriptCreateButton();
-        m_scriptAssignButton = shell.GetScriptAssignButton();
-        m_scriptClearButton = shell.GetScriptClearButton();
-        m_spriteComponentActionButton = shell.GetSpriteComponentActionButton();
-        m_collider2DComponentSectionLabel = shell.GetCollider2DComponentSectionLabel();
-        m_collider2DSummaryLabel = shell.GetCollider2DSummaryLabel();
-        m_collider2DEnabledCheckBox = shell.GetCollider2DEnabledCheckBox();
-        m_collider2DTriggerCheckBox = shell.GetCollider2DTriggerCheckBox();
-        m_collider2DShapeTypeLabel = shell.GetCollider2DShapeTypeLabel();
-        m_collider2DShapeTypeEdit = shell.GetCollider2DShapeTypeEdit();
-        m_collider2DOffsetLabel = shell.GetCollider2DOffsetLabel();
-        m_collider2DSizeLabel = shell.GetCollider2DSizeLabel();
-        m_collider2DRotationLabel = shell.GetCollider2DRotationLabel();
-        m_collider2DRotationEdit = shell.GetCollider2DRotationEdit();
-        m_collider2DEditControls = shell.GetCollider2DEditControls();
-        m_collider2DEditButton = shell.GetCollider2DEditButton();
-        m_collider2DComponentActionButton = shell.GetCollider2DComponentActionButton();
-        m_addComponentButton = shell.GetAddComponentButton();
-        m_materialOpenButton = shell.GetMaterialOpenButton();
-        m_materialSharedNoticeLabel = shell.GetMaterialSharedNoticeLabel();
-        m_materialDetailsSectionLabel = shell.GetMaterialDetailsSectionLabel();
-        m_materialDetailLabels = shell.GetMaterialDetailLabels();
-        m_materialDetailEditControls = shell.GetMaterialDetailEditControls();
-        m_materialTextureDropHighlight = shell.GetMaterialTextureDropHighlight();
-        m_materialTextureBrowseButton = shell.GetMaterialTextureBrowseButton();
-        m_materialTintColorButton = shell.GetMaterialTintColorButton();
-        m_materialOutlineEnabledCheckBox = shell.GetMaterialOutlineEnabledCheckBox();
-        m_materialOutlineColorButton = shell.GetMaterialOutlineColorButton();
+        m_inspectorSummaryLabel = view.GetSummaryLabel();
+        m_transformSectionLabel = view.GetTransformSectionLabel();
+        m_transformEditControls = view.GetTransformEditControls();
+        m_spriteComponentSectionLabel = view.GetSpriteComponentSectionLabel();
+        m_spriteRefLabel = view.GetSpriteRefLabel();
+        m_spriteRefDropHighlight = view.GetSpriteRefDropHighlight();
+        m_spriteRefEdit = view.GetSpriteRefEdit();
+        m_scriptAssetLabel = view.GetScriptAssetLabel();
+        m_scriptAssetEdit = view.GetScriptAssetEdit();
+        m_scriptCreateButton = view.GetScriptCreateButton();
+        m_scriptAssignButton = view.GetScriptAssignButton();
+        m_scriptClearButton = view.GetScriptClearButton();
+        m_spriteComponentActionButton = view.GetSpriteComponentActionButton();
+        m_collider2DComponentSectionLabel = view.GetCollider2DComponentSectionLabel();
+        m_collider2DSummaryLabel = view.GetCollider2DSummaryLabel();
+        m_collider2DEnabledCheckBox = view.GetCollider2DEnabledCheckBox();
+        m_collider2DTriggerCheckBox = view.GetCollider2DTriggerCheckBox();
+        m_collider2DShapeTypeLabel = view.GetCollider2DShapeTypeLabel();
+        m_collider2DShapeTypeEdit = view.GetCollider2DShapeTypeEdit();
+        m_collider2DOffsetLabel = view.GetCollider2DOffsetLabel();
+        m_collider2DSizeLabel = view.GetCollider2DSizeLabel();
+        m_collider2DRotationLabel = view.GetCollider2DRotationLabel();
+        m_collider2DRotationEdit = view.GetCollider2DRotationEdit();
+        m_collider2DEditControls = view.GetCollider2DEditControls();
+        m_collider2DEditButton = view.GetCollider2DEditButton();
+        m_collider2DComponentActionButton = view.GetCollider2DComponentActionButton();
+        m_addComponentButton = view.GetAddComponentButton();
+        m_materialOpenButton = view.GetMaterialOpenButton();
+        m_materialSharedNoticeLabel = view.GetMaterialSharedNoticeLabel();
+        m_materialDetailsSectionLabel = view.GetMaterialDetailsSectionLabel();
+        m_materialDetailLabels = view.GetMaterialDetailLabels();
+        m_materialDetailEditControls = view.GetMaterialDetailEditControls();
+        m_materialTextureDropHighlight = view.GetMaterialTextureDropHighlight();
+        m_materialTextureBrowseButton = view.GetMaterialTextureBrowseButton();
+        m_materialTintColorButton = view.GetMaterialTintColorButton();
+        m_materialOutlineEnabledCheckBox = view.GetMaterialOutlineEnabledCheckBox();
+        m_materialOutlineColorButton = view.GetMaterialOutlineColorButton();
         m_cursor = &cursor;
         SetWindowTextIfChanged(m_spriteRefLabel, L"Material");
         SetWindowEnabled(m_materialTextureBrowseButton, FALSE);

--- a/Editor/Source/Panels/InspectorPanelController.h
+++ b/Editor/Source/Panels/InspectorPanelController.h
@@ -14,7 +14,6 @@
 #include "Assets/SpriteMaterialAsset.h"
 #include "Utils/EditorStringUtils.h"
 #include "Panels/HierarchyPanelController.h"
-#include "Shell/EditorShell.h"
 #include "ICursor.h"
 #include "InputSystem.h"
 #include "Commands/SceneEditingOperations.h"
@@ -23,6 +22,7 @@
 namespace Xelqoria::Editor
 {
     class AssetsPanelController;
+    class InspectorPanelView;
 
     /// <summary>
     /// Inspector から要求された Script 操作種別を表す。
@@ -182,11 +182,11 @@ namespace Xelqoria::Editor
     {
     public:
         /// <summary>
-        /// EditorShell の HWND 群へ接続する。
+        /// Inspector Panel View の HWND 群へ接続する。
         /// </summary>
-        /// <param name="shell">接続先の EditorShell。</param>
+        /// <param name="view">接続先の Panel View。</param>
         /// <param name="cursor">カーソル位置を取得する Platform 実装。</param>
-        void Bind(const EditorShell& shell, Platform::ICursor& cursor);
+        void Bind(const InspectorPanelView& view, Platform::ICursor& cursor);
 
         /// <summary>
         /// 現在選択中 Entity を Inspector 表示へ反映する。

--- a/Editor/Source/Panels/InspectorPanelView.cpp
+++ b/Editor/Source/Panels/InspectorPanelView.cpp
@@ -1,0 +1,113 @@
+#include "Panels/InspectorPanelView.h"
+
+#include <algorithm>
+
+#include "Shell/EditorShell.h"
+
+namespace Xelqoria::Editor
+{
+    namespace
+    {
+        void AppendArrayControls(std::vector<HWND>& controls, const std::array<HWND, 3>& values)
+        {
+            controls.insert(controls.end(), values.begin(), values.end());
+        }
+
+        void AppendArrayControls(std::vector<HWND>& controls, const std::array<HWND, 4>& values)
+        {
+            controls.insert(controls.end(), values.begin(), values.end());
+        }
+
+        void AppendArrayControls(std::vector<HWND>& controls, const std::array<HWND, 5>& values)
+        {
+            controls.insert(controls.end(), values.begin(), values.end());
+        }
+
+        void AppendArrayControls(std::vector<HWND>& controls, const std::array<HWND, 9>& values)
+        {
+            controls.insert(controls.end(), values.begin(), values.end());
+        }
+
+    }
+
+    std::vector<HWND> InspectorPanelView::GetInspectorControls(EditorShell& shell)
+    {
+        std::vector<HWND> controls{
+            shell.m_inspectorPanel,
+            shell.m_inspectorSummaryLabel,
+            shell.m_transformSectionLabel
+        };
+        AppendArrayControls(controls, shell.m_transformLabels);
+        AppendArrayControls(controls, shell.m_transformEditControls);
+        controls.insert(
+            controls.end(),
+            {
+                shell.m_spriteComponentSectionLabel,
+                shell.m_spriteRefLabel,
+                shell.m_spriteRefDropHighlight,
+                shell.m_spriteRefEdit,
+                shell.m_materialOpenButton,
+                shell.m_scriptAssetLabel,
+                shell.m_scriptAssetEdit,
+                shell.m_scriptCreateButton,
+                shell.m_scriptAssignButton,
+                shell.m_scriptClearButton,
+                shell.m_spriteComponentActionButton,
+                shell.m_materialSharedNoticeLabel,
+                shell.m_materialDetailsSectionLabel
+            });
+        AppendArrayControls(controls, shell.m_materialDetailLabels);
+        AppendArrayControls(controls, shell.m_materialDetailEditControls);
+        controls.insert(
+            controls.end(),
+            {
+                shell.m_materialTextureDropHighlight,
+                shell.m_materialTextureBrowseButton,
+                shell.m_materialTintColorButton,
+                shell.m_materialOutlineEnabledCheckBox,
+                shell.m_materialOutlineColorButton,
+                shell.m_collider2DComponentSectionLabel,
+                shell.m_collider2DSummaryLabel,
+                shell.m_collider2DEnabledCheckBox,
+                shell.m_collider2DTriggerCheckBox,
+                shell.m_collider2DShapeTypeLabel,
+                shell.m_collider2DShapeTypeEdit,
+                shell.m_collider2DOffsetLabel,
+                shell.m_collider2DSizeLabel,
+                shell.m_collider2DRotationLabel,
+                shell.m_collider2DRotationEdit
+            });
+        AppendArrayControls(controls, shell.m_collider2DEditControls);
+        controls.insert(
+            controls.end(),
+            {
+                shell.m_collider2DEditButton,
+                shell.m_collider2DComponentActionButton,
+                shell.m_addComponentButton
+            });
+        return controls;
+    }
+
+    std::vector<HWND> InspectorPanelView::GetInspectorVisibleControls(EditorShell& shell)
+    {
+        std::vector<HWND> controls = GetInspectorControls(shell);
+        controls.erase(
+            std::remove(controls.begin(), controls.end(), shell.m_spriteRefDropHighlight),
+            controls.end());
+        controls.erase(
+            std::remove(controls.begin(), controls.end(), shell.m_materialTextureDropHighlight),
+            controls.end());
+        return controls;
+    }
+
+    InspectorPanelView::InspectorPanelView(EditorShell& shell)
+        : EditorPanelViewBase(
+            EditorPanelId::Inspector,
+            L"Inspector",
+            [&shell]() { return GetInspectorControls(shell); },
+            [&shell]() { return GetInspectorVisibleControls(shell); },
+            []() { return std::vector<HWND>{}; },
+            [&shell]() { return std::vector<HWND>{ shell.m_spriteRefDropHighlight, shell.m_materialTextureDropHighlight }; })
+    {
+    }
+}

--- a/Editor/Source/Panels/InspectorPanelView.cpp
+++ b/Editor/Source/Panels/InspectorPanelView.cpp
@@ -107,7 +107,46 @@ namespace Xelqoria::Editor
             [&shell]() { return GetInspectorControls(shell); },
             [&shell]() { return GetInspectorVisibleControls(shell); },
             []() { return std::vector<HWND>{}; },
-            [&shell]() { return std::vector<HWND>{ shell.m_spriteRefDropHighlight, shell.m_materialTextureDropHighlight }; })
+            [&shell]() { return std::vector<HWND>{ shell.m_spriteRefDropHighlight, shell.m_materialTextureDropHighlight }; }),
+          m_shell(shell)
     {
     }
+
+    HWND InspectorPanelView::GetSummaryLabel() const { return m_shell.m_inspectorSummaryLabel; }
+    HWND InspectorPanelView::GetTransformSectionLabel() const { return m_shell.m_transformSectionLabel; }
+    const std::array<HWND, 9>& InspectorPanelView::GetTransformEditControls() const { return m_shell.m_transformEditControls; }
+    HWND InspectorPanelView::GetSpriteComponentSectionLabel() const { return m_shell.m_spriteComponentSectionLabel; }
+    HWND InspectorPanelView::GetSpriteRefLabel() const { return m_shell.m_spriteRefLabel; }
+    HWND InspectorPanelView::GetSpriteRefDropHighlight() const { return m_shell.m_spriteRefDropHighlight; }
+    HWND InspectorPanelView::GetSpriteRefEdit() const { return m_shell.m_spriteRefEdit; }
+    HWND InspectorPanelView::GetScriptAssetLabel() const { return m_shell.m_scriptAssetLabel; }
+    HWND InspectorPanelView::GetScriptAssetEdit() const { return m_shell.m_scriptAssetEdit; }
+    HWND InspectorPanelView::GetScriptCreateButton() const { return m_shell.m_scriptCreateButton; }
+    HWND InspectorPanelView::GetScriptAssignButton() const { return m_shell.m_scriptAssignButton; }
+    HWND InspectorPanelView::GetScriptClearButton() const { return m_shell.m_scriptClearButton; }
+    HWND InspectorPanelView::GetSpriteComponentActionButton() const { return m_shell.m_spriteComponentActionButton; }
+    HWND InspectorPanelView::GetCollider2DComponentSectionLabel() const { return m_shell.m_collider2DComponentSectionLabel; }
+    HWND InspectorPanelView::GetCollider2DSummaryLabel() const { return m_shell.m_collider2DSummaryLabel; }
+    HWND InspectorPanelView::GetCollider2DEnabledCheckBox() const { return m_shell.m_collider2DEnabledCheckBox; }
+    HWND InspectorPanelView::GetCollider2DTriggerCheckBox() const { return m_shell.m_collider2DTriggerCheckBox; }
+    HWND InspectorPanelView::GetCollider2DShapeTypeLabel() const { return m_shell.m_collider2DShapeTypeLabel; }
+    HWND InspectorPanelView::GetCollider2DShapeTypeEdit() const { return m_shell.m_collider2DShapeTypeEdit; }
+    HWND InspectorPanelView::GetCollider2DOffsetLabel() const { return m_shell.m_collider2DOffsetLabel; }
+    HWND InspectorPanelView::GetCollider2DSizeLabel() const { return m_shell.m_collider2DSizeLabel; }
+    HWND InspectorPanelView::GetCollider2DRotationLabel() const { return m_shell.m_collider2DRotationLabel; }
+    HWND InspectorPanelView::GetCollider2DRotationEdit() const { return m_shell.m_collider2DRotationEdit; }
+    const std::array<HWND, 4>& InspectorPanelView::GetCollider2DEditControls() const { return m_shell.m_collider2DEditControls; }
+    HWND InspectorPanelView::GetCollider2DEditButton() const { return m_shell.m_collider2DEditButton; }
+    HWND InspectorPanelView::GetCollider2DComponentActionButton() const { return m_shell.m_collider2DComponentActionButton; }
+    HWND InspectorPanelView::GetAddComponentButton() const { return m_shell.m_addComponentButton; }
+    HWND InspectorPanelView::GetMaterialOpenButton() const { return m_shell.m_materialOpenButton; }
+    HWND InspectorPanelView::GetMaterialSharedNoticeLabel() const { return m_shell.m_materialSharedNoticeLabel; }
+    HWND InspectorPanelView::GetMaterialDetailsSectionLabel() const { return m_shell.m_materialDetailsSectionLabel; }
+    const std::array<HWND, 5>& InspectorPanelView::GetMaterialDetailLabels() const { return m_shell.m_materialDetailLabels; }
+    const std::array<HWND, 5>& InspectorPanelView::GetMaterialDetailEditControls() const { return m_shell.m_materialDetailEditControls; }
+    HWND InspectorPanelView::GetMaterialTextureDropHighlight() const { return m_shell.m_materialTextureDropHighlight; }
+    HWND InspectorPanelView::GetMaterialTextureBrowseButton() const { return m_shell.m_materialTextureBrowseButton; }
+    HWND InspectorPanelView::GetMaterialTintColorButton() const { return m_shell.m_materialTintColorButton; }
+    HWND InspectorPanelView::GetMaterialOutlineEnabledCheckBox() const { return m_shell.m_materialOutlineEnabledCheckBox; }
+    HWND InspectorPanelView::GetMaterialOutlineColorButton() const { return m_shell.m_materialOutlineColorButton; }
 }

--- a/Editor/Source/Panels/InspectorPanelView.h
+++ b/Editor/Source/Panels/InspectorPanelView.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <array>
+
 #include "Panels/EditorPanelViewBase.h"
 
 namespace Xelqoria::Editor
@@ -17,8 +19,48 @@ namespace Xelqoria::Editor
         /// </summary>
         explicit InspectorPanelView(EditorShell& shell);
 
+        [[nodiscard]] HWND GetSummaryLabel() const;
+        [[nodiscard]] HWND GetTransformSectionLabel() const;
+        [[nodiscard]] const std::array<HWND, 9>& GetTransformEditControls() const;
+        [[nodiscard]] HWND GetSpriteComponentSectionLabel() const;
+        [[nodiscard]] HWND GetSpriteRefLabel() const;
+        [[nodiscard]] HWND GetSpriteRefDropHighlight() const;
+        [[nodiscard]] HWND GetSpriteRefEdit() const;
+        [[nodiscard]] HWND GetScriptAssetLabel() const;
+        [[nodiscard]] HWND GetScriptAssetEdit() const;
+        [[nodiscard]] HWND GetScriptCreateButton() const;
+        [[nodiscard]] HWND GetScriptAssignButton() const;
+        [[nodiscard]] HWND GetScriptClearButton() const;
+        [[nodiscard]] HWND GetSpriteComponentActionButton() const;
+        [[nodiscard]] HWND GetCollider2DComponentSectionLabel() const;
+        [[nodiscard]] HWND GetCollider2DSummaryLabel() const;
+        [[nodiscard]] HWND GetCollider2DEnabledCheckBox() const;
+        [[nodiscard]] HWND GetCollider2DTriggerCheckBox() const;
+        [[nodiscard]] HWND GetCollider2DShapeTypeLabel() const;
+        [[nodiscard]] HWND GetCollider2DShapeTypeEdit() const;
+        [[nodiscard]] HWND GetCollider2DOffsetLabel() const;
+        [[nodiscard]] HWND GetCollider2DSizeLabel() const;
+        [[nodiscard]] HWND GetCollider2DRotationLabel() const;
+        [[nodiscard]] HWND GetCollider2DRotationEdit() const;
+        [[nodiscard]] const std::array<HWND, 4>& GetCollider2DEditControls() const;
+        [[nodiscard]] HWND GetCollider2DEditButton() const;
+        [[nodiscard]] HWND GetCollider2DComponentActionButton() const;
+        [[nodiscard]] HWND GetAddComponentButton() const;
+        [[nodiscard]] HWND GetMaterialOpenButton() const;
+        [[nodiscard]] HWND GetMaterialSharedNoticeLabel() const;
+        [[nodiscard]] HWND GetMaterialDetailsSectionLabel() const;
+        [[nodiscard]] const std::array<HWND, 5>& GetMaterialDetailLabels() const;
+        [[nodiscard]] const std::array<HWND, 5>& GetMaterialDetailEditControls() const;
+        [[nodiscard]] HWND GetMaterialTextureDropHighlight() const;
+        [[nodiscard]] HWND GetMaterialTextureBrowseButton() const;
+        [[nodiscard]] HWND GetMaterialTintColorButton() const;
+        [[nodiscard]] HWND GetMaterialOutlineEnabledCheckBox() const;
+        [[nodiscard]] HWND GetMaterialOutlineColorButton() const;
+
     private:
         [[nodiscard]] static std::vector<HWND> GetInspectorControls(EditorShell& shell);
         [[nodiscard]] static std::vector<HWND> GetInspectorVisibleControls(EditorShell& shell);
+
+        EditorShell& m_shell;
     };
 }

--- a/Editor/Source/Panels/InspectorPanelView.h
+++ b/Editor/Source/Panels/InspectorPanelView.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include "Panels/EditorPanelViewBase.h"
+
+namespace Xelqoria::Editor
+{
+    class EditorShell;
+
+    /// <summary>
+    /// Inspector Panel の HWND 群を管理する View。
+    /// </summary>
+    class InspectorPanelView final : public EditorPanelViewBase
+    {
+    public:
+        /// <summary>
+        /// EditorShell が生成した Inspector control 群へ接続する。
+        /// </summary>
+        explicit InspectorPanelView(EditorShell& shell);
+
+    private:
+        [[nodiscard]] static std::vector<HWND> GetInspectorControls(EditorShell& shell);
+        [[nodiscard]] static std::vector<HWND> GetInspectorVisibleControls(EditorShell& shell);
+    };
+}

--- a/Editor/Source/Panels/LogOutputPanelController.cpp
+++ b/Editor/Source/Panels/LogOutputPanelController.cpp
@@ -9,6 +9,7 @@
 
 #include "PlatformAdapters/ButtonClickWin32Adapter.h"
 #include "EditorTheme.h"
+#include "Panels/LogOutputPanelView.h"
 
 namespace Xelqoria::Editor
 {
@@ -117,13 +118,13 @@ namespace Xelqoria::Editor
         }
     }
 
-    void LogOutputPanelController::Bind(const EditorShell& shell, Platform::IClipboard& clipboard)
+    void LogOutputPanelController::Bind(const LogOutputPanelView& view, Platform::IClipboard& clipboard)
     {
-        m_tabControl = shell.GetLogOutputTabControl();
-        m_clearButton = shell.GetLogClearButton();
-        m_copyButton = shell.GetLogCopyButton();
-        m_filterEdit = shell.GetLogFilterEdit();
-        m_listBox = shell.GetLogListBox();
+        m_tabControl = view.GetTabControl();
+        m_clearButton = view.GetClearButton();
+        m_copyButton = view.GetCopyButton();
+        m_filterEdit = view.GetFilterEdit();
+        m_listBox = view.GetListBox();
         m_clipboard = &clipboard;
         EnsureDummyLogs();
         RefreshVisibleRows();

--- a/Editor/Source/Panels/LogOutputPanelController.h
+++ b/Editor/Source/Panels/LogOutputPanelController.h
@@ -6,12 +6,13 @@
 #include <vector>
 
 #include "ButtonClickInput.h"
-#include "Shell/EditorShell.h"
 #include "IClipboard.h"
 #include "InputSystem.h"
 
 namespace Xelqoria::Editor
 {
+    class LogOutputPanelView;
+
     /// <summary>
     /// LogOutput パネルに表示するログ種別を表す。
     /// </summary>
@@ -39,10 +40,10 @@ namespace Xelqoria::Editor
     {
     public:
         /// <summary>
-        /// EditorShell の HWND 群へ接続する。
+        /// LogOutput Panel View の HWND 群へ接続する。
         /// </summary>
-        /// <param name="shell">接続先の EditorShell。</param>
-        void Bind(const EditorShell& shell, Platform::IClipboard& clipboard);
+        /// <param name="view">接続先の Panel View。</param>
+        void Bind(const LogOutputPanelView& view, Platform::IClipboard& clipboard);
 
         /// <summary>
         /// 指定カテゴリへログ行を追加する。

--- a/Editor/Source/Panels/LogOutputPanelView.cpp
+++ b/Editor/Source/Panels/LogOutputPanelView.cpp
@@ -11,7 +11,33 @@ namespace Xelqoria::Editor
             [&shell]() { return std::vector<HWND>{ shell.m_logOutputPanel, shell.m_logOutputTabControl, shell.m_logClearButton, shell.m_logCopyButton, shell.m_logFilterEdit, shell.m_logListBox }; },
             [&shell]() { return std::vector<HWND>{ shell.m_logOutputPanel, shell.m_logOutputTabControl, shell.m_logClearButton, shell.m_logFilterEdit, shell.m_logListBox }; },
             [&shell]() { return std::vector<HWND>{ shell.m_logCopyButton }; },
-            []() { return std::vector<HWND>{}; })
+            []() { return std::vector<HWND>{}; }),
+          m_shell(shell)
     {
+    }
+
+    HWND LogOutputPanelView::GetTabControl() const
+    {
+        return m_shell.m_logOutputTabControl;
+    }
+
+    HWND LogOutputPanelView::GetClearButton() const
+    {
+        return m_shell.m_logClearButton;
+    }
+
+    HWND LogOutputPanelView::GetCopyButton() const
+    {
+        return m_shell.m_logCopyButton;
+    }
+
+    HWND LogOutputPanelView::GetFilterEdit() const
+    {
+        return m_shell.m_logFilterEdit;
+    }
+
+    HWND LogOutputPanelView::GetListBox() const
+    {
+        return m_shell.m_logListBox;
     }
 }

--- a/Editor/Source/Panels/LogOutputPanelView.cpp
+++ b/Editor/Source/Panels/LogOutputPanelView.cpp
@@ -1,0 +1,17 @@
+#include "Panels/LogOutputPanelView.h"
+
+#include "Shell/EditorShell.h"
+
+namespace Xelqoria::Editor
+{
+    LogOutputPanelView::LogOutputPanelView(EditorShell& shell)
+        : EditorPanelViewBase(
+            EditorPanelId::LogOutput,
+            L"Console",
+            [&shell]() { return std::vector<HWND>{ shell.m_logOutputPanel, shell.m_logOutputTabControl, shell.m_logClearButton, shell.m_logCopyButton, shell.m_logFilterEdit, shell.m_logListBox }; },
+            [&shell]() { return std::vector<HWND>{ shell.m_logOutputPanel, shell.m_logOutputTabControl, shell.m_logClearButton, shell.m_logFilterEdit, shell.m_logListBox }; },
+            [&shell]() { return std::vector<HWND>{ shell.m_logCopyButton }; },
+            []() { return std::vector<HWND>{}; })
+    {
+    }
+}

--- a/Editor/Source/Panels/LogOutputPanelView.h
+++ b/Editor/Source/Panels/LogOutputPanelView.h
@@ -16,5 +16,14 @@ namespace Xelqoria::Editor
         /// EditorShell が生成した LogOutput control 群へ接続する。
         /// </summary>
         explicit LogOutputPanelView(EditorShell& shell);
+
+        [[nodiscard]] HWND GetTabControl() const;
+        [[nodiscard]] HWND GetClearButton() const;
+        [[nodiscard]] HWND GetCopyButton() const;
+        [[nodiscard]] HWND GetFilterEdit() const;
+        [[nodiscard]] HWND GetListBox() const;
+
+    private:
+        EditorShell& m_shell;
     };
 }

--- a/Editor/Source/Panels/LogOutputPanelView.h
+++ b/Editor/Source/Panels/LogOutputPanelView.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include "Panels/EditorPanelViewBase.h"
+
+namespace Xelqoria::Editor
+{
+    class EditorShell;
+
+    /// <summary>
+    /// LogOutput Panel の HWND 群を管理する View。
+    /// </summary>
+    class LogOutputPanelView final : public EditorPanelViewBase
+    {
+    public:
+        /// <summary>
+        /// EditorShell が生成した LogOutput control 群へ接続する。
+        /// </summary>
+        explicit LogOutputPanelView(EditorShell& shell);
+    };
+}

--- a/Editor/Source/Panels/MaterialPanelController.cpp
+++ b/Editor/Source/Panels/MaterialPanelController.cpp
@@ -13,7 +13,7 @@
 #include <utility>
 
 #include "Panels/AssetsPanelController.h"
-#include "Shell/EditorShell.h"
+#include "Panels/MaterialPanelView.h"
 #include "Utils/EditorStringUtils.h"
 
 namespace Xelqoria::Editor
@@ -78,14 +78,14 @@ namespace Xelqoria::Editor
         }
     }
 
-    void MaterialPanelController::Bind(const EditorShell& shell, Platform::ICursor& cursor)
+    void MaterialPanelController::Bind(const MaterialPanelView& view, Platform::ICursor& cursor)
     {
-        m_materialSummaryLabel = shell.GetMaterialSummaryLabel();
-        m_materialSharedNoticeLabel = shell.GetMaterialSharedNoticeLabel();
-        m_materialDetailsSectionLabel = shell.GetMaterialDetailsSectionLabel();
-        m_materialDetailLabels = shell.GetMaterialDetailLabels();
-        m_materialDetailEditControls = shell.GetMaterialDetailEditControls();
-        m_materialTextureDropHighlight = shell.GetMaterialTextureDropHighlight();
+        m_materialSummaryLabel = view.GetSummaryLabel();
+        m_materialSharedNoticeLabel = view.GetSharedNoticeLabel();
+        m_materialDetailsSectionLabel = view.GetDetailsSectionLabel();
+        m_materialDetailLabels = view.GetDetailLabels();
+        m_materialDetailEditControls = view.GetDetailEditControls();
+        m_materialTextureDropHighlight = view.GetTextureDropHighlight();
         m_cursor = &cursor;
     }
 

--- a/Editor/Source/Panels/MaterialPanelController.h
+++ b/Editor/Source/Panels/MaterialPanelController.h
@@ -14,7 +14,7 @@
 namespace Xelqoria::Editor
 {
     class AssetsPanelController;
-    class EditorShell;
+    class MaterialPanelView;
 
     /// <summary>
     /// Material パネルで行われた編集適用結果を表す。
@@ -49,11 +49,11 @@ namespace Xelqoria::Editor
     {
     public:
         /// <summary>
-        /// EditorShell の Material パネル HWND 群へ接続する。
+        /// Material Panel View の HWND 群へ接続する。
         /// </summary>
-        /// <param name="shell">接続先の EditorShell。</param>
+        /// <param name="view">接続先の Panel View。</param>
         /// <param name="cursor">カーソル位置を取得する Platform 実装。</param>
-        void Bind(const EditorShell& shell, Platform::ICursor& cursor);
+        void Bind(const MaterialPanelView& view, Platform::ICursor& cursor);
 
         /// <summary>
         /// 指定 MaterialAssetId を Material パネルで開く。

--- a/Editor/Source/Panels/MaterialPanelView.cpp
+++ b/Editor/Source/Panels/MaterialPanelView.cpp
@@ -1,0 +1,43 @@
+#include "Panels/MaterialPanelView.h"
+
+#include "Shell/EditorShell.h"
+
+namespace Xelqoria::Editor
+{
+    std::vector<HWND> MaterialPanelView::GetMaterialControls(EditorShell& shell)
+    {
+        std::vector<HWND> controls{
+            shell.m_materialPanel,
+            shell.m_materialSummaryLabel,
+            shell.m_materialSharedNoticeLabel,
+            shell.m_materialDetailsSectionLabel
+        };
+        controls.insert(controls.end(), shell.m_materialDetailLabels.begin(), shell.m_materialDetailLabels.end());
+        controls.insert(controls.end(), shell.m_materialDetailEditControls.begin(), shell.m_materialDetailEditControls.end());
+        controls.push_back(shell.m_materialTextureDropHighlight);
+        return controls;
+    }
+
+    std::vector<HWND> MaterialPanelView::GetMaterialVisibleControls(EditorShell& shell)
+    {
+        std::vector<HWND> controls{
+            shell.m_materialPanel,
+            shell.m_materialSharedNoticeLabel,
+            shell.m_materialDetailsSectionLabel
+        };
+        controls.insert(controls.end(), shell.m_materialDetailLabels.begin(), shell.m_materialDetailLabels.end());
+        controls.insert(controls.end(), shell.m_materialDetailEditControls.begin(), shell.m_materialDetailEditControls.end());
+        return controls;
+    }
+
+    MaterialPanelView::MaterialPanelView(EditorShell& shell)
+        : EditorPanelViewBase(
+            EditorPanelId::Material,
+            L"Material",
+            [&shell]() { return GetMaterialControls(shell); },
+            [&shell]() { return GetMaterialVisibleControls(shell); },
+            [&shell]() { return std::vector<HWND>{ shell.m_materialSummaryLabel }; },
+            [&shell]() { return std::vector<HWND>{ shell.m_materialTextureDropHighlight }; })
+    {
+    }
+}

--- a/Editor/Source/Panels/MaterialPanelView.cpp
+++ b/Editor/Source/Panels/MaterialPanelView.cpp
@@ -37,7 +37,38 @@ namespace Xelqoria::Editor
             [&shell]() { return GetMaterialControls(shell); },
             [&shell]() { return GetMaterialVisibleControls(shell); },
             [&shell]() { return std::vector<HWND>{ shell.m_materialSummaryLabel }; },
-            [&shell]() { return std::vector<HWND>{ shell.m_materialTextureDropHighlight }; })
+            [&shell]() { return std::vector<HWND>{ shell.m_materialTextureDropHighlight }; }),
+          m_shell(shell)
     {
+    }
+
+    HWND MaterialPanelView::GetSummaryLabel() const
+    {
+        return m_shell.m_materialSummaryLabel;
+    }
+
+    HWND MaterialPanelView::GetSharedNoticeLabel() const
+    {
+        return m_shell.m_materialSharedNoticeLabel;
+    }
+
+    HWND MaterialPanelView::GetDetailsSectionLabel() const
+    {
+        return m_shell.m_materialDetailsSectionLabel;
+    }
+
+    const std::array<HWND, 5>& MaterialPanelView::GetDetailLabels() const
+    {
+        return m_shell.m_materialDetailLabels;
+    }
+
+    const std::array<HWND, 5>& MaterialPanelView::GetDetailEditControls() const
+    {
+        return m_shell.m_materialDetailEditControls;
+    }
+
+    HWND MaterialPanelView::GetTextureDropHighlight() const
+    {
+        return m_shell.m_materialTextureDropHighlight;
     }
 }

--- a/Editor/Source/Panels/MaterialPanelView.h
+++ b/Editor/Source/Panels/MaterialPanelView.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include "Panels/EditorPanelViewBase.h"
+
+namespace Xelqoria::Editor
+{
+    class EditorShell;
+
+    /// <summary>
+    /// Material Panel の HWND 群を管理する View。
+    /// </summary>
+    class MaterialPanelView final : public EditorPanelViewBase
+    {
+    public:
+        /// <summary>
+        /// EditorShell が生成した Material control 群へ接続する。
+        /// </summary>
+        explicit MaterialPanelView(EditorShell& shell);
+
+    private:
+        [[nodiscard]] static std::vector<HWND> GetMaterialControls(EditorShell& shell);
+        [[nodiscard]] static std::vector<HWND> GetMaterialVisibleControls(EditorShell& shell);
+    };
+}

--- a/Editor/Source/Panels/MaterialPanelView.h
+++ b/Editor/Source/Panels/MaterialPanelView.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <array>
+
 #include "Panels/EditorPanelViewBase.h"
 
 namespace Xelqoria::Editor
@@ -17,8 +19,17 @@ namespace Xelqoria::Editor
         /// </summary>
         explicit MaterialPanelView(EditorShell& shell);
 
+        [[nodiscard]] HWND GetSummaryLabel() const;
+        [[nodiscard]] HWND GetSharedNoticeLabel() const;
+        [[nodiscard]] HWND GetDetailsSectionLabel() const;
+        [[nodiscard]] const std::array<HWND, 5>& GetDetailLabels() const;
+        [[nodiscard]] const std::array<HWND, 5>& GetDetailEditControls() const;
+        [[nodiscard]] HWND GetTextureDropHighlight() const;
+
     private:
         [[nodiscard]] static std::vector<HWND> GetMaterialControls(EditorShell& shell);
         [[nodiscard]] static std::vector<HWND> GetMaterialVisibleControls(EditorShell& shell);
+
+        EditorShell& m_shell;
     };
 }

--- a/Editor/Source/Panels/SceneViewPanelView.cpp
+++ b/Editor/Source/Panels/SceneViewPanelView.cpp
@@ -11,7 +11,38 @@ namespace Xelqoria::Editor
             [&shell]() { return std::vector<HWND>{ shell.m_sceneViewPanel, shell.m_sceneViewPlanLabel, shell.m_projectSummaryLabel, shell.m_projectSceneListBox, shell.m_projectSceneDetailLabel, shell.m_sceneViewHost, shell.m_sceneViewSizeLabel, shell.m_buildAndPlayButton, shell.m_pauseResumePlayButton, shell.m_endPlayButton }; },
             [&shell]() { return std::vector<HWND>{ shell.m_sceneViewPanel, shell.m_sceneViewHost, shell.m_buildAndPlayButton, shell.m_pauseResumePlayButton, shell.m_endPlayButton }; },
             [&shell]() { return std::vector<HWND>{ shell.m_sceneViewPlanLabel, shell.m_projectSummaryLabel, shell.m_projectSceneListBox, shell.m_projectSceneDetailLabel, shell.m_sceneViewSizeLabel }; },
-            []() { return std::vector<HWND>{}; })
+            []() { return std::vector<HWND>{}; }),
+          m_shell(shell)
     {
+    }
+
+    SceneViewSurface SceneViewPanelView::GetSceneViewSurface() const
+    {
+        return m_shell.GetSceneViewSurface();
+    }
+
+    HWND SceneViewPanelView::GetSceneViewPlanLabel() const
+    {
+        return m_shell.m_sceneViewPlanLabel;
+    }
+
+    HWND SceneViewPanelView::GetSceneViewSizeLabel() const
+    {
+        return m_shell.m_sceneViewSizeLabel;
+    }
+
+    HWND SceneViewPanelView::GetProjectSummaryLabel() const
+    {
+        return m_shell.m_projectSummaryLabel;
+    }
+
+    HWND SceneViewPanelView::GetProjectSceneListBox() const
+    {
+        return m_shell.m_projectSceneListBox;
+    }
+
+    HWND SceneViewPanelView::GetProjectSceneDetailLabel() const
+    {
+        return m_shell.m_projectSceneDetailLabel;
     }
 }

--- a/Editor/Source/Panels/SceneViewPanelView.cpp
+++ b/Editor/Source/Panels/SceneViewPanelView.cpp
@@ -1,0 +1,17 @@
+#include "Panels/SceneViewPanelView.h"
+
+#include "Shell/EditorShell.h"
+
+namespace Xelqoria::Editor
+{
+    SceneViewPanelView::SceneViewPanelView(EditorShell& shell)
+        : EditorPanelViewBase(
+            EditorPanelId::SceneView,
+            L"Scene",
+            [&shell]() { return std::vector<HWND>{ shell.m_sceneViewPanel, shell.m_sceneViewPlanLabel, shell.m_projectSummaryLabel, shell.m_projectSceneListBox, shell.m_projectSceneDetailLabel, shell.m_sceneViewHost, shell.m_sceneViewSizeLabel, shell.m_buildAndPlayButton, shell.m_pauseResumePlayButton, shell.m_endPlayButton }; },
+            [&shell]() { return std::vector<HWND>{ shell.m_sceneViewPanel, shell.m_sceneViewHost, shell.m_buildAndPlayButton, shell.m_pauseResumePlayButton, shell.m_endPlayButton }; },
+            [&shell]() { return std::vector<HWND>{ shell.m_sceneViewPlanLabel, shell.m_projectSummaryLabel, shell.m_projectSceneListBox, shell.m_projectSceneDetailLabel, shell.m_sceneViewSizeLabel }; },
+            []() { return std::vector<HWND>{}; })
+    {
+    }
+}

--- a/Editor/Source/Panels/SceneViewPanelView.h
+++ b/Editor/Source/Panels/SceneViewPanelView.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include "Panels/EditorPanelViewBase.h"
+
+namespace Xelqoria::Editor
+{
+    class EditorShell;
+
+    /// <summary>
+    /// SceneView Panel の HWND 群を管理する View。
+    /// </summary>
+    class SceneViewPanelView final : public EditorPanelViewBase
+    {
+    public:
+        /// <summary>
+        /// EditorShell が生成した SceneView control 群へ接続する。
+        /// </summary>
+        explicit SceneViewPanelView(EditorShell& shell);
+    };
+}

--- a/Editor/Source/Panels/SceneViewPanelView.h
+++ b/Editor/Source/Panels/SceneViewPanelView.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "Panels/EditorPanelViewBase.h"
+#include "SceneViewSurface.h"
 
 namespace Xelqoria::Editor
 {
@@ -16,5 +17,15 @@ namespace Xelqoria::Editor
         /// EditorShell が生成した SceneView control 群へ接続する。
         /// </summary>
         explicit SceneViewPanelView(EditorShell& shell);
+
+        [[nodiscard]] SceneViewSurface GetSceneViewSurface() const;
+        [[nodiscard]] HWND GetSceneViewPlanLabel() const;
+        [[nodiscard]] HWND GetSceneViewSizeLabel() const;
+        [[nodiscard]] HWND GetProjectSummaryLabel() const;
+        [[nodiscard]] HWND GetProjectSceneListBox() const;
+        [[nodiscard]] HWND GetProjectSceneDetailLabel() const;
+
+    private:
+        EditorShell& m_shell;
     };
 }

--- a/Editor/Source/Panels/SpritePanelController.cpp
+++ b/Editor/Source/Panels/SpritePanelController.cpp
@@ -3,17 +3,17 @@
 #include <filesystem>
 #include <utility>
 
-#include "Shell/EditorShell.h"
+#include "Panels/SpritePanelView.h"
 #include "Utils/EditorStringUtils.h"
 
 namespace Xelqoria::Editor
 {
-    void SpritePanelController::Bind(const EditorShell& shell)
+    void SpritePanelController::Bind(const SpritePanelView& view)
     {
-        m_spriteSummaryLabel = shell.GetSpriteSummaryLabel();
-        m_spriteDetailsSectionLabel = shell.GetSpriteDetailsSectionLabel();
-        m_spriteDetailLabels = shell.GetSpriteDetailLabels();
-        m_spriteDetailEditControls = shell.GetSpriteDetailEditControls();
+        m_spriteSummaryLabel = view.GetSummaryLabel();
+        m_spriteDetailsSectionLabel = view.GetDetailsSectionLabel();
+        m_spriteDetailLabels = view.GetDetailLabels();
+        m_spriteDetailEditControls = view.GetDetailEditControls();
     }
 
     void SpritePanelController::OpenSprite(

--- a/Editor/Source/Panels/SpritePanelController.h
+++ b/Editor/Source/Panels/SpritePanelController.h
@@ -9,7 +9,7 @@
 
 namespace Xelqoria::Editor
 {
-    class EditorShell;
+    class SpritePanelView;
 
     /// <summary>
     /// Sprite 専用パネルの表示同期を管理する。
@@ -18,10 +18,10 @@ namespace Xelqoria::Editor
     {
     public:
         /// <summary>
-        /// EditorShell の Sprite パネル HWND 群へ接続する。
+        /// Sprite Panel View の HWND 群へ接続する。
         /// </summary>
-        /// <param name="shell">接続先の EditorShell。</param>
-        void Bind(const EditorShell& shell);
+        /// <param name="view">接続先の Panel View。</param>
+        void Bind(const SpritePanelView& view);
 
         /// <summary>
         /// 指定 SpriteAssetId を Sprite パネルで開く。

--- a/Editor/Source/Panels/SpritePanelView.cpp
+++ b/Editor/Source/Panels/SpritePanelView.cpp
@@ -34,7 +34,28 @@ namespace Xelqoria::Editor
             [&shell]() { return GetSpriteControls(shell); },
             [&shell]() { return GetSpriteVisibleControls(shell); },
             [&shell]() { return std::vector<HWND>{ shell.m_spriteSummaryLabel }; },
-            []() { return std::vector<HWND>{}; })
+            []() { return std::vector<HWND>{}; }),
+          m_shell(shell)
     {
+    }
+
+    HWND SpritePanelView::GetSummaryLabel() const
+    {
+        return m_shell.m_spriteSummaryLabel;
+    }
+
+    HWND SpritePanelView::GetDetailsSectionLabel() const
+    {
+        return m_shell.m_spriteDetailsSectionLabel;
+    }
+
+    const std::array<HWND, 4>& SpritePanelView::GetDetailLabels() const
+    {
+        return m_shell.m_spriteDetailLabels;
+    }
+
+    const std::array<HWND, 4>& SpritePanelView::GetDetailEditControls() const
+    {
+        return m_shell.m_spriteDetailEditControls;
     }
 }

--- a/Editor/Source/Panels/SpritePanelView.cpp
+++ b/Editor/Source/Panels/SpritePanelView.cpp
@@ -1,0 +1,40 @@
+#include "Panels/SpritePanelView.h"
+
+#include "Shell/EditorShell.h"
+
+namespace Xelqoria::Editor
+{
+    std::vector<HWND> SpritePanelView::GetSpriteControls(EditorShell& shell)
+    {
+        std::vector<HWND> controls{
+            shell.m_spritePanel,
+            shell.m_spriteSummaryLabel,
+            shell.m_spriteDetailsSectionLabel
+        };
+        controls.insert(controls.end(), shell.m_spriteDetailLabels.begin(), shell.m_spriteDetailLabels.end());
+        controls.insert(controls.end(), shell.m_spriteDetailEditControls.begin(), shell.m_spriteDetailEditControls.end());
+        return controls;
+    }
+
+    std::vector<HWND> SpritePanelView::GetSpriteVisibleControls(EditorShell& shell)
+    {
+        std::vector<HWND> controls{
+            shell.m_spritePanel,
+            shell.m_spriteDetailsSectionLabel
+        };
+        controls.insert(controls.end(), shell.m_spriteDetailLabels.begin(), shell.m_spriteDetailLabels.end());
+        controls.insert(controls.end(), shell.m_spriteDetailEditControls.begin(), shell.m_spriteDetailEditControls.end());
+        return controls;
+    }
+
+    SpritePanelView::SpritePanelView(EditorShell& shell)
+        : EditorPanelViewBase(
+            EditorPanelId::Sprite,
+            L"Sprite",
+            [&shell]() { return GetSpriteControls(shell); },
+            [&shell]() { return GetSpriteVisibleControls(shell); },
+            [&shell]() { return std::vector<HWND>{ shell.m_spriteSummaryLabel }; },
+            []() { return std::vector<HWND>{}; })
+    {
+    }
+}

--- a/Editor/Source/Panels/SpritePanelView.h
+++ b/Editor/Source/Panels/SpritePanelView.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <array>
+
 #include "Panels/EditorPanelViewBase.h"
 
 namespace Xelqoria::Editor
@@ -17,8 +19,15 @@ namespace Xelqoria::Editor
         /// </summary>
         explicit SpritePanelView(EditorShell& shell);
 
+        [[nodiscard]] HWND GetSummaryLabel() const;
+        [[nodiscard]] HWND GetDetailsSectionLabel() const;
+        [[nodiscard]] const std::array<HWND, 4>& GetDetailLabels() const;
+        [[nodiscard]] const std::array<HWND, 4>& GetDetailEditControls() const;
+
     private:
         [[nodiscard]] static std::vector<HWND> GetSpriteControls(EditorShell& shell);
         [[nodiscard]] static std::vector<HWND> GetSpriteVisibleControls(EditorShell& shell);
+
+        EditorShell& m_shell;
     };
 }

--- a/Editor/Source/Panels/SpritePanelView.h
+++ b/Editor/Source/Panels/SpritePanelView.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include "Panels/EditorPanelViewBase.h"
+
+namespace Xelqoria::Editor
+{
+    class EditorShell;
+
+    /// <summary>
+    /// Sprite Panel の HWND 群を管理する View。
+    /// </summary>
+    class SpritePanelView final : public EditorPanelViewBase
+    {
+    public:
+        /// <summary>
+        /// EditorShell が生成した Sprite control 群へ接続する。
+        /// </summary>
+        explicit SpritePanelView(EditorShell& shell);
+
+    private:
+        [[nodiscard]] static std::vector<HWND> GetSpriteControls(EditorShell& shell);
+        [[nodiscard]] static std::vector<HWND> GetSpriteVisibleControls(EditorShell& shell);
+    };
+}

--- a/Editor/Source/Project/ProjectPanelController.cpp
+++ b/Editor/Source/Project/ProjectPanelController.cpp
@@ -5,13 +5,15 @@
 #include <iterator>
 #include <string>
 
+#include "Panels/SceneViewPanelView.h"
+
 namespace Xelqoria::Editor
 {
-    void ProjectPanelController::Bind(const EditorShell& shell)
+    void ProjectPanelController::Bind(const SceneViewPanelView& view)
     {
-        m_projectSummaryLabel = shell.GetProjectSummaryLabel();
-        m_projectSceneListBox = shell.GetProjectSceneListBox();
-        m_projectSceneDetailLabel = shell.GetProjectSceneDetailLabel();
+        m_projectSummaryLabel = view.GetProjectSummaryLabel();
+        m_projectSceneListBox = view.GetProjectSceneListBox();
+        m_projectSceneDetailLabel = view.GetProjectSceneDetailLabel();
     }
 
     void ProjectPanelController::Refresh(const EditorSceneDocument& document, bool sceneDirty)

--- a/Editor/Source/Project/ProjectPanelController.h
+++ b/Editor/Source/Project/ProjectPanelController.h
@@ -5,10 +5,11 @@
 #include <vector>
 
 #include "Project/EditorSceneDocument.h"
-#include "Shell/EditorShell.h"
 
 namespace Xelqoria::Editor
 {
+    class SceneViewPanelView;
+
     /// <summary>
     /// 現在のプロジェクト内容と Scene 一覧の表示を管理する。
     /// </summary>
@@ -16,10 +17,10 @@ namespace Xelqoria::Editor
     {
     public:
         /// <summary>
-        /// EditorShell の HWND 群へ接続する。
+        /// SceneView Panel View 内の Project HWND 群へ接続する。
         /// </summary>
-        /// <param name="shell">接続先の EditorShell。</param>
-        void Bind(const EditorShell& shell);
+        /// <param name="view">接続先の Panel View。</param>
+        void Bind(const SceneViewPanelView& view);
 
         /// <summary>
         /// プロジェクト情報と Scene 一覧を再表示する。

--- a/Editor/Source/SceneView/SceneViewController.cpp
+++ b/Editor/Source/SceneView/SceneViewController.cpp
@@ -6,8 +6,8 @@
 #include <cstdint>
 #include <iterator>
 #include <optional>
+#include "Panels/SceneViewPanelView.h"
 #include "SceneView/EditorCamera2D.h"
-#include "Shell/EditorShell.h"
 #include "SceneView/SceneViewInteractionTypes.h"
 #include <Assets/IMaterialAssetResolver.h>
 #include <Assets/SpriteAssetRegistry.h>
@@ -17,12 +17,12 @@
 
 namespace Xelqoria::Editor
 {
-    void SceneViewController::Bind(const EditorShell& shell)
+    void SceneViewController::Bind(const SceneViewPanelView& view)
     {
-        const SceneViewSurface sceneViewSurface = shell.GetSceneViewSurface();
+        const SceneViewSurface sceneViewSurface = view.GetSceneViewSurface();
         m_sceneViewHost = static_cast<HWND>(sceneViewSurface.nativeWindow);
-        m_sceneViewPlanLabel = shell.GetSceneViewPlanLabel();
-        m_sceneViewSizeLabel = shell.GetSceneViewSizeLabel();
+        m_sceneViewPlanLabel = view.GetSceneViewPlanLabel();
+        m_sceneViewSizeLabel = view.GetSceneViewSizeLabel();
         m_inputTracker.Bind(m_sceneViewHost);
     }
 

--- a/Editor/Source/SceneView/SceneViewController.h
+++ b/Editor/Source/SceneView/SceneViewController.h
@@ -5,7 +5,7 @@
 #include <cstdint>
 
 #include "SceneView/EditorCamera2D.h"
-#include "Shell/EditorShell.h"
+#include "SceneViewSurface.h"
 #include "InputSystem.h"
 #include "DragDrop/SceneDropPlacementService.h"
 #include "SceneView/SceneViewInputTracker.h"
@@ -21,6 +21,8 @@
 
 namespace Xelqoria::Editor
 {
+    class SceneViewPanelView;
+
     /// <summary>
     /// SceneView の Editor 入力状態とドロップ処理を管理する。
     /// </summary>
@@ -28,10 +30,10 @@ namespace Xelqoria::Editor
     {
     public:
         /// <summary>
-        /// EditorShell の HWND 群へ接続する。
+        /// SceneView Panel View の HWND 群へ接続する。
         /// </summary>
-        /// <param name="shell">接続先の EditorShell。</param>
-        void Bind(const EditorShell& shell);
+        /// <param name="view">接続先の Panel View。</param>
+        void Bind(const SceneViewPanelView& view);
 
         /// <summary>
         /// SceneView ビューポートサイズ変更を反映する。

--- a/Editor/Source/Shell/EditorShell.cpp
+++ b/Editor/Source/Shell/EditorShell.cpp
@@ -16,11 +16,21 @@
 #include <UxTheme.h>
 
 #include "EditorTheme.h"
+#include "Panels/AssetsPanelView.h"
+#include "Panels/Collider2DPanelView.h"
+#include "Panels/HierarchyPanelView.h"
+#include "Panels/InspectorPanelView.h"
+#include "Panels/LogOutputPanelView.h"
+#include "Panels/MaterialPanelView.h"
+#include "Panels/SceneViewPanelView.h"
+#include "Panels/SpritePanelView.h"
 
 #pragma comment(lib, "uxtheme.lib")
 
 namespace Xelqoria::Editor
 {
+    EditorShell::EditorShell() = default;
+
     namespace
     {
         constexpr UINT_PTR ParentWindowSubclassId = 1;
@@ -983,6 +993,14 @@ namespace Xelqoria::Editor
             && InitializeLogOutputPanel(parentWindow, hInstance);
         if (initialized)
         {
+            m_hierarchyPanelView = std::make_unique<HierarchyPanelView>(*this);
+            m_assetsPanelView = std::make_unique<AssetsPanelView>(*this);
+            m_inspectorPanelView = std::make_unique<InspectorPanelView>(*this);
+            m_materialPanelView = std::make_unique<MaterialPanelView>(*this);
+            m_spritePanelView = std::make_unique<SpritePanelView>(*this);
+            m_collider2DPanelView = std::make_unique<Collider2DPanelView>(*this);
+            m_sceneViewPanelView = std::make_unique<SceneViewPanelView>(*this);
+            m_logOutputPanelView = std::make_unique<LogOutputPanelView>(*this);
             SyncDockTabs();
         }
 
@@ -3460,152 +3478,39 @@ namespace Xelqoria::Editor
         return DrawHierarchyListBoxItem(*drawItem);
     }
 
-    void EditorShell::ShowPanelControls(EditorPanelId panelId, bool visible) const
+    IEditorPanelView& EditorShell::GetPanelView(EditorPanelId panelId) const
     {
-        const int showCommand = visible ? SW_SHOW : SW_HIDE;
         switch (panelId)
         {
         case EditorPanelId::Hierarchy:
-            for (HWND control : { m_hierarchyPanel, m_hierarchyListBox, m_hierarchyNameEdit, m_hierarchyCreateButton, m_hierarchyDuplicateButton, m_hierarchyDeleteButton })
-            {
-                ShowWindow(control, showCommand);
-            }
-            ShowWindow(m_hierarchySummaryLabel, SW_HIDE);
-            break;
+            return GetHierarchyPanelView();
         case EditorPanelId::Assets:
-            for (HWND control : { m_assetsPanel, m_assetsListView })
-            {
-                ShowWindow(control, showCommand);
-            }
-            ShowWindow(m_assetsSummaryLabel, SW_HIDE);
-            break;
+            return GetAssetsPanelView();
         case EditorPanelId::SceneView:
-            for (HWND control : { m_sceneViewPanel, m_sceneViewHost, m_buildAndPlayButton, m_pauseResumePlayButton, m_endPlayButton })
-            {
-                ShowWindow(control, showCommand);
-            }
-            ShowWindow(m_sceneViewPlanLabel, SW_HIDE);
-            ShowWindow(m_projectSummaryLabel, SW_HIDE);
-            ShowWindow(m_projectSceneListBox, SW_HIDE);
-            ShowWindow(m_projectSceneDetailLabel, SW_HIDE);
-            ShowWindow(m_sceneViewSizeLabel, SW_HIDE);
-            break;
+            return GetSceneViewPanelView();
         case EditorPanelId::Inspector:
-            for (HWND control : { m_inspectorPanel, m_inspectorSummaryLabel, m_transformSectionLabel, m_transformLabels[0], m_transformLabels[1], m_transformLabels[2], m_transformEditControls[0], m_transformEditControls[1], m_transformEditControls[2], m_transformEditControls[3], m_transformEditControls[4], m_transformEditControls[5], m_transformEditControls[6], m_transformEditControls[7], m_transformEditControls[8], m_spriteComponentSectionLabel, m_spriteRefLabel, m_spriteRefEdit, m_materialOpenButton, m_scriptAssetLabel, m_scriptAssetEdit, m_scriptCreateButton, m_scriptAssignButton, m_scriptClearButton, m_spriteComponentActionButton, m_materialSharedNoticeLabel, m_materialDetailsSectionLabel, m_materialDetailLabels[0], m_materialDetailLabels[1], m_materialDetailLabels[2], m_materialDetailLabels[3], m_materialDetailLabels[4], m_materialDetailEditControls[0], m_materialDetailEditControls[1], m_materialDetailEditControls[2], m_materialDetailEditControls[3], m_materialDetailEditControls[4], m_materialTextureBrowseButton, m_materialTintColorButton, m_materialOutlineEnabledCheckBox, m_materialOutlineColorButton, m_collider2DComponentSectionLabel, m_collider2DSummaryLabel, m_collider2DEnabledCheckBox, m_collider2DTriggerCheckBox, m_collider2DShapeTypeLabel, m_collider2DShapeTypeEdit, m_collider2DOffsetLabel, m_collider2DSizeLabel, m_collider2DRotationLabel, m_collider2DRotationEdit, m_collider2DEditControls[0], m_collider2DEditControls[1], m_collider2DEditControls[2], m_collider2DEditControls[3], m_collider2DEditButton, m_collider2DComponentActionButton, m_addComponentButton })
-            {
-                ShowWindow(control, showCommand);
-            }
-            if (false == visible)
-            {
-                ShowWindow(m_spriteRefDropHighlight, SW_HIDE);
-                ShowWindow(m_materialTextureDropHighlight, SW_HIDE);
-            }
-            break;
-        case EditorPanelId::Material:
-            for (HWND control : { m_materialPanel, m_materialSharedNoticeLabel, m_materialDetailsSectionLabel, m_materialDetailLabels[0], m_materialDetailLabels[1], m_materialDetailLabels[2], m_materialDetailLabels[3], m_materialDetailLabels[4], m_materialDetailEditControls[0], m_materialDetailEditControls[1], m_materialDetailEditControls[2], m_materialDetailEditControls[3], m_materialDetailEditControls[4] })
-            {
-                ShowWindow(control, showCommand);
-            }
-            ShowWindow(m_materialSummaryLabel, SW_HIDE);
-            if (false == visible)
-            {
-                ShowWindow(m_materialTextureDropHighlight, SW_HIDE);
-            }
-            break;
+            return GetInspectorPanelView();
         case EditorPanelId::Sprite:
-            for (HWND control : { m_spritePanel, m_spriteDetailsSectionLabel, m_spriteDetailLabels[0], m_spriteDetailLabels[1], m_spriteDetailLabels[2], m_spriteDetailLabels[3], m_spriteDetailEditControls[0], m_spriteDetailEditControls[1], m_spriteDetailEditControls[2], m_spriteDetailEditControls[3] })
-            {
-                ShowWindow(control, showCommand);
-            }
-            ShowWindow(m_spriteSummaryLabel, SW_HIDE);
-            break;
+            return GetSpritePanelView();
+        case EditorPanelId::Material:
+            return GetMaterialPanelView();
         case EditorPanelId::Collider2D:
-            for (HWND control : { m_collider2DPanel, m_collider2DSummaryLabel, m_collider2DComponentSectionLabel, m_collider2DEnabledCheckBox, m_collider2DTriggerCheckBox, m_collider2DShapeTypeLabel, m_collider2DShapeTypeEdit, m_collider2DOffsetLabel, m_collider2DSizeLabel, m_collider2DEditControls[0], m_collider2DEditControls[1], m_collider2DEditControls[2], m_collider2DEditControls[3] })
-            {
-                ShowWindow(control, showCommand);
-            }
-            break;
+            return GetCollider2DPanelView();
         case EditorPanelId::LogOutput:
-            for (HWND control : { m_logOutputPanel, m_logOutputTabControl, m_logClearButton, m_logFilterEdit, m_logListBox })
-            {
-                ShowWindow(control, showCommand);
-            }
-            ShowWindow(m_logCopyButton, SW_HIDE);
-            break;
+            return GetLogOutputPanelView();
         default:
-            break;
+            return GetSceneViewPanelView();
         }
+    }
+
+    void EditorShell::ShowPanelControls(EditorPanelId panelId, bool visible) const
+    {
+        GetPanelView(panelId).Show(visible);
     }
 
     void EditorShell::SetPanelParent(EditorPanelId panelId, HWND parentWindow) const
     {
-        if (nullptr == parentWindow)
-        {
-            return;
-        }
-
-        const auto setParent =
-            [parentWindow](HWND control)
-            {
-                if (nullptr != control && GetParent(control) != parentWindow)
-                {
-                    SetParent(control, parentWindow);
-                }
-            };
-
-        switch (panelId)
-        {
-        case EditorPanelId::Hierarchy:
-            for (HWND control : { m_hierarchyPanel, m_hierarchySummaryLabel, m_hierarchyListBox, m_hierarchyNameEdit, m_hierarchyCreateButton, m_hierarchyDuplicateButton, m_hierarchyDeleteButton })
-            {
-                setParent(control);
-            }
-            break;
-        case EditorPanelId::Assets:
-            for (HWND control : { m_assetsPanel, m_assetsSummaryLabel, m_assetsListView })
-            {
-                setParent(control);
-            }
-            break;
-        case EditorPanelId::SceneView:
-            for (HWND control : { m_sceneViewPanel, m_sceneViewPlanLabel, m_projectSummaryLabel, m_projectSceneListBox, m_projectSceneDetailLabel, m_sceneViewHost, m_sceneViewSizeLabel, m_buildAndPlayButton, m_pauseResumePlayButton, m_endPlayButton })
-            {
-                setParent(control);
-            }
-            break;
-        case EditorPanelId::Inspector:
-            for (HWND control : { m_inspectorPanel, m_inspectorSummaryLabel, m_transformSectionLabel, m_transformLabels[0], m_transformLabels[1], m_transformLabels[2], m_transformEditControls[0], m_transformEditControls[1], m_transformEditControls[2], m_transformEditControls[3], m_transformEditControls[4], m_transformEditControls[5], m_transformEditControls[6], m_transformEditControls[7], m_transformEditControls[8], m_spriteComponentSectionLabel, m_spriteRefLabel, m_spriteRefDropHighlight, m_spriteRefEdit, m_materialOpenButton, m_scriptAssetLabel, m_scriptAssetEdit, m_scriptCreateButton, m_scriptAssignButton, m_scriptClearButton, m_spriteComponentActionButton, m_materialSharedNoticeLabel, m_materialDetailsSectionLabel, m_materialDetailLabels[0], m_materialDetailLabels[1], m_materialDetailLabels[2], m_materialDetailLabels[3], m_materialDetailLabels[4], m_materialDetailEditControls[0], m_materialDetailEditControls[1], m_materialDetailEditControls[2], m_materialDetailEditControls[3], m_materialDetailEditControls[4], m_materialTextureDropHighlight, m_materialTextureBrowseButton, m_materialTintColorButton, m_materialOutlineEnabledCheckBox, m_materialOutlineColorButton, m_collider2DComponentSectionLabel, m_collider2DSummaryLabel, m_collider2DEnabledCheckBox, m_collider2DTriggerCheckBox, m_collider2DShapeTypeLabel, m_collider2DShapeTypeEdit, m_collider2DOffsetLabel, m_collider2DSizeLabel, m_collider2DRotationLabel, m_collider2DRotationEdit, m_collider2DEditControls[0], m_collider2DEditControls[1], m_collider2DEditControls[2], m_collider2DEditControls[3], m_collider2DEditButton, m_collider2DComponentActionButton, m_addComponentButton })
-            {
-                setParent(control);
-            }
-            break;
-        case EditorPanelId::Material:
-            for (HWND control : { m_materialPanel, m_materialSummaryLabel, m_materialSharedNoticeLabel, m_materialDetailsSectionLabel, m_materialDetailLabels[0], m_materialDetailLabels[1], m_materialDetailLabels[2], m_materialDetailLabels[3], m_materialDetailLabels[4], m_materialDetailEditControls[0], m_materialDetailEditControls[1], m_materialDetailEditControls[2], m_materialDetailEditControls[3], m_materialDetailEditControls[4], m_materialTextureDropHighlight })
-            {
-                setParent(control);
-            }
-            break;
-        case EditorPanelId::Sprite:
-            for (HWND control : { m_spritePanel, m_spriteSummaryLabel, m_spriteDetailsSectionLabel, m_spriteDetailLabels[0], m_spriteDetailLabels[1], m_spriteDetailLabels[2], m_spriteDetailLabels[3], m_spriteDetailEditControls[0], m_spriteDetailEditControls[1], m_spriteDetailEditControls[2], m_spriteDetailEditControls[3] })
-            {
-                setParent(control);
-            }
-            break;
-        case EditorPanelId::Collider2D:
-            for (HWND control : { m_collider2DPanel, m_collider2DSummaryLabel, m_collider2DComponentSectionLabel, m_collider2DEnabledCheckBox, m_collider2DTriggerCheckBox, m_collider2DShapeTypeLabel, m_collider2DShapeTypeEdit, m_collider2DOffsetLabel, m_collider2DSizeLabel, m_collider2DEditControls[0], m_collider2DEditControls[1], m_collider2DEditControls[2], m_collider2DEditControls[3] })
-            {
-                setParent(control);
-            }
-            break;
-        case EditorPanelId::LogOutput:
-            for (HWND control : { m_logOutputPanel, m_logOutputTabControl, m_logClearButton, m_logCopyButton, m_logFilterEdit, m_logListBox })
-            {
-                setParent(control);
-            }
-            break;
-        default:
-            break;
-        }
+        GetPanelView(panelId).SetParent(parentWindow);
     }
 
     RECT EditorShell::GetPanelCaptionRect(EditorPanelId panelId) const
@@ -6540,6 +6445,46 @@ namespace Xelqoria::Editor
     HWND EditorShell::GetLogListBox() const
     {
         return m_logListBox;
+    }
+
+    HierarchyPanelView& EditorShell::GetHierarchyPanelView() const
+    {
+        return *m_hierarchyPanelView;
+    }
+
+    AssetsPanelView& EditorShell::GetAssetsPanelView() const
+    {
+        return *m_assetsPanelView;
+    }
+
+    InspectorPanelView& EditorShell::GetInspectorPanelView() const
+    {
+        return *m_inspectorPanelView;
+    }
+
+    MaterialPanelView& EditorShell::GetMaterialPanelView() const
+    {
+        return *m_materialPanelView;
+    }
+
+    SpritePanelView& EditorShell::GetSpritePanelView() const
+    {
+        return *m_spritePanelView;
+    }
+
+    Collider2DPanelView& EditorShell::GetCollider2DPanelView() const
+    {
+        return *m_collider2DPanelView;
+    }
+
+    SceneViewPanelView& EditorShell::GetSceneViewPanelView() const
+    {
+        return *m_sceneViewPanelView;
+    }
+
+    LogOutputPanelView& EditorShell::GetLogOutputPanelView() const
+    {
+        return *m_logOutputPanelView;
     }
 
     HWND EditorShell::CreateChildWindow(

--- a/Editor/Source/Shell/EditorShell.cpp
+++ b/Editor/Source/Shell/EditorShell.cpp
@@ -1054,7 +1054,7 @@ namespace Xelqoria::Editor
         if (m_ownsDefaultFont && nullptr != m_defaultFont)
         {
             HFONT stockFont = static_cast<HFONT>(GetStockObject(DEFAULT_GUI_FONT));
-            const std::array<HWND, 121> controls = CollectControls();
+            const std::vector<HWND> controls = CollectControls();
             for (HWND control : controls)
             {
                 if (nullptr != control)
@@ -5577,7 +5577,7 @@ namespace Xelqoria::Editor
             m_ownsDefaultFont = false;
         }
 
-        const std::array<HWND, 121> controls = CollectControls();
+        const std::vector<HWND> controls = CollectControls();
 
         for (HWND control : controls)
         {
@@ -5600,9 +5600,9 @@ namespace Xelqoria::Editor
         return true;
     }
 
-    std::array<HWND, 121> EditorShell::CollectControls() const
+    std::vector<HWND> EditorShell::CollectControls() const
     {
-        return {
+        std::vector<HWND> controls{
             m_workspaceBackground,
             m_topBar,
             m_topBarProjectButton,
@@ -5622,109 +5622,28 @@ namespace Xelqoria::Editor
             m_dockGuideWindows[5],
             m_dockGuideWindows[6],
             m_dockGuideWindows[7],
-            m_dockGuideWindows[8],
-            m_hierarchyPanel,
-            m_assetsPanel,
-            m_inspectorPanel,
-            m_spritePanel,
-            m_materialPanel,
-            m_collider2DPanel,
-            m_sceneViewPanel,
-            m_sceneViewPlanLabel,
-            m_projectSummaryLabel,
-            m_projectSceneListBox,
-            m_projectSceneDetailLabel,
-            m_sceneViewHost,
-            m_sceneViewSizeLabel,
-            m_buildAndPlayButton,
-            m_pauseResumePlayButton,
-            m_endPlayButton,
-            m_logOutputPanel,
-            m_logOutputTabControl,
-            m_logClearButton,
-            m_logCopyButton,
-            m_logFilterEdit,
-            m_logListBox,
-            m_assetsListView,
-            m_assetsSummaryLabel,
-            m_hierarchySummaryLabel,
-            m_hierarchySearchEdit,
-            m_hierarchyListBox,
-            m_hierarchyNameEdit,
-            m_hierarchyCreateButton,
-            m_hierarchyDuplicateButton,
-            m_hierarchyDeleteButton,
-            m_inspectorSummaryLabel,
-            m_transformSectionLabel,
-            m_transformLabels[0],
-            m_transformLabels[1],
-            m_transformLabels[2],
-            m_transformEditControls[0],
-            m_transformEditControls[1],
-            m_transformEditControls[2],
-            m_transformEditControls[3],
-            m_transformEditControls[4],
-            m_transformEditControls[5],
-            m_transformEditControls[6],
-            m_transformEditControls[7],
-            m_transformEditControls[8],
-            m_spriteComponentSectionLabel,
-            m_spriteRefLabel,
-            m_spriteRefDropHighlight,
-            m_spriteRefEdit,
-            m_materialOpenButton,
-            m_materialSummaryLabel,
-            m_materialSharedNoticeLabel,
-            m_materialDetailsSectionLabel,
-            m_materialDetailLabels[0],
-            m_materialDetailLabels[1],
-            m_materialDetailLabels[2],
-            m_materialDetailLabels[3],
-            m_materialDetailLabels[4],
-            m_materialDetailEditControls[0],
-            m_materialDetailEditControls[1],
-            m_materialDetailEditControls[2],
-            m_materialDetailEditControls[3],
-            m_materialDetailEditControls[4],
-            m_materialTextureDropHighlight,
-            m_materialTextureBrowseButton,
-            m_materialTintColorButton,
-            m_materialOutlineEnabledCheckBox,
-            m_materialOutlineColorButton,
-            m_collider2DSummaryLabel,
-            m_spriteSummaryLabel,
-            m_spriteDetailsSectionLabel,
-            m_spriteDetailLabels[0],
-            m_spriteDetailLabels[1],
-            m_spriteDetailLabels[2],
-            m_spriteDetailLabels[3],
-            m_spriteDetailEditControls[0],
-            m_spriteDetailEditControls[1],
-            m_spriteDetailEditControls[2],
-            m_spriteDetailEditControls[3],
-            m_scriptAssetLabel,
-            m_scriptAssetEdit,
-            m_scriptCreateButton,
-            m_scriptAssignButton,
-            m_scriptClearButton,
-            m_spriteComponentActionButton,
-            m_collider2DComponentSectionLabel,
-            m_collider2DEnabledCheckBox,
-            m_collider2DTriggerCheckBox,
-            m_collider2DShapeTypeLabel,
-            m_collider2DShapeTypeEdit,
-            m_collider2DOffsetLabel,
-            m_collider2DSizeLabel,
-            m_collider2DRotationLabel,
-            m_collider2DRotationEdit,
-            m_collider2DEditControls[0],
-            m_collider2DEditControls[1],
-            m_collider2DEditControls[2],
-            m_collider2DEditControls[3],
-            m_collider2DEditButton,
-            m_collider2DComponentActionButton,
-            m_addComponentButton
+            m_dockGuideWindows[8]
         };
+
+        const std::array<const IEditorPanelView*, 8> panelViews{
+            m_hierarchyPanelView.get(),
+            m_assetsPanelView.get(),
+            m_inspectorPanelView.get(),
+            m_spritePanelView.get(),
+            m_materialPanelView.get(),
+            m_collider2DPanelView.get(),
+            m_sceneViewPanelView.get(),
+            m_logOutputPanelView.get()
+        };
+        for (const IEditorPanelView* panelView : panelViews)
+        {
+            if (nullptr != panelView)
+            {
+                panelView->CollectControls(controls);
+            }
+        }
+
+        return controls;
     }
 
     int EditorShell::ScaleMetric(int value) const

--- a/Editor/Source/Shell/EditorShell.h
+++ b/Editor/Source/Shell/EditorShell.h
@@ -4,6 +4,7 @@
 #include <array>
 #include <cstdint>
 #include <filesystem>
+#include <memory>
 #include <optional>
 #include <string>
 #include <vector>
@@ -15,12 +16,27 @@
 
 namespace Xelqoria::Editor
 {
+    class AssetsPanelView;
+    class Collider2DPanelView;
+    class HierarchyPanelView;
+    class InspectorPanelView;
+    class IEditorPanelView;
+    class LogOutputPanelView;
+    class MaterialPanelView;
+    class SceneViewPanelView;
+    class SpritePanelView;
+
     /// <summary>
     /// Editor 固定 UI の Win32 child window 群とレイアウトを管理する。
     /// </summary>
     class EditorShell
     {
     public:
+        /// <summary>
+        /// EditorShell を生成する。
+        /// </summary>
+        EditorShell();
+
         /// <summary>
         /// EditorShell 用 child window 群を生成する。
         /// </summary>
@@ -447,6 +463,54 @@ namespace Xelqoria::Editor
         /// </summary>
         /// <returns>LogOutput ListBox の HWND。</returns>
         [[nodiscard]] HWND GetLogListBox() const;
+
+        /// <summary>
+        /// Hierarchy Panel View を取得する。
+        /// </summary>
+        /// <returns>Hierarchy Panel View。</returns>
+        [[nodiscard]] HierarchyPanelView& GetHierarchyPanelView() const;
+
+        /// <summary>
+        /// Assets Panel View を取得する。
+        /// </summary>
+        /// <returns>Assets Panel View。</returns>
+        [[nodiscard]] AssetsPanelView& GetAssetsPanelView() const;
+
+        /// <summary>
+        /// Inspector Panel View を取得する。
+        /// </summary>
+        /// <returns>Inspector Panel View。</returns>
+        [[nodiscard]] InspectorPanelView& GetInspectorPanelView() const;
+
+        /// <summary>
+        /// Material Panel View を取得する。
+        /// </summary>
+        /// <returns>Material Panel View。</returns>
+        [[nodiscard]] MaterialPanelView& GetMaterialPanelView() const;
+
+        /// <summary>
+        /// Sprite Panel View を取得する。
+        /// </summary>
+        /// <returns>Sprite Panel View。</returns>
+        [[nodiscard]] SpritePanelView& GetSpritePanelView() const;
+
+        /// <summary>
+        /// Collider2D Panel View を取得する。
+        /// </summary>
+        /// <returns>Collider2D Panel View。</returns>
+        [[nodiscard]] Collider2DPanelView& GetCollider2DPanelView() const;
+
+        /// <summary>
+        /// SceneView Panel View を取得する。
+        /// </summary>
+        /// <returns>SceneView Panel View。</returns>
+        [[nodiscard]] SceneViewPanelView& GetSceneViewPanelView() const;
+
+        /// <summary>
+        /// LogOutput Panel View を取得する。
+        /// </summary>
+        /// <returns>LogOutput Panel View。</returns>
+        [[nodiscard]] LogOutputPanelView& GetLogOutputPanelView() const;
 
         /// <summary>
         /// Dock UI のフレーム入力を処理する。
@@ -1006,6 +1070,11 @@ namespace Xelqoria::Editor
         [[nodiscard]] static const wchar_t* GetPanelTitle(EditorPanelId panelId);
 
         /// <summary>
+        /// 指定 Panel の View 境界を返す。
+        /// </summary>
+        [[nodiscard]] IEditorPanelView& GetPanelView(EditorPanelId panelId) const;
+
+        /// <summary>
         /// DockArea の有効なアクティブタブ index を返す。
         /// </summary>
         [[nodiscard]] int ClampActiveTabIndex(DockAreaId dockAreaId) const;
@@ -1213,6 +1282,15 @@ namespace Xelqoria::Editor
             int height = 0;
         };
 
+        friend class AssetsPanelView;
+        friend class Collider2DPanelView;
+        friend class HierarchyPanelView;
+        friend class InspectorPanelView;
+        friend class LogOutputPanelView;
+        friend class MaterialPanelView;
+        friend class SceneViewPanelView;
+        friend class SpritePanelView;
+
         HFONT m_defaultFont = nullptr;
         HBRUSH m_windowBackgroundBrush = nullptr;
         HBRUSH m_panelBackgroundBrush = nullptr;
@@ -1265,6 +1343,14 @@ namespace Xelqoria::Editor
         HWND m_logCopyButton = nullptr;
         HWND m_logFilterEdit = nullptr;
         HWND m_logListBox = nullptr;
+        std::unique_ptr<HierarchyPanelView> m_hierarchyPanelView{};
+        std::unique_ptr<AssetsPanelView> m_assetsPanelView{};
+        std::unique_ptr<InspectorPanelView> m_inspectorPanelView{};
+        std::unique_ptr<MaterialPanelView> m_materialPanelView{};
+        std::unique_ptr<SpritePanelView> m_spritePanelView{};
+        std::unique_ptr<Collider2DPanelView> m_collider2DPanelView{};
+        std::unique_ptr<SceneViewPanelView> m_sceneViewPanelView{};
+        std::unique_ptr<LogOutputPanelView> m_logOutputPanelView{};
         HWND m_assetsListView = nullptr;
         HWND m_assetsSummaryLabel = nullptr;
         HWND m_hierarchySummaryLabel = nullptr;

--- a/Editor/Source/Shell/EditorShell.h
+++ b/Editor/Source/Shell/EditorShell.h
@@ -1132,7 +1132,7 @@ namespace Xelqoria::Editor
         /// EditorShell が管理する child window 群を列挙する。
         /// </summary>
         /// <returns>管理対象 child window の一覧。</returns>
-        [[nodiscard]] std::array<HWND, 121> CollectControls() const;
+        [[nodiscard]] std::vector<HWND> CollectControls() const;
 
         /// <summary>
         /// 指定値を現在 DPI に合わせて拡大縮小する。

--- a/Editor/Xelqoria.Editor.vcxproj
+++ b/Editor/Xelqoria.Editor.vcxproj
@@ -21,16 +21,23 @@
   <ItemGroup>
     <ClCompile Include="Source\App\Application.cpp" />
     <ClCompile Include="Source\Panels\AssetsPanelController.cpp" />
+    <ClCompile Include="Source\Panels\AssetsPanelView.cpp" />
+    <ClCompile Include="Source\Panels\Collider2DPanelView.cpp" />
     <ClCompile Include="Source\Commands\EditorCommandController.cpp" />
+    <ClCompile Include="Source\Panels\EditorPanelViewBase.cpp" />
     <ClCompile Include="Source\Assets\EditorAssetPathUtils.cpp" />
     <ClCompile Include="Source\Project\EditorProject.cpp" />
     <ClCompile Include="Source\Project\EditorSceneDocument.cpp" />
     <ClCompile Include="Source\Shell\EditorShell.cpp" />
     <ClCompile Include="Source\App\Entry.cpp" />
     <ClCompile Include="Source\Panels\HierarchyPanelController.cpp" />
+    <ClCompile Include="Source\Panels\HierarchyPanelView.cpp" />
     <ClCompile Include="Source\Panels\InspectorPanelController.cpp" />
+    <ClCompile Include="Source\Panels\InspectorPanelView.cpp" />
     <ClCompile Include="Source\Panels\LogOutputPanelController.cpp" />
+    <ClCompile Include="Source\Panels\LogOutputPanelView.cpp" />
     <ClCompile Include="Source\Panels\MaterialPanelController.cpp" />
+    <ClCompile Include="Source\Panels\MaterialPanelView.cpp" />
     <ClCompile Include="Source\Project\ProjectPanelController.cpp" />
     <ClCompile Include="Source\Project\RecentProjectsStore.cpp" />
     <ClCompile Include="Source\Rendering\RenderBackendBootstrap.cpp" />
@@ -38,17 +45,21 @@
     <ClCompile Include="Source\Commands\SceneCommandHistory.cpp" />
     <ClCompile Include="Source\Commands\SceneEditingOperations.cpp" />
     <ClCompile Include="Source\SceneView\SceneViewController.cpp" />
+    <ClCompile Include="Source\Panels\SceneViewPanelView.cpp" />
     <ClCompile Include="Source\SceneView\SceneViewInputTracker.cpp" />
     <ClCompile Include="Source\SceneView\SceneViewRenderer.cpp" />
     <ClCompile Include="Source\SceneView\SceneViewStatusPresenter.cpp" />
     <ClCompile Include="Source\Assets\ScriptAssetService.cpp" />
     <ClCompile Include="Source\Script\ScriptRuntimeSession.cpp" />
     <ClCompile Include="Source\Panels\SpritePanelController.cpp" />
+    <ClCompile Include="Source\Panels\SpritePanelView.cpp" />
     <ClCompile Include="Source\App\StartupScreenController.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="Source\App\Application.h" />
     <ClInclude Include="Source\Panels\AssetsPanelController.h" />
+    <ClInclude Include="Source\Panels\AssetsPanelView.h" />
+    <ClInclude Include="Source\Panels\Collider2DPanelView.h" />
     <ClInclude Include="Source\PlatformAdapters\ButtonClickWin32Adapter.h" />
     <ClInclude Include="Source\Commands\EditorCommandController.h" />
     <ClInclude Include="Source\Assets\EditorAssetPathUtils.h" />
@@ -60,10 +71,15 @@
     <ClInclude Include="Source\Utils\EditorStringUtils.h" />
     <ClInclude Include="Source\SceneView\EditorCamera2D.h" />
     <ClInclude Include="Source\Panels\HierarchyPanelController.h" />
+    <ClInclude Include="Source\Panels\HierarchyPanelView.h" />
     <ClInclude Include="Source\Panels\InspectorPanelController.h" />
+    <ClInclude Include="Source\Panels\InspectorPanelView.h" />
     <ClInclude Include="Source\Panels\IEditorPanelView.h" />
+    <ClInclude Include="Source\Panels\EditorPanelViewBase.h" />
     <ClInclude Include="Source\Panels\LogOutputPanelController.h" />
+    <ClInclude Include="Source\Panels\LogOutputPanelView.h" />
     <ClInclude Include="Source\Panels\MaterialPanelController.h" />
+    <ClInclude Include="Source\Panels\MaterialPanelView.h" />
     <ClInclude Include="Source\Project\ProjectPanelController.h" />
     <ClInclude Include="Source\Project\RecentProjectsStore.h" />
     <ClInclude Include="Source\Rendering\RenderBackendBootstrap.h" />
@@ -72,6 +88,7 @@
     <ClInclude Include="Source\Commands\SceneCommandHistory.h" />
     <ClInclude Include="Source\Commands\SceneEditingOperations.h" />
     <ClInclude Include="Source\SceneView\SceneViewController.h" />
+    <ClInclude Include="Source\Panels\SceneViewPanelView.h" />
     <ClInclude Include="Source\SceneView\SceneViewInputTracker.h" />
     <ClInclude Include="Source\SceneView\SceneViewInteractionTypes.h" />
     <ClInclude Include="Source\SceneView\SceneViewOverlay.h" />
@@ -80,6 +97,7 @@
     <ClInclude Include="Source\Assets\ScriptAssetService.h" />
     <ClInclude Include="Source\Script\ScriptRuntimeSession.h" />
     <ClInclude Include="Source\Panels\SpritePanelController.h" />
+    <ClInclude Include="Source\Panels\SpritePanelView.h" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Core\Xelqoria.Core.vcxproj">

--- a/Editor/Xelqoria.Editor.vcxproj.filters
+++ b/Editor/Xelqoria.Editor.vcxproj.filters
@@ -12,8 +12,17 @@
     <ClCompile Include="Source\Panels\AssetsPanelController.cpp">
       <Filter>Source\Panels</Filter>
     </ClCompile>
+    <ClCompile Include="Source\Panels\AssetsPanelView.cpp">
+      <Filter>Source\Panels</Filter>
+    </ClCompile>
+    <ClCompile Include="Source\Panels\Collider2DPanelView.cpp">
+      <Filter>Source\Panels</Filter>
+    </ClCompile>
     <ClCompile Include="Source\Commands\EditorCommandController.cpp">
       <Filter>Source\Commands</Filter>
+    </ClCompile>
+    <ClCompile Include="Source\Panels\EditorPanelViewBase.cpp">
+      <Filter>Source\Panels</Filter>
     </ClCompile>
     <ClCompile Include="Source\Assets\EditorAssetPathUtils.cpp">
       <Filter>Source\Assets</Filter>
@@ -33,13 +42,25 @@
     <ClCompile Include="Source\Panels\HierarchyPanelController.cpp">
       <Filter>Source\Panels</Filter>
     </ClCompile>
+    <ClCompile Include="Source\Panels\HierarchyPanelView.cpp">
+      <Filter>Source\Panels</Filter>
+    </ClCompile>
     <ClCompile Include="Source\Panels\InspectorPanelController.cpp">
+      <Filter>Source\Panels</Filter>
+    </ClCompile>
+    <ClCompile Include="Source\Panels\InspectorPanelView.cpp">
       <Filter>Source\Panels</Filter>
     </ClCompile>
     <ClCompile Include="Source\Panels\LogOutputPanelController.cpp">
       <Filter>Source\Panels</Filter>
     </ClCompile>
+    <ClCompile Include="Source\Panels\LogOutputPanelView.cpp">
+      <Filter>Source\Panels</Filter>
+    </ClCompile>
     <ClCompile Include="Source\Panels\MaterialPanelController.cpp">
+      <Filter>Source\Panels</Filter>
+    </ClCompile>
+    <ClCompile Include="Source\Panels\MaterialPanelView.cpp">
       <Filter>Source\Panels</Filter>
     </ClCompile>
     <ClCompile Include="Source\Project\ProjectPanelController.cpp">
@@ -66,6 +87,9 @@
     <ClCompile Include="Source\SceneView\SceneViewController.cpp">
       <Filter>Source\SceneView</Filter>
     </ClCompile>
+    <ClCompile Include="Source\Panels\SceneViewPanelView.cpp">
+      <Filter>Source\Panels</Filter>
+    </ClCompile>
     <ClCompile Include="Source\SceneView\SceneViewInputTracker.cpp">
       <Filter>Source\SceneView</Filter>
     </ClCompile>
@@ -84,12 +108,21 @@
     <ClCompile Include="Source\Panels\SpritePanelController.cpp">
       <Filter>Source\Panels</Filter>
     </ClCompile>
+    <ClCompile Include="Source\Panels\SpritePanelView.cpp">
+      <Filter>Source\Panels</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="Source\App\Application.h">
       <Filter>Source\App</Filter>
     </ClInclude>
     <ClInclude Include="Source\Panels\AssetsPanelController.h">
+      <Filter>Source\Panels</Filter>
+    </ClInclude>
+    <ClInclude Include="Source\Panels\AssetsPanelView.h">
+      <Filter>Source\Panels</Filter>
+    </ClInclude>
+    <ClInclude Include="Source\Panels\Collider2DPanelView.h">
       <Filter>Source\Panels</Filter>
     </ClInclude>
     <ClInclude Include="Source\PlatformAdapters\ButtonClickWin32Adapter.h">
@@ -125,16 +158,31 @@
     <ClInclude Include="Source\Panels\HierarchyPanelController.h">
       <Filter>Source\Panels</Filter>
     </ClInclude>
+    <ClInclude Include="Source\Panels\HierarchyPanelView.h">
+      <Filter>Source\Panels</Filter>
+    </ClInclude>
     <ClInclude Include="Source\Panels\InspectorPanelController.h">
+      <Filter>Source\Panels</Filter>
+    </ClInclude>
+    <ClInclude Include="Source\Panels\InspectorPanelView.h">
       <Filter>Source\Panels</Filter>
     </ClInclude>
     <ClInclude Include="Source\Panels\IEditorPanelView.h">
       <Filter>Source\Panels</Filter>
     </ClInclude>
+    <ClInclude Include="Source\Panels\EditorPanelViewBase.h">
+      <Filter>Source\Panels</Filter>
+    </ClInclude>
     <ClInclude Include="Source\Panels\LogOutputPanelController.h">
       <Filter>Source\Panels</Filter>
     </ClInclude>
+    <ClInclude Include="Source\Panels\LogOutputPanelView.h">
+      <Filter>Source\Panels</Filter>
+    </ClInclude>
     <ClInclude Include="Source\Panels\MaterialPanelController.h">
+      <Filter>Source\Panels</Filter>
+    </ClInclude>
+    <ClInclude Include="Source\Panels\MaterialPanelView.h">
       <Filter>Source\Panels</Filter>
     </ClInclude>
     <ClInclude Include="Source\Project\ProjectPanelController.h">
@@ -161,6 +209,9 @@
     <ClInclude Include="Source\SceneView\SceneViewController.h">
       <Filter>Source\SceneView</Filter>
     </ClInclude>
+    <ClInclude Include="Source\Panels\SceneViewPanelView.h">
+      <Filter>Source\Panels</Filter>
+    </ClInclude>
     <ClInclude Include="Source\SceneView\SceneViewInputTracker.h">
       <Filter>Source\SceneView</Filter>
     </ClInclude>
@@ -183,6 +234,9 @@
       <Filter>Source\Script</Filter>
     </ClInclude>
     <ClInclude Include="Source\Panels\SpritePanelController.h">
+      <Filter>Source\Panels</Filter>
+    </ClInclude>
+    <ClInclude Include="Source\Panels\SpritePanelView.h">
       <Filter>Source\Panels</Filter>
     </ClInclude>
   </ItemGroup>

--- a/docs/plans/issue-316-panel-views.md
+++ b/docs/plans/issue-316-panel-views.md
@@ -1,0 +1,51 @@
+# ExecPlan: issue-316 PanelView 実装と EditorShell からの Panel 固有 View 処理分離
+
+## 目的
+
+各 Panel の HWND 群を `XXXPanelView` 境界から扱えるようにし、`EditorShell` の Dock / Floating / Tab 処理から Panel 固有の表示・親変更処理を分離する。
+
+## 対象範囲
+
+- 変更対象プロジェクト: `Editor`
+- 変更対象ファイル: `Editor/Source/Panels/*PanelView.*`, `Editor/Source/Shell/EditorShell.*`, `Editor/Xelqoria.Editor.vcxproj`, `Editor/Xelqoria.Editor.vcxproj.filters`
+- 変更対象クラス: `EditorShell`, 各 `XXXPanelView`
+- 影響する機能: Dock 初期配置、Floating、Tab 切り替え、Panel 表示・非表示、Panel 親ウィンドウ変更
+
+## 前提
+
+- parent issue: issue-313
+- 先行 issue: issue-314, issue-315
+- ブランチ運用ルール: `docs/agents/branch-rules.md`
+- parent issue ブランチ: `issue-313`
+- この child issue のブランチ: `issue-316`
+- PR の向き: `issue-313`
+
+## 実装方針
+
+既存 UI の見た目と操作を維持するため、まず PanelView を既存 HWND 群へ接続する View 境界として実装する。Dock / Floating / Tab の状態は引き続き `EditorShell` が保持し、PanelView は表示・親変更・control 列挙だけを担当する。
+
+## 作業手順
+
+1. 各 `XXXPanelView.h` / `.cpp` を追加する
+2. `EditorShell` に各 PanelView メンバーを追加する
+3. 既存 Panel 初期化後に PanelView を生成する
+4. `ShowPanelControls` と `SetPanelParent` を PanelView 呼び出しへ変更する
+5. project/filter を更新する
+6. 依存チェックと静的確認を実行する
+7. `issue-313` 向け PR を作成する
+
+## 検証方法
+
+- 実行するビルド: `msbuild Xelqoria.sln /t:Xelqoria.Editor /p:Configuration=Debug /p:Platform=x64`
+- 実行するテスト: LayerDependencyChecker
+- 手動確認項目: PanelView が Dock / Floating / Tab 状態を持たないこと、`ShowPanelControls` / `SetPanelParent` が PanelView 経由になっていること
+
+## 完了条件
+
+- 対象 Panel すべてに `XXXPanelView.h` / `XXXPanelView.cpp` が追加されている
+- 各 `XXXPanelView` が `IEditorPanelView` を実装している
+- `EditorShell` が各 PanelView を保持している
+- `ShowPanelControls` と `SetPanelParent` 相当の処理が PanelView の `Show` / `SetParent` を呼ぶ形になっている
+- Dock / Floating / Tab の仕様を変更していない
+- レイヤー責務に違反していない
+- `issue-313` に向けた PR が作成されている

--- a/docs/plans/issue-317-controller-bind-and-controls.md
+++ b/docs/plans/issue-317-controller-bind-and-controls.md
@@ -1,0 +1,26 @@
+# Issue 317: Controller Bind And CollectControls
+
+## Goal
+
+Controller の Bind 先を `EditorShell` から対応する PanelView へ移し、`EditorShell::CollectControls()` を固定長配列から `std::vector<HWND>` へ変更する。
+
+## Context
+
+- Parent issue: #313
+- Depends on: #316
+- Branch: `issue-317`
+
+## Plan
+
+- [x] `issue-316` を取り込む。
+- [x] 各 PanelView に Controller が必要とする HWND getter を追加する。
+- [x] 対象 Controller の `Bind` 引数を PanelView に変更する。
+- [x] Project UI は既存配置に合わせて `SceneViewPanelView` から Bind する。
+- [x] `EditorShell::CollectControls()` を `std::vector<HWND>` 返却に変更し、PanelView の `CollectControls` で集約する。
+- [x] ビルドと検証を実行する。
+
+## Verification
+
+- [x] `git diff --check`
+- [x] `dotnet run --project Tools/LayerDependencyChecker/LayerDependencyChecker.csproj -- .`
+- [x] `MSBuild.exe Editor\Xelqoria.Editor.vcxproj /p:Configuration=Debug /p:Platform=x64`


### PR DESCRIPTION
## Summary
- Merge dependent `issue-316` work into `issue-317`.
- Change target panel controllers from `EditorShell` binding to explicit PanelView binding.
- Bind Project UI and SceneView controller through `SceneViewPanelView`, matching the current UI placement.
- Convert `EditorShell::CollectControls()` to `std::vector<HWND>` and aggregate controls through `IEditorPanelView::CollectControls`.
- Add ExecPlan for issue 317.

## Verification
- `git diff --check`
- `dotnet run --project Tools/LayerDependencyChecker/LayerDependencyChecker.csproj -- .`
- `MSBuild.exe Editor\Xelqoria.Editor.vcxproj /p:Configuration=Debug /p:Platform=x64`

Part of #313. Implements #317.