### PR TITLE
既存プロジェクトの Assets 配下移行処理を追加する

### DIFF
--- a/Editor/Source/App/Application.cpp
+++ b/Editor/Source/App/Application.cpp
@@ -55,7 +55,8 @@ namespace Xelqoria::Editor
                         ownerWindow,
                         {},
                         {
-                            Platform::FileDialogFilter{ L"Xelqoria Project (*.proj)", L"*.proj" },
+                            Platform::FileDialogFilter{ L"Xelqoria Project (*.xelqoria)", L"*.xelqoria" },
+                            Platform::FileDialogFilter{ L"Legacy Xelqoria Project (*.proj)", L"*.proj" },
                             Platform::FileDialogFilter{ L"All Files (*.*)", L"*.*" }
                         },
                         {}

--- a/Editor/Source/App/Application.cpp
+++ b/Editor/Source/App/Application.cpp
@@ -552,6 +552,11 @@ namespace Xelqoria::Editor
             return false;
         }
 
+        for (const std::wstring& message : m_sceneDocument.GetProjectMigrationMessages())
+        {
+            AppendEditorLog(message.c_str());
+        }
+
         RecordCurrentProject();
         m_assetsPanelController.Refresh(m_sceneDocument.GetProjectInfo());
         m_sceneDocument.RefreshProjectAssetRegistries();
@@ -581,6 +586,11 @@ namespace Xelqoria::Editor
             SetWindowTextW(m_editorShell.GetSceneViewPlanLabel(), L"プロジェクトを開けませんでした。");
             AppendEditorLog(L"プロジェクトを開けませんでした。");
             return false;
+        }
+
+        for (const std::wstring& message : m_sceneDocument.GetProjectMigrationMessages())
+        {
+            AppendEditorLog(message.c_str());
         }
 
         RecordCurrentProject();

--- a/Editor/Source/App/StartupScreenController.cpp
+++ b/Editor/Source/App/StartupScreenController.cpp
@@ -509,7 +509,8 @@ namespace Xelqoria::Editor
                         GetParent(m_openButton),
                         {},
                         {
-                            Platform::FileDialogFilter{ L"Xelqoria Project (*.proj)", L"*.proj" },
+                            Platform::FileDialogFilter{ L"Xelqoria Project (*.xelqoria)", L"*.xelqoria" },
+                            Platform::FileDialogFilter{ L"Legacy Xelqoria Project (*.proj)", L"*.proj" },
                             Platform::FileDialogFilter{ L"All Files (*.*)", L"*.*" }
                         },
                         {}

--- a/Editor/Source/Panels/Assets/AssetsPanelController.cpp
+++ b/Editor/Source/Panels/Assets/AssetsPanelController.cpp
@@ -1169,6 +1169,7 @@ namespace Xelqoria::Editor
         if (const std::optional<int> iconIndex = addIcon(L"file_proj.png"); iconIndex.has_value())
         {
             m_fileIconIndices.emplace(L".proj", *iconIndex);
+            m_fileIconIndices.emplace(L".xelqoria", *iconIndex);
         }
 
         if (const std::optional<int> iconIndex = addIcon(L"file_script.png"); iconIndex.has_value())

--- a/Editor/Source/Project/EditorProject.cpp
+++ b/Editor/Source/Project/EditorProject.cpp
@@ -1,8 +1,11 @@
 #include "Project/EditorProject.h"
 
 #include <algorithm>
+#include <array>
+#include <cstdint>
 #include <fstream>
 #include <optional>
+#include <sstream>
 #include <string_view>
 #include <system_error>
 
@@ -15,7 +18,19 @@ namespace Xelqoria::Editor
     namespace
     {
         constexpr const char* ProjectFileHeader = "XelqoriaProject=1";
-        constexpr const wchar_t* InitialSceneFileName = L"Main.xelqoria.scene";
+        constexpr std::uint32_t CurrentProjectStructureVersion = 1;
+        constexpr const wchar_t* ProjectFileExtension = L".xelqoria";
+        constexpr const wchar_t* AssetsDirectoryName = L"Assets";
+        constexpr const wchar_t* ScenesDirectoryName = L"Scenes";
+        constexpr const wchar_t* TexturesDirectoryName = L"Textures";
+        constexpr const wchar_t* MaterialsDirectoryName = L"Materials";
+        constexpr const wchar_t* ScriptsDirectoryName = L"Scripts";
+        constexpr const wchar_t* ProjectSettingsDirectoryName = L"ProjectSettings";
+        constexpr const wchar_t* ProjectSettingsFileName = L"project_settings.json";
+        constexpr const wchar_t* InternalDirectoryName = L".xelqoria";
+        constexpr const wchar_t* CacheDirectoryName = L"cache";
+        constexpr const wchar_t* InitialSceneFileName = L"Main.scene";
+        constexpr const char* ProjectVersion = "1";
 
         [[nodiscard]] std::optional<std::string> ReadValue(std::string_view line, std::string_view key)
         {
@@ -25,6 +40,50 @@ namespace Xelqoria::Editor
             }
 
             return std::string(line.substr(key.size() + 1));
+        }
+
+        [[nodiscard]] std::string ToProjectRelativeGenericString(
+            const std::filesystem::path& path,
+            const std::filesystem::path& rootDirectory,
+            std::error_code& errorCode)
+        {
+            const std::filesystem::path relativePath = std::filesystem::relative(path, rootDirectory, errorCode);
+            if (errorCode)
+            {
+                return {};
+            }
+
+            return relativePath.generic_string();
+        }
+
+        [[nodiscard]] std::string BuildDefaultProjectSettingsText(const std::wstring& projectName)
+        {
+            std::ostringstream text;
+            text << "{\n";
+            text << "  \"projectName\": \"" << ToNarrowString(projectName) << "\"\n";
+            text << "}\n";
+            return text.str();
+        }
+
+        [[nodiscard]] bool WriteTextFile(
+            const std::filesystem::path& filePath,
+            std::string_view text)
+        {
+            std::error_code errorCode;
+            std::filesystem::create_directories(filePath.parent_path(), errorCode);
+            if (errorCode)
+            {
+                return false;
+            }
+
+            std::ofstream output(filePath, std::ios::binary | std::ios::trunc);
+            if (false == output.is_open())
+            {
+                return false;
+            }
+
+            output << text;
+            return output.good();
         }
     }
 
@@ -41,13 +100,35 @@ namespace Xelqoria::Editor
         EditorProjectInfo info{};
         info.name = projectName;
         info.rootDirectory = parentDirectory / projectName;
-        info.projectFilePath = info.rootDirectory / (projectName + L".proj");
-        info.scenesDirectory = info.rootDirectory / L"Scenes";
+        info.projectFilePath = info.rootDirectory / (projectName + ProjectFileExtension);
+        info.assetRootDirectory = info.rootDirectory / AssetsDirectoryName;
+        info.scenesDirectory = info.assetRootDirectory / ScenesDirectoryName;
+        info.projectSettingsFilePath = info.rootDirectory / ProjectSettingsDirectoryName / ProjectSettingsFileName;
+        info.internalDirectory = info.rootDirectory / InternalDirectoryName;
+        info.cacheDirectory = info.internalDirectory / CacheDirectoryName;
         info.activeScenePath = info.scenesDirectory / InitialSceneFileName;
 
         std::error_code errorCode;
-        std::filesystem::create_directories(info.scenesDirectory, errorCode);
-        if (errorCode)
+        const std::array<std::filesystem::path, 6> requiredDirectories =
+        {
+            info.scenesDirectory,
+            info.assetRootDirectory / TexturesDirectoryName,
+            info.assetRootDirectory / MaterialsDirectoryName,
+            info.assetRootDirectory / ScriptsDirectoryName,
+            info.projectSettingsFilePath.parent_path(),
+            info.cacheDirectory
+        };
+
+        for (const std::filesystem::path& directory : requiredDirectories)
+        {
+            std::filesystem::create_directories(directory, errorCode);
+            if (errorCode)
+            {
+                return false;
+            }
+        }
+
+        if (false == WriteTextFile(info.projectSettingsFilePath, BuildDefaultProjectSettingsText(projectName)))
         {
             return false;
         }
@@ -83,20 +164,42 @@ namespace Xelqoria::Editor
 
         std::optional<std::string> projectName{};
         std::optional<std::string> activeScene{};
+        std::optional<std::string> assetRoot{};
+        std::optional<std::string> projectSettings{};
+        std::optional<std::string> startupScene{};
         std::string line{};
         while (std::getline(input, line))
         {
-            if (const auto value = ReadValue(line, "Name"))
+            if (const auto value = ReadValue(line, "projectName"))
             {
                 projectName = value;
+            }
+            else if (const auto value = ReadValue(line, "Name"))
+            {
+                projectName = value;
+            }
+            else if (const auto value = ReadValue(line, "startupScene"))
+            {
+                startupScene = value;
             }
             else if (const auto value = ReadValue(line, "ActiveScene"))
             {
                 activeScene = value;
             }
+            else if (const auto value = ReadValue(line, "assetRoot"))
+            {
+                assetRoot = value;
+            }
+            else if (const auto value = ReadValue(line, "projectSettings"))
+            {
+                projectSettings = value;
+            }
         }
 
-        if (false == projectName.has_value() || false == activeScene.has_value())
+        const std::optional<std::string>& scenePathText = startupScene.has_value()
+            ? startupScene
+            : activeScene;
+        if (false == projectName.has_value() || false == scenePathText.has_value())
         {
             return false;
         }
@@ -106,9 +209,23 @@ namespace Xelqoria::Editor
             return false;
         }
 
-        const std::filesystem::path activeSceneRelativePath(*activeScene);
+        const std::filesystem::path activeSceneRelativePath(*scenePathText);
         if (false == EditorPathSecurity::IsSafeRelativePath(activeSceneRelativePath)
             || activeSceneRelativePath.extension() != ".scene")
+        {
+            return false;
+        }
+
+        const bool isModernProjectFile = projectFilePath.extension() == ProjectFileExtension;
+        const std::filesystem::path assetRootRelativePath = assetRoot.has_value()
+            ? std::filesystem::path(*assetRoot)
+            : std::filesystem::path(AssetsDirectoryName);
+        const std::filesystem::path projectSettingsRelativePath = projectSettings.has_value()
+            ? std::filesystem::path(*projectSettings)
+            : std::filesystem::path(ProjectSettingsDirectoryName) / ProjectSettingsFileName;
+        if ((isModernProjectFile && false == assetRoot.has_value())
+            || false == EditorPathSecurity::IsSafeRelativePath(assetRootRelativePath)
+            || false == EditorPathSecurity::IsSafeRelativePath(projectSettingsRelativePath))
         {
             return false;
         }
@@ -117,7 +234,11 @@ namespace Xelqoria::Editor
         info.name = ToWideString(*projectName);
         info.projectFilePath = projectFilePath;
         info.rootDirectory = projectFilePath.parent_path();
-        info.scenesDirectory = info.rootDirectory / L"Scenes";
+        info.assetRootDirectory = info.rootDirectory / assetRootRelativePath;
+        info.scenesDirectory = info.assetRootDirectory / ScenesDirectoryName;
+        info.projectSettingsFilePath = info.rootDirectory / projectSettingsRelativePath;
+        info.internalDirectory = info.rootDirectory / InternalDirectoryName;
+        info.cacheDirectory = info.internalDirectory / CacheDirectoryName;
         info.activeScenePath = info.rootDirectory / activeSceneRelativePath;
 
         if (false == std::filesystem::exists(info.activeScenePath))
@@ -125,9 +246,18 @@ namespace Xelqoria::Editor
             return false;
         }
 
-        if (false == EditorPathSecurity::IsPathInsideOrEqual(info.activeScenePath, info.scenesDirectory))
+        const std::filesystem::path expectedSceneRoot = isModernProjectFile
+            ? info.scenesDirectory
+            : info.rootDirectory / ScenesDirectoryName;
+        if (false == EditorPathSecurity::IsPathInsideOrEqual(info.activeScenePath, expectedSceneRoot))
         {
             return false;
+        }
+
+        if (false == isModernProjectFile)
+        {
+            info.assetRootDirectory = info.rootDirectory;
+            info.scenesDirectory = expectedSceneRoot;
         }
 
         m_info = info;
@@ -214,7 +344,9 @@ namespace Xelqoria::Editor
     bool EditorProject::WriteProjectFile(const EditorProjectInfo& info) const
     {
         if (false == EditorPathSecurity::IsValidProjectName(info.name)
-            || false == EditorPathSecurity::IsPathInsideOrEqual(info.activeScenePath, info.scenesDirectory))
+            || false == EditorPathSecurity::IsPathInsideOrEqual(info.activeScenePath, info.scenesDirectory)
+            || false == EditorPathSecurity::IsPathInsideOrEqual(info.scenesDirectory, info.assetRootDirectory)
+            || false == EditorPathSecurity::IsPathInsideOrEqual(info.projectSettingsFilePath, info.rootDirectory))
         {
             return false;
         }
@@ -232,15 +364,31 @@ namespace Xelqoria::Editor
             return false;
         }
 
-        const std::filesystem::path relativeScenePath = std::filesystem::relative(info.activeScenePath, info.rootDirectory, errorCode);
+        const std::string relativeScenePath = ToProjectRelativeGenericString(info.activeScenePath, info.rootDirectory, errorCode);
+        if (errorCode)
+        {
+            return false;
+        }
+
+        const std::string relativeAssetRoot = ToProjectRelativeGenericString(info.assetRootDirectory, info.rootDirectory, errorCode);
+        if (errorCode)
+        {
+            return false;
+        }
+
+        const std::string relativeProjectSettings = ToProjectRelativeGenericString(info.projectSettingsFilePath, info.rootDirectory, errorCode);
         if (errorCode)
         {
             return false;
         }
 
         output << ProjectFileHeader << '\n';
-        output << "Name=" << ToNarrowString(info.name) << '\n';
-        output << "ActiveScene=" << relativeScenePath.generic_string() << '\n';
+        output << "projectName=" << ToNarrowString(info.name) << '\n';
+        output << "version=" << ProjectVersion << '\n';
+        output << "projectStructureVersion=" << CurrentProjectStructureVersion << '\n';
+        output << "assetRoot=" << relativeAssetRoot << '\n';
+        output << "projectSettings=" << relativeProjectSettings << '\n';
+        output << "startupScene=" << relativeScenePath << '\n';
         return output.good();
     }
 

--- a/Editor/Source/Project/EditorProject.cpp
+++ b/Editor/Source/Project/EditorProject.cpp
@@ -3,6 +3,7 @@
 #include <algorithm>
 #include <array>
 #include <cstdint>
+#include <cwctype>
 #include <fstream>
 #include <optional>
 #include <sstream>
@@ -32,6 +33,15 @@ namespace Xelqoria::Editor
         constexpr const wchar_t* InitialSceneFileName = L"Main.scene";
         constexpr const char* ProjectVersion = "1";
 
+        struct ProjectMigrationResult
+        {
+            bool attempted = false;
+            bool succeeded = true;
+            std::filesystem::path startupScenePath{};
+            std::filesystem::path projectSettingsFilePath{};
+            std::vector<std::wstring> messages{};
+        };
+
         [[nodiscard]] std::optional<std::string> ReadValue(std::string_view line, std::string_view key)
         {
             if (line.size() <= key.size() + 1 || line.substr(0, key.size()) != key || line[key.size()] != '=')
@@ -40,6 +50,203 @@ namespace Xelqoria::Editor
             }
 
             return std::string(line.substr(key.size() + 1));
+        }
+
+        [[nodiscard]] std::optional<std::uint32_t> ParseUnsignedValue(const std::optional<std::string>& value)
+        {
+            if (false == value.has_value())
+            {
+                return std::nullopt;
+            }
+
+            try
+            {
+                return static_cast<std::uint32_t>(std::stoul(*value));
+            }
+            catch (...)
+            {
+                return std::nullopt;
+            }
+        }
+
+        [[nodiscard]] std::wstring ToLowerPathPart(std::wstring text)
+        {
+            for (wchar_t& character : text)
+            {
+                character = static_cast<wchar_t>(std::towlower(character));
+            }
+
+            return text;
+        }
+
+        [[nodiscard]] bool IsExcludedRootDirectory(const std::filesystem::path& directory)
+        {
+            const std::wstring name = ToLowerPathPart(directory.filename().wstring());
+            return name == L"assets"
+                || name == L"projectsettings"
+                || name == L".xelqoria"
+                || name == L".git"
+                || name == L".vs"
+                || name == L"build"
+                || name == L"bin"
+                || name == L"obj"
+                || name == L"out";
+        }
+
+        [[nodiscard]] bool IsMaterialJsonFile(const std::filesystem::path& path)
+        {
+            const std::wstring fileName = ToLowerPathPart(path.filename().wstring());
+            return ToLowerPathPart(path.extension().wstring()) == L".json"
+                && ((fileName.size() > std::wstring(L"_material.json").size()
+                        && fileName.ends_with(L"_material.json"))
+                    || fileName.starts_with(L"material_"));
+        }
+
+        [[nodiscard]] std::optional<std::filesystem::path> ResolveRootFileMigrationDirectory(
+            const std::filesystem::path& rootDirectory,
+            const std::filesystem::path& filePath)
+        {
+            const std::wstring fileName = ToLowerPathPart(filePath.filename().wstring());
+            const std::wstring extension = ToLowerPathPart(filePath.extension().wstring());
+            if (extension == L".scene")
+            {
+                return rootDirectory / AssetsDirectoryName / ScenesDirectoryName;
+            }
+
+            if (extension == L".png"
+                || extension == L".jpg"
+                || extension == L".jpeg"
+                || extension == L".bmp"
+                || extension == L".tga")
+            {
+                return rootDirectory / AssetsDirectoryName / TexturesDirectoryName;
+            }
+
+            if (extension == L".material" || extension == L".mat" || IsMaterialJsonFile(filePath))
+            {
+                return rootDirectory / AssetsDirectoryName / MaterialsDirectoryName;
+            }
+
+            if (extension == L".cpp" || extension == L".h" || extension == L".hpp" || extension == L".cs")
+            {
+                return rootDirectory / AssetsDirectoryName / ScriptsDirectoryName;
+            }
+
+            if (fileName == L"project_settings.json")
+            {
+                return rootDirectory / ProjectSettingsDirectoryName;
+            }
+
+            return std::nullopt;
+        }
+
+        [[nodiscard]] std::optional<std::filesystem::path> ResolveRootDirectoryMigrationDirectory(
+            const std::filesystem::path& rootDirectory,
+            const std::filesystem::path& directoryPath)
+        {
+            const std::wstring name = ToLowerPathPart(directoryPath.filename().wstring());
+            if (name == L"scenes")
+            {
+                return rootDirectory / AssetsDirectoryName / ScenesDirectoryName;
+            }
+
+            if (name == L"textures")
+            {
+                return rootDirectory / AssetsDirectoryName / TexturesDirectoryName;
+            }
+
+            if (name == L"materials")
+            {
+                return rootDirectory / AssetsDirectoryName / MaterialsDirectoryName;
+            }
+
+            if (name == L"scripts")
+            {
+                return rootDirectory / AssetsDirectoryName / ScriptsDirectoryName;
+            }
+
+            return std::nullopt;
+        }
+
+        [[nodiscard]] std::filesystem::path BuildUniquePath(const std::filesystem::path& targetPath)
+        {
+            if (false == std::filesystem::exists(targetPath))
+            {
+                return targetPath;
+            }
+
+            const std::filesystem::path parentPath = targetPath.parent_path();
+            const std::wstring stem = targetPath.stem().wstring();
+            const std::wstring extension = targetPath.extension().wstring();
+            for (int index = 1; ; ++index)
+            {
+                const std::filesystem::path candidate =
+                    parentPath / (stem + L"_" + std::to_wstring(index) + extension);
+                if (false == std::filesystem::exists(candidate))
+                {
+                    return candidate;
+                }
+            }
+        }
+
+        [[nodiscard]] bool IsSamePath(
+            const std::filesystem::path& lhs,
+            const std::filesystem::path& rhs)
+        {
+            if (lhs.empty() || rhs.empty())
+            {
+                return false;
+            }
+
+            return EditorPathSecurity::NormalizeForContainment(lhs)
+                == EditorPathSecurity::NormalizeForContainment(rhs);
+        }
+
+        [[nodiscard]] std::optional<std::filesystem::path> TryMovePath(
+            const std::filesystem::path& sourcePath,
+            const std::filesystem::path& targetDirectory,
+            ProjectMigrationResult& result,
+            const std::filesystem::path& oldStartupScenePath,
+            std::filesystem::path& newStartupScenePath)
+        {
+            std::error_code errorCode;
+            std::filesystem::create_directories(targetDirectory, errorCode);
+            if (errorCode)
+            {
+                result.succeeded = false;
+                result.messages.push_back(L"Project migration error: failed to create " + targetDirectory.wstring());
+                return std::nullopt;
+            }
+
+            const std::filesystem::path targetPath = BuildUniquePath(targetDirectory / sourcePath.filename());
+            std::filesystem::rename(sourcePath, targetPath, errorCode);
+            if (errorCode)
+            {
+                result.succeeded = false;
+                result.messages.push_back(L"Project migration error: failed to move " + sourcePath.wstring());
+                return std::nullopt;
+            }
+
+            if (IsSamePath(sourcePath, oldStartupScenePath))
+            {
+                newStartupScenePath = targetPath;
+            }
+            else if (std::filesystem::is_directory(targetPath, errorCode)
+                && false == static_cast<bool>(errorCode)
+                && EditorPathSecurity::IsPathInsideOrEqual(oldStartupScenePath, sourcePath))
+            {
+                errorCode.clear();
+                const std::filesystem::path relativeStartupScene =
+                    std::filesystem::relative(oldStartupScenePath, sourcePath, errorCode);
+                if (false == static_cast<bool>(errorCode))
+                {
+                    newStartupScenePath = targetPath / relativeStartupScene;
+                }
+            }
+
+            result.messages.push_back(L"Project migration: moved " + sourcePath.filename().wstring()
+                + L" -> " + targetPath.wstring());
+            return targetPath;
         }
 
         [[nodiscard]] std::string ToProjectRelativeGenericString(
@@ -84,6 +291,199 @@ namespace Xelqoria::Editor
 
             output << text;
             return output.good();
+        }
+
+        [[nodiscard]] bool WriteProjectMetadataFile(const EditorProjectInfo& info)
+        {
+            if (false == EditorPathSecurity::IsValidProjectName(info.name)
+                || false == EditorPathSecurity::IsPathInsideOrEqual(info.activeScenePath, info.scenesDirectory)
+                || false == EditorPathSecurity::IsPathInsideOrEqual(info.scenesDirectory, info.assetRootDirectory)
+                || false == EditorPathSecurity::IsPathInsideOrEqual(info.projectSettingsFilePath, info.rootDirectory))
+            {
+                return false;
+            }
+
+            std::error_code errorCode;
+            std::filesystem::create_directories(info.rootDirectory, errorCode);
+            if (errorCode)
+            {
+                return false;
+            }
+
+            std::ofstream output(info.projectFilePath, std::ios::binary | std::ios::trunc);
+            if (false == output.is_open())
+            {
+                return false;
+            }
+
+            const std::string relativeScenePath = ToProjectRelativeGenericString(info.activeScenePath, info.rootDirectory, errorCode);
+            if (errorCode)
+            {
+                return false;
+            }
+
+            const std::string relativeAssetRoot = ToProjectRelativeGenericString(info.assetRootDirectory, info.rootDirectory, errorCode);
+            if (errorCode)
+            {
+                return false;
+            }
+
+            const std::string relativeProjectSettings = ToProjectRelativeGenericString(info.projectSettingsFilePath, info.rootDirectory, errorCode);
+            if (errorCode)
+            {
+                return false;
+            }
+
+            output << ProjectFileHeader << '\n';
+            output << "projectName=" << ToNarrowString(info.name) << '\n';
+            output << "version=" << ProjectVersion << '\n';
+            output << "projectStructureVersion=" << CurrentProjectStructureVersion << '\n';
+            output << "assetRoot=" << relativeAssetRoot << '\n';
+            output << "projectSettings=" << relativeProjectSettings << '\n';
+            output << "startupScene=" << relativeScenePath << '\n';
+            return output.good();
+        }
+
+        [[nodiscard]] ProjectMigrationResult MigrateProjectStructure(
+            EditorProjectInfo& info,
+            const std::filesystem::path& sourceProjectFilePath,
+            const std::filesystem::path& oldStartupSceneRelativePath)
+        {
+            ProjectMigrationResult result{};
+            result.attempted = true;
+            result.startupScenePath = info.rootDirectory / oldStartupSceneRelativePath;
+            result.projectSettingsFilePath = info.projectSettingsFilePath;
+            result.messages.push_back(L"Project migration: started");
+
+            std::error_code errorCode;
+            const std::array<std::filesystem::path, 6> requiredDirectories =
+            {
+                info.scenesDirectory,
+                info.assetRootDirectory / TexturesDirectoryName,
+                info.assetRootDirectory / MaterialsDirectoryName,
+                info.assetRootDirectory / ScriptsDirectoryName,
+                info.projectSettingsFilePath.parent_path(),
+                info.cacheDirectory
+            };
+
+            for (const std::filesystem::path& directory : requiredDirectories)
+            {
+                std::filesystem::create_directories(directory, errorCode);
+                if (errorCode)
+                {
+                    result.succeeded = false;
+                    result.messages.push_back(L"Project migration error: failed to create " + directory.wstring());
+                    return result;
+                }
+            }
+
+            const std::filesystem::path oldStartupScenePath = info.rootDirectory / oldStartupSceneRelativePath;
+            std::filesystem::path newStartupScenePath = oldStartupScenePath;
+            const std::filesystem::path newProjectFilePath = info.projectFilePath;
+
+            for (const std::filesystem::directory_entry& entry : std::filesystem::directory_iterator(info.rootDirectory, errorCode))
+            {
+                if (errorCode)
+                {
+                    result.succeeded = false;
+                    result.messages.push_back(L"Project migration error: failed to enumerate project root");
+                    return result;
+                }
+
+                const std::filesystem::path entryPath = entry.path();
+                if (IsSamePath(entryPath, sourceProjectFilePath) || IsSamePath(entryPath, newProjectFilePath))
+                {
+                    continue;
+                }
+
+                errorCode.clear();
+                if (entry.is_directory(errorCode) && false == static_cast<bool>(errorCode))
+                {
+                    if (IsExcludedRootDirectory(entryPath))
+                    {
+                        continue;
+                    }
+
+                    const std::optional<std::filesystem::path> targetDirectory =
+                        ResolveRootDirectoryMigrationDirectory(info.rootDirectory, entryPath);
+                    if (targetDirectory.has_value())
+                    {
+                        std::filesystem::create_directories(*targetDirectory, errorCode);
+                        if (errorCode)
+                        {
+                            result.succeeded = false;
+                            result.messages.push_back(L"Project migration error: failed to create " + targetDirectory->wstring());
+                            return result;
+                        }
+
+                        for (const std::filesystem::directory_entry& childEntry : std::filesystem::directory_iterator(entryPath, errorCode))
+                        {
+                            if (errorCode)
+                            {
+                                result.succeeded = false;
+                                result.messages.push_back(L"Project migration error: failed to enumerate " + entryPath.wstring());
+                                return result;
+                            }
+
+                            (void)TryMovePath(childEntry.path(), *targetDirectory, result, oldStartupScenePath, newStartupScenePath);
+                        }
+
+                        errorCode.clear();
+                        std::filesystem::remove(entryPath, errorCode);
+                    }
+
+                    continue;
+                }
+
+                errorCode.clear();
+                if (entry.is_regular_file(errorCode) && false == static_cast<bool>(errorCode))
+                {
+                    const std::optional<std::filesystem::path> targetDirectory =
+                        ResolveRootFileMigrationDirectory(info.rootDirectory, entryPath);
+                    if (targetDirectory.has_value())
+                    {
+                        const std::filesystem::path beforeMovePath = entryPath;
+                        const std::optional<std::filesystem::path> movedPath =
+                            TryMovePath(entryPath, *targetDirectory, result, oldStartupScenePath, newStartupScenePath);
+                        if (ToLowerPathPart(beforeMovePath.filename().wstring()) == L"project_settings.json")
+                        {
+                            if (movedPath.has_value())
+                            {
+                                result.projectSettingsFilePath = *movedPath;
+                            }
+                        }
+                    }
+                }
+            }
+
+            if (false == std::filesystem::exists(result.projectSettingsFilePath))
+            {
+                result.projectSettingsFilePath = info.projectSettingsFilePath;
+                if (false == WriteTextFile(result.projectSettingsFilePath, BuildDefaultProjectSettingsText(info.name)))
+                {
+                    result.succeeded = false;
+                    result.messages.push_back(L"Project migration error: failed to create project settings");
+                    return result;
+                }
+            }
+
+            if (false == std::filesystem::exists(newStartupScenePath))
+            {
+                newStartupScenePath = info.scenesDirectory / InitialSceneFileName;
+            }
+
+            info.activeScenePath = newStartupScenePath;
+            info.projectSettingsFilePath = result.projectSettingsFilePath;
+            if (false == WriteProjectMetadataFile(info))
+            {
+                result.succeeded = false;
+                result.messages.push_back(L"Project migration error: failed to write project file");
+                return result;
+            }
+
+            result.startupScenePath = newStartupScenePath;
+            result.messages.push_back(L"Project migration: completed");
+            return result;
         }
     }
 
@@ -149,6 +549,8 @@ namespace Xelqoria::Editor
 
     bool EditorProject::Open(const std::filesystem::path& projectFilePath)
     {
+        m_lastMigrationMessages.clear();
+
         std::ifstream input(projectFilePath, std::ios::binary);
         if (false == input.is_open())
         {
@@ -166,6 +568,7 @@ namespace Xelqoria::Editor
         std::optional<std::string> activeScene{};
         std::optional<std::string> assetRoot{};
         std::optional<std::string> projectSettings{};
+        std::optional<std::string> projectStructureVersion{};
         std::optional<std::string> startupScene{};
         std::string line{};
         while (std::getline(input, line))
@@ -194,6 +597,10 @@ namespace Xelqoria::Editor
             {
                 projectSettings = value;
             }
+            else if (const auto value = ReadValue(line, "projectStructureVersion"))
+            {
+                projectStructureVersion = value;
+            }
         }
 
         const std::optional<std::string>& scenePathText = startupScene.has_value()
@@ -216,14 +623,19 @@ namespace Xelqoria::Editor
             return false;
         }
 
-        const bool isModernProjectFile = projectFilePath.extension() == ProjectFileExtension;
-        const std::filesystem::path assetRootRelativePath = assetRoot.has_value()
+        bool isModernProjectFile = projectFilePath.extension() == ProjectFileExtension;
+        const std::optional<std::uint32_t> parsedProjectStructureVersion =
+            ParseUnsignedValue(projectStructureVersion);
+        const bool needsMigration = false == parsedProjectStructureVersion.has_value()
+            || *parsedProjectStructureVersion < CurrentProjectStructureVersion;
+        std::filesystem::path effectiveProjectFilePath = projectFilePath;
+        std::filesystem::path assetRootRelativePath = assetRoot.has_value()
             ? std::filesystem::path(*assetRoot)
             : std::filesystem::path(AssetsDirectoryName);
-        const std::filesystem::path projectSettingsRelativePath = projectSettings.has_value()
+        std::filesystem::path projectSettingsRelativePath = projectSettings.has_value()
             ? std::filesystem::path(*projectSettings)
             : std::filesystem::path(ProjectSettingsDirectoryName) / ProjectSettingsFileName;
-        if ((isModernProjectFile && false == assetRoot.has_value())
+        if ((isModernProjectFile && false == needsMigration && false == assetRoot.has_value())
             || false == EditorPathSecurity::IsSafeRelativePath(assetRootRelativePath)
             || false == EditorPathSecurity::IsSafeRelativePath(projectSettingsRelativePath))
         {
@@ -232,7 +644,7 @@ namespace Xelqoria::Editor
 
         EditorProjectInfo info{};
         info.name = ToWideString(*projectName);
-        info.projectFilePath = projectFilePath;
+        info.projectFilePath = effectiveProjectFilePath;
         info.rootDirectory = projectFilePath.parent_path();
         info.assetRootDirectory = info.rootDirectory / assetRootRelativePath;
         info.scenesDirectory = info.assetRootDirectory / ScenesDirectoryName;
@@ -240,6 +652,29 @@ namespace Xelqoria::Editor
         info.internalDirectory = info.rootDirectory / InternalDirectoryName;
         info.cacheDirectory = info.internalDirectory / CacheDirectoryName;
         info.activeScenePath = info.rootDirectory / activeSceneRelativePath;
+
+        if (needsMigration)
+        {
+            info.projectFilePath = info.rootDirectory / (info.name + ProjectFileExtension);
+            info.assetRootDirectory = info.rootDirectory / AssetsDirectoryName;
+            info.scenesDirectory = info.assetRootDirectory / ScenesDirectoryName;
+            info.projectSettingsFilePath = info.rootDirectory / ProjectSettingsDirectoryName / ProjectSettingsFileName;
+            info.internalDirectory = info.rootDirectory / InternalDirectoryName;
+            info.cacheDirectory = info.internalDirectory / CacheDirectoryName;
+
+            ProjectMigrationResult migrationResult =
+                MigrateProjectStructure(info, projectFilePath, activeSceneRelativePath);
+            m_lastMigrationMessages = std::move(migrationResult.messages);
+            if (false == migrationResult.succeeded)
+            {
+                return false;
+            }
+
+            isModernProjectFile = true;
+            effectiveProjectFilePath = info.projectFilePath;
+            assetRootRelativePath = AssetsDirectoryName;
+            info.activeScenePath = migrationResult.startupScenePath;
+        }
 
         if (false == std::filesystem::exists(info.activeScenePath))
         {
@@ -341,55 +776,14 @@ namespace Xelqoria::Editor
         return m_info;
     }
 
+    const std::vector<std::wstring>& EditorProject::GetLastMigrationMessages() const
+    {
+        return m_lastMigrationMessages;
+    }
+
     bool EditorProject::WriteProjectFile(const EditorProjectInfo& info) const
     {
-        if (false == EditorPathSecurity::IsValidProjectName(info.name)
-            || false == EditorPathSecurity::IsPathInsideOrEqual(info.activeScenePath, info.scenesDirectory)
-            || false == EditorPathSecurity::IsPathInsideOrEqual(info.scenesDirectory, info.assetRootDirectory)
-            || false == EditorPathSecurity::IsPathInsideOrEqual(info.projectSettingsFilePath, info.rootDirectory))
-        {
-            return false;
-        }
-
-        std::error_code errorCode;
-        std::filesystem::create_directories(info.rootDirectory, errorCode);
-        if (errorCode)
-        {
-            return false;
-        }
-
-        std::ofstream output(info.projectFilePath, std::ios::binary | std::ios::trunc);
-        if (false == output.is_open())
-        {
-            return false;
-        }
-
-        const std::string relativeScenePath = ToProjectRelativeGenericString(info.activeScenePath, info.rootDirectory, errorCode);
-        if (errorCode)
-        {
-            return false;
-        }
-
-        const std::string relativeAssetRoot = ToProjectRelativeGenericString(info.assetRootDirectory, info.rootDirectory, errorCode);
-        if (errorCode)
-        {
-            return false;
-        }
-
-        const std::string relativeProjectSettings = ToProjectRelativeGenericString(info.projectSettingsFilePath, info.rootDirectory, errorCode);
-        if (errorCode)
-        {
-            return false;
-        }
-
-        output << ProjectFileHeader << '\n';
-        output << "projectName=" << ToNarrowString(info.name) << '\n';
-        output << "version=" << ProjectVersion << '\n';
-        output << "projectStructureVersion=" << CurrentProjectStructureVersion << '\n';
-        output << "assetRoot=" << relativeAssetRoot << '\n';
-        output << "projectSettings=" << relativeProjectSettings << '\n';
-        output << "startupScene=" << relativeScenePath << '\n';
-        return output.good();
+        return WriteProjectMetadataFile(info);
     }
 
     bool EditorProject::WriteSceneFile(

--- a/Editor/Source/Project/EditorProject.h
+++ b/Editor/Source/Project/EditorProject.h
@@ -25,7 +25,7 @@ namespace Xelqoria::Editor
         std::filesystem::path rootDirectory{};
 
         /// <summary>
-        /// `.proj` ファイルのパスを表す。
+        /// プロジェクトファイルのパスを表す。
         /// </summary>
         std::filesystem::path projectFilePath{};
 
@@ -33,6 +33,26 @@ namespace Xelqoria::Editor
         /// Scene 保存フォルダを表す。
         /// </summary>
         std::filesystem::path scenesDirectory{};
+
+        /// <summary>
+        /// Assets ルートフォルダを表す。
+        /// </summary>
+        std::filesystem::path assetRootDirectory{};
+
+        /// <summary>
+        /// Project Settings ファイルのパスを表す。
+        /// </summary>
+        std::filesystem::path projectSettingsFilePath{};
+
+        /// <summary>
+        /// Editor 内部管理フォルダを表す。
+        /// </summary>
+        std::filesystem::path internalDirectory{};
+
+        /// <summary>
+        /// Editor 内部キャッシュフォルダを表す。
+        /// </summary>
+        std::filesystem::path cacheDirectory{};
 
         /// <summary>
         /// 現在編集中の Scene ファイルパスを表す。
@@ -59,9 +79,9 @@ namespace Xelqoria::Editor
             const Game::Scene& initialScene);
 
         /// <summary>
-        /// 既存の `.proj` ファイルを開く。
+        /// 既存のプロジェクトファイルを開く。
         /// </summary>
-        /// <param name="projectFilePath">開く `.proj` ファイル。</param>
+        /// <param name="projectFilePath">開くプロジェクトファイル。</param>
         /// <returns>読込に成功した場合は true。</returns>
         [[nodiscard]] bool Open(const std::filesystem::path& projectFilePath);
 
@@ -111,7 +131,7 @@ namespace Xelqoria::Editor
 
     private:
         /// <summary>
-        /// `.proj` ファイルを書き出す。
+        /// プロジェクトファイルを書き出す。
         /// </summary>
         /// <param name="info">書き出すプロジェクト情報。</param>
         /// <returns>書き出しに成功した場合は true。</returns>

--- a/Editor/Source/Project/EditorProject.h
+++ b/Editor/Source/Project/EditorProject.h
@@ -129,6 +129,12 @@ namespace Xelqoria::Editor
         /// <returns>プロジェクト情報。未オープン時は空。</returns>
         [[nodiscard]] const std::optional<EditorProjectInfo>& GetInfo() const;
 
+        /// <summary>
+        /// 直近のプロジェクト構成移行ログを取得する。
+        /// </summary>
+        /// <returns>移行結果ログ一覧。</returns>
+        [[nodiscard]] const std::vector<std::wstring>& GetLastMigrationMessages() const;
+
     private:
         /// <summary>
         /// プロジェクトファイルを書き出す。
@@ -149,5 +155,6 @@ namespace Xelqoria::Editor
 
     private:
         std::optional<EditorProjectInfo> m_info{};
+        std::vector<std::wstring> m_lastMigrationMessages{};
     };
 }

--- a/Editor/Source/Project/EditorSceneDocument.cpp
+++ b/Editor/Source/Project/EditorSceneDocument.cpp
@@ -1365,6 +1365,11 @@ namespace Xelqoria::Editor
         return m_project.GetInfo();
     }
 
+    const std::vector<std::wstring>& EditorSceneDocument::GetProjectMigrationMessages() const
+    {
+        return m_project.GetLastMigrationMessages();
+    }
+
     std::vector<std::filesystem::path> EditorSceneDocument::EnumerateProjectSceneFiles() const
     {
         return m_project.EnumerateSceneFiles();

--- a/Editor/Source/Project/EditorSceneDocument.h
+++ b/Editor/Source/Project/EditorSceneDocument.h
@@ -70,7 +70,7 @@ namespace Xelqoria::Editor
         /// <summary>
         /// 既存プロジェクトを開き、アクティブ Scene を読み込む。
         /// </summary>
-        /// <param name="projectFilePath">開く `.proj` ファイル。</param>
+        /// <param name="projectFilePath">開くプロジェクトファイル。</param>
         /// <returns>読込に成功した場合は true。</returns>
         [[nodiscard]] bool OpenProject(const std::filesystem::path& projectFilePath);
 

--- a/Editor/Source/Project/EditorSceneDocument.h
+++ b/Editor/Source/Project/EditorSceneDocument.h
@@ -284,6 +284,12 @@ namespace Xelqoria::Editor
         [[nodiscard]] const std::optional<EditorProjectInfo>& GetProjectInfo() const;
 
         /// <summary>
+        /// 直近のプロジェクト構成移行ログを取得する。
+        /// </summary>
+        /// <returns>移行結果ログ一覧。</returns>
+        [[nodiscard]] const std::vector<std::wstring>& GetProjectMigrationMessages() const;
+
+        /// <summary>
         /// 現在のプロジェクトで管理している Scene ファイルを列挙する。
         /// </summary>
         /// <returns>Scene ファイルパス一覧。</returns>

--- a/Editor/Source/Project/RecentProjectsStore.cpp
+++ b/Editor/Source/Project/RecentProjectsStore.cpp
@@ -12,6 +12,21 @@ namespace Xelqoria::Editor
     namespace
     {
         constexpr std::size_t MaxRecentProjectCount = 5;
+
+        /// <summary>
+        /// プロジェクトファイル種別に応じた Scene 保存フォルダを取得する。
+        /// </summary>
+        /// <param name="projectFilePath">対象プロジェクトファイル。</param>
+        /// <returns>Scene 保存フォルダ。</returns>
+        [[nodiscard]] std::filesystem::path GetScenesDirectory(const std::filesystem::path& projectFilePath)
+        {
+            if (projectFilePath.extension() == L".xelqoria")
+            {
+                return projectFilePath.parent_path() / L"Assets" / L"Scenes";
+            }
+
+            return projectFilePath.parent_path() / L"Scenes";
+        }
     }
 
     std::vector<EditorProjectInfo> RecentProjectsStore::Load() const
@@ -43,7 +58,13 @@ namespace Xelqoria::Editor
             info.name = name;
             info.projectFilePath = projectFilePath;
             info.rootDirectory = projectFilePath.parent_path();
-            info.scenesDirectory = info.rootDirectory / L"Scenes";
+            info.assetRootDirectory = projectFilePath.extension() == L".xelqoria"
+                ? info.rootDirectory / L"Assets"
+                : info.rootDirectory;
+            info.scenesDirectory = GetScenesDirectory(projectFilePath);
+            info.projectSettingsFilePath = info.rootDirectory / L"ProjectSettings" / L"project_settings.json";
+            info.internalDirectory = info.rootDirectory / L".xelqoria";
+            info.cacheDirectory = info.internalDirectory / L"cache";
             projects.emplace_back(info);
         }
 

--- a/Editor/Source/Project/RecentProjectsStore.h
+++ b/Editor/Source/Project/RecentProjectsStore.h
@@ -16,7 +16,7 @@ namespace Xelqoria::Editor
         /// <summary>
         /// 最近使ったプロジェクト一覧を読み込む。
         /// </summary>
-        /// <returns>存在する `.proj` のみを含むプロジェクト情報一覧。</returns>
+        /// <returns>存在するプロジェクトファイルのみを含むプロジェクト情報一覧。</returns>
         [[nodiscard]] std::vector<EditorProjectInfo> Load() const;
 
         /// <summary>

--- a/docs/plans/issue-335-project-standard-structure.md
+++ b/docs/plans/issue-335-project-standard-structure.md
@@ -1,0 +1,51 @@
+# ExecPlan: issue-335 新規プロジェクト標準構成とプロジェクトファイル保存内容を更新する
+
+## 目的
+
+新規プロジェクト作成時に、ユーザー管理対象の Assets とプロジェクト管理ファイルを分離した標準構成を生成する。
+
+## 対象範囲
+
+- 変更対象プロジェクト: `Editor`, `tests/Editor`
+- 変更対象ファイル: `EditorProject.h`, `EditorProject.cpp`, `EditorProjectTests.cpp`
+- 変更対象クラス: `Xelqoria::Editor::EditorProject`
+- 影響する機能: 新規プロジェクト作成、プロジェクトファイル保存、既存プロジェクト読込
+
+## 前提
+
+- parent issue: issue-334
+- ブランチ運用ルール: `docs/agents/branch-rules.md`
+- parent issue ブランチ: `issue-334`
+- この child issue のブランチ: `issue-335`
+- PR の向き: `issue-335` -> `issue-334`
+
+## 実装方針
+
+新規プロジェクト作成時の標準構成を `EditorProject` に集約する。
+
+新しいプロジェクトファイルは `<ProjectName>.xelqoria` とし、`projectStructureVersion`、`assetRoot`、`projectSettings`、`startupScene` をプロジェクトルートからの相対パスで保存する。既存 `.proj` 形式は Open 側で引き続き読み込めるようにする。
+
+## 作業手順
+
+1. `EditorProject` のプロジェクト情報に Assets、ProjectSettings、内部ディレクトリのパスを追加する
+2. 新規作成時に `Assets/Scenes`、`Assets/Textures`、`Assets/Materials`、`Assets/Scripts`、`ProjectSettings`、`.xelqoria/cache` を作成する
+3. 初期 Scene を `Assets/Scenes/Main.scene` に保存する
+4. `<ProjectName>.xelqoria` に新しいメタデータを保存する
+5. 既存 `.proj` 読み込み互換を維持する
+6. EditorProject のテストを新構成に更新する
+7. Editor テストまたはビルドを実行する
+
+## 検証方法
+
+- 実行するビルド: `dotnet build tools/LayerDependencyChecker/LayerDependencyChecker.csproj` または利用可能な Visual Studio ビルド
+- 実行するテスト: `Xelqoria.Tests.Editor`
+- 手動確認項目: 生成されたプロジェクトファイルの相対パス、標準ディレクトリ構成
+
+## 完了条件
+
+- 新規プロジェクト作成時に標準構成のディレクトリとファイルが作成される
+- `.xelqoria` に `projectStructureVersion`、`assetRoot`、`projectSettings`、`startupScene` が保存される
+- `.xelqoria` 内のパスがプロジェクトルートからの相対パスで保存される
+- 初期 Scene が `Assets/Scenes/Main.scene` に配置される
+- 関連テストが通る
+- `issue-335` から `issue-334` への PR が作成されている

--- a/docs/plans/issue-337-project-assets-migration.md
+++ b/docs/plans/issue-337-project-assets-migration.md
@@ -1,0 +1,59 @@
+# ExecPlan: issue-337 既存プロジェクトの Assets 配下移行処理を追加する
+
+## 目的
+
+既存プロジェクトを開いたとき、旧構成のルート直下アセットや旧ディレクトリを新しい `Assets` 配下の標準構成へ移行する。
+
+## 対象範囲
+
+- 変更対象プロジェクト: `Editor`, `tests/Editor`
+- 変更対象ファイル: `EditorProject.h`, `EditorProject.cpp`, `EditorSceneDocument.h`, `EditorSceneDocument.cpp`, `Application.cpp`, `EditorProjectTests.cpp`
+- 変更対象クラス: `Xelqoria::Editor::EditorProject`, `Xelqoria::Editor::EditorSceneDocument`, `Xelqoria::Editor::Application`
+- 影響する機能: 既存プロジェクト読込、旧プロジェクト移行、Editor ログ出力
+
+## 前提
+
+- parent issue: issue-334
+- 先行 child issue: issue-335
+- ブランチ運用ルール: `docs/agents/branch-rules.md`
+- parent issue ブランチ: `issue-334`
+- この child issue のブランチ: `issue-337`
+- PR の向き: `issue-337` -> `issue-334`
+
+## 実装方針
+
+`EditorProject::Open` で `projectStructureVersion` が未定義または現行より古いプロジェクトを検出し、プロジェクトルート配下のユーザーアセットを `Assets` 配下へ移動する。
+
+移行対象は Scene、Texture、Material、Script、ProjectSettings に限定し、`.git`、`.vs`、`.xelqoria`、`Assets`、`ProjectSettings`、ビルド出力系ディレクトリは移行対象から除外する。移動先に同名ファイルがある場合は `_1`、`_2` 形式で一意化する。移行後は新しい `.xelqoria` メタデータを保存し、旧 `.proj` は削除せず残す。
+
+移行結果のメッセージは `EditorProject` から `EditorSceneDocument` 経由で `Application` に渡し、既存プロジェクトを開いた直後に LogOutput へ追記する。
+
+## 作業手順
+
+1. 旧プロジェクト判定用に `projectStructureVersion` を読み取る
+2. 旧構成の場合に標準ディレクトリを作成する
+3. ルート直下の移行対象ファイルを `Assets/*` または `ProjectSettings` へ移動する
+4. 旧 `Scenes`、`Textures`、`Materials`、`Scripts` の内容を `Assets/*` に統合する
+5. 衝突時に一意な移動先パスを生成する
+6. 新しい `.xelqoria` メタデータを書き出す
+7. 移行ログを Editor の LogOutput に表示する
+8. 移行あり、移行なし、legacy `.proj` のテストを追加・更新する
+9. Editor テストと差分チェックを実行する
+
+## 検証方法
+
+- 実行するビルド: `MSBuild tests/Editor/Xelqoria.Tests.Editor.vcxproj /p:Configuration=Debug /p:Platform=x64 /m`
+- 実行するテスト: `artifacts/x64/Debug/Xelqoria.Tests.Editor.exe`
+- 実行する静的確認: `git diff --check`
+- 手動確認項目: 移行後の `.xelqoria` の相対パス、衝突時のリネーム、現行構成で再移行されないこと
+
+## 完了条件
+
+- 旧プロジェクトを開くと標準構成が作成される
+- 旧ルート直下アセットと旧ディレクトリ内容が `Assets` 配下へ移動される
+- 同名ファイル衝突時に既存ファイルを上書きしない
+- 移行後の `.xelqoria` に現行 `projectStructureVersion` と相対パスが保存される
+- 現行構成のプロジェクトを開いても再移行されない
+- 移行結果が Editor の LogOutput に表示される
+- 関連テストが通る
+- `issue-337` から `issue-334` への PR が作成されている

--- a/tests/Editor/Source/EditorProjectTests.cpp
+++ b/tests/Editor/Source/EditorProjectTests.cpp
@@ -26,6 +26,28 @@ namespace
         scene.CreateEntity();
         return scene;
     }
+
+    void WriteSceneFile(const std::filesystem::path& path)
+    {
+        std::filesystem::create_directories(path.parent_path());
+        std::ofstream output(path, std::ios::binary | std::ios::trunc);
+        output << Xelqoria::Game::SceneSerializer::SaveToText(MakeScene());
+    }
+
+    void WriteTextFile(const std::filesystem::path& path, const char* text)
+    {
+        std::filesystem::create_directories(path.parent_path());
+        std::ofstream output(path, std::ios::binary | std::ios::trunc);
+        output << text;
+    }
+
+    [[nodiscard]] std::string ReadTextFile(const std::filesystem::path& path)
+    {
+        std::ifstream input(path, std::ios::binary);
+        return std::string(
+            std::istreambuf_iterator<char>(input),
+            std::istreambuf_iterator<char>());
+    }
 }
 
 TEST(EditorProjectTests, CreateBuildsStandardProjectStructureAndInitialScene)
@@ -121,7 +143,7 @@ TEST(EditorProjectTests, OpenPreservesUtf8ProjectName)
     std::filesystem::remove_all(parentDirectory);
 }
 
-TEST(EditorProjectTests, OpenSupportsLegacyProjFile)
+TEST(EditorProjectTests, OpenSupportsLegacyProjFileByMigratingIt)
 {
     const std::filesystem::path parentDirectory = MakeTempDirectory(L"XelqoriaEditorProjectTests_LegacyOpen");
     const std::filesystem::path projectRoot = parentDirectory / L"LegacyProject";
@@ -145,8 +167,79 @@ TEST(EditorProjectTests, OpenSupportsLegacyProjFile)
     Xelqoria::Editor::EditorProject project{};
     ASSERT_TRUE(project.Open(projectFilePath));
     ASSERT_TRUE(project.GetInfo().has_value());
-    EXPECT_EQ(scenePath, project.GetInfo()->activeScenePath);
-    EXPECT_EQ(scenesDirectory, project.GetInfo()->scenesDirectory);
+    EXPECT_EQ(projectRoot / L"Assets" / L"Scenes" / L"Main.xelqoria.scene", project.GetInfo()->activeScenePath);
+    EXPECT_EQ(projectRoot / L"Assets" / L"Scenes", project.GetInfo()->scenesDirectory);
+    EXPECT_FALSE(std::filesystem::exists(scenePath));
+    EXPECT_FALSE(std::filesystem::exists(scenesDirectory));
+
+    std::filesystem::remove_all(parentDirectory);
+}
+
+TEST(EditorProjectTests, OpenMigratesLegacyProjectToAssetsStructure)
+{
+    const std::filesystem::path parentDirectory = MakeTempDirectory(L"XelqoriaEditorProjectTests_MigrateLegacy");
+    const std::filesystem::path projectRoot = parentDirectory / L"LegacyProject";
+    std::filesystem::create_directories(projectRoot);
+    WriteSceneFile(projectRoot / L"Main.scene");
+    WriteSceneFile(projectRoot / L"Scenes" / L"Intro.scene");
+    WriteTextFile(projectRoot / L"player.png", "image");
+    WriteTextFile(projectRoot / L"Textures" / L"player.png", "folder image");
+    WriteTextFile(projectRoot / L"Assets" / L"Textures" / L"player.png", "existing image");
+    WriteTextFile(projectRoot / L"PlayerScript.cpp", "void Update() {}\n");
+    WriteTextFile(projectRoot / L"player_material.json", "{}\n");
+    WriteTextFile(projectRoot / L"project_settings.json", "{\"legacy\":true}\n");
+
+    const std::filesystem::path projectFilePath = projectRoot / L"LegacyProject.proj";
+    {
+        std::ofstream projectFile(projectFilePath, std::ios::binary | std::ios::trunc);
+        projectFile << "XelqoriaProject=1\n";
+        projectFile << "Name=LegacyProject\n";
+        projectFile << "ActiveScene=Main.scene\n";
+    }
+
+    Xelqoria::Editor::EditorProject project{};
+    ASSERT_TRUE(project.Open(projectFilePath));
+    ASSERT_TRUE(project.GetInfo().has_value());
+
+    EXPECT_EQ(projectRoot / L"LegacyProject.xelqoria", project.GetInfo()->projectFilePath);
+    EXPECT_EQ(projectRoot / L"Assets", project.GetInfo()->assetRootDirectory);
+    EXPECT_EQ(projectRoot / L"Assets" / L"Scenes" / L"Main.scene", project.GetInfo()->activeScenePath);
+    EXPECT_TRUE(std::filesystem::exists(projectRoot / L"Assets" / L"Scenes" / L"Main.scene"));
+    EXPECT_TRUE(std::filesystem::exists(projectRoot / L"Assets" / L"Scenes" / L"Intro.scene"));
+    EXPECT_TRUE(std::filesystem::exists(projectRoot / L"Assets" / L"Textures" / L"player.png"));
+    EXPECT_TRUE(std::filesystem::exists(projectRoot / L"Assets" / L"Textures" / L"player_1.png"));
+    EXPECT_TRUE(std::filesystem::exists(projectRoot / L"Assets" / L"Textures" / L"player_2.png"));
+    EXPECT_TRUE(std::filesystem::exists(projectRoot / L"Assets" / L"Scripts" / L"PlayerScript.cpp"));
+    EXPECT_TRUE(std::filesystem::exists(projectRoot / L"Assets" / L"Materials" / L"player_material.json"));
+    EXPECT_TRUE(std::filesystem::exists(projectRoot / L"ProjectSettings" / L"project_settings.json"));
+    EXPECT_TRUE(std::filesystem::exists(projectRoot / L".xelqoria" / L"cache"));
+
+    const std::string projectText = ReadTextFile(projectRoot / L"LegacyProject.xelqoria");
+    EXPECT_NE(std::string::npos, projectText.find("projectStructureVersion=1\n"));
+    EXPECT_NE(std::string::npos, projectText.find("assetRoot=Assets\n"));
+    EXPECT_NE(std::string::npos, projectText.find("projectSettings=ProjectSettings/project_settings.json\n"));
+    EXPECT_NE(std::string::npos, projectText.find("startupScene=Assets/Scenes/Main.scene\n"));
+
+    EXPECT_FALSE(project.GetLastMigrationMessages().empty());
+
+    std::filesystem::remove_all(parentDirectory);
+}
+
+TEST(EditorProjectTests, OpenDoesNotMigrateCurrentStructureAgain)
+{
+    const std::filesystem::path parentDirectory = MakeTempDirectory(L"XelqoriaEditorProjectTests_NoRemigrate");
+    Xelqoria::Editor::EditorProject createdProject{};
+    ASSERT_TRUE(createdProject.Create(L"CurrentProject", parentDirectory, MakeScene()));
+
+    const std::filesystem::path projectRoot = parentDirectory / L"CurrentProject";
+    WriteTextFile(projectRoot / L"legacy.png", "legacy root image");
+
+    Xelqoria::Editor::EditorProject openedProject{};
+    ASSERT_TRUE(openedProject.Open(projectRoot / L"CurrentProject.xelqoria"));
+
+    EXPECT_TRUE(std::filesystem::exists(projectRoot / L"legacy.png"));
+    EXPECT_FALSE(std::filesystem::exists(projectRoot / L"Assets" / L"Textures" / L"legacy.png"));
+    EXPECT_TRUE(openedProject.GetLastMigrationMessages().empty());
 
     std::filesystem::remove_all(parentDirectory);
 }

--- a/tests/Editor/Source/EditorProjectTests.cpp
+++ b/tests/Editor/Source/EditorProjectTests.cpp
@@ -2,6 +2,7 @@
 
 #include <filesystem>
 #include <fstream>
+#include <iterator>
 #include <vector>
 
 #include <gtest/gtest.h>
@@ -27,7 +28,7 @@ namespace
     }
 }
 
-TEST(EditorProjectTests, CreateBuildsProjectFileScenesDirectoryAndInitialScene)
+TEST(EditorProjectTests, CreateBuildsStandardProjectStructureAndInitialScene)
 {
     const std::filesystem::path parentDirectory = MakeTempDirectory(L"XelqoriaEditorProjectTests_Create");
     Xelqoria::Editor::EditorProject project{};
@@ -35,10 +36,43 @@ TEST(EditorProjectTests, CreateBuildsProjectFileScenesDirectoryAndInitialScene)
     EXPECT_TRUE(project.Create(L"SampleProject", parentDirectory, MakeScene()));
 
     const std::filesystem::path projectRoot = parentDirectory / L"SampleProject";
-    EXPECT_TRUE(std::filesystem::exists(projectRoot / L"SampleProject.proj"));
-    EXPECT_TRUE(std::filesystem::is_directory(projectRoot / L"Scenes"));
-    EXPECT_TRUE(std::filesystem::exists(projectRoot / L"Scenes" / L"Main.xelqoria.scene"));
+    EXPECT_TRUE(std::filesystem::exists(projectRoot / L"SampleProject.xelqoria"));
+    EXPECT_TRUE(std::filesystem::is_directory(projectRoot / L"Assets" / L"Scenes"));
+    EXPECT_TRUE(std::filesystem::is_directory(projectRoot / L"Assets" / L"Textures"));
+    EXPECT_TRUE(std::filesystem::is_directory(projectRoot / L"Assets" / L"Materials"));
+    EXPECT_TRUE(std::filesystem::is_directory(projectRoot / L"Assets" / L"Scripts"));
+    EXPECT_TRUE(std::filesystem::is_directory(projectRoot / L"ProjectSettings"));
+    EXPECT_TRUE(std::filesystem::is_directory(projectRoot / L".xelqoria" / L"cache"));
+    EXPECT_TRUE(std::filesystem::exists(projectRoot / L"ProjectSettings" / L"project_settings.json"));
+    EXPECT_TRUE(std::filesystem::exists(projectRoot / L"Assets" / L"Scenes" / L"Main.scene"));
     EXPECT_TRUE(project.HasProject());
+
+    std::filesystem::remove_all(parentDirectory);
+}
+
+TEST(EditorProjectTests, CreateWritesProjectMetadataAsRootRelativePaths)
+{
+    const std::filesystem::path parentDirectory = MakeTempDirectory(L"XelqoriaEditorProjectTests_Metadata");
+    Xelqoria::Editor::EditorProject project{};
+
+    ASSERT_TRUE(project.Create(L"SampleProject", parentDirectory, MakeScene()));
+
+    const std::filesystem::path projectFilePath = parentDirectory / L"SampleProject" / L"SampleProject.xelqoria";
+    std::string text{};
+    {
+        std::ifstream input(projectFilePath, std::ios::binary);
+        ASSERT_TRUE(input.is_open());
+        text.assign(
+            std::istreambuf_iterator<char>(input),
+            std::istreambuf_iterator<char>());
+    }
+
+    EXPECT_NE(std::string::npos, text.find("projectName=SampleProject\n"));
+    EXPECT_NE(std::string::npos, text.find("version=1\n"));
+    EXPECT_NE(std::string::npos, text.find("projectStructureVersion=1\n"));
+    EXPECT_NE(std::string::npos, text.find("assetRoot=Assets\n"));
+    EXPECT_NE(std::string::npos, text.find("projectSettings=ProjectSettings/project_settings.json\n"));
+    EXPECT_NE(std::string::npos, text.find("startupScene=Assets/Scenes/Main.scene\n"));
 
     std::filesystem::remove_all(parentDirectory);
 }
@@ -52,7 +86,7 @@ TEST(EditorProjectTests, SaveAsSwitchesCurrentProject)
 
     ASSERT_TRUE(project.GetInfo().has_value());
     EXPECT_EQ(L"RenamedProject", project.GetInfo()->name);
-    EXPECT_TRUE(std::filesystem::exists(parentDirectory / L"RenamedProject" / L"RenamedProject.proj"));
+    EXPECT_TRUE(std::filesystem::exists(parentDirectory / L"RenamedProject" / L"RenamedProject.xelqoria"));
 
     std::filesystem::remove_all(parentDirectory);
 }
@@ -64,11 +98,11 @@ TEST(EditorProjectTests, OpenReadsProjectAndEnumeratesScenes)
     ASSERT_TRUE(createdProject.Create(L"OpenProject", parentDirectory, MakeScene()));
 
     Xelqoria::Editor::EditorProject openedProject{};
-    EXPECT_TRUE(openedProject.Open(parentDirectory / L"OpenProject" / L"OpenProject.proj"));
+    EXPECT_TRUE(openedProject.Open(parentDirectory / L"OpenProject" / L"OpenProject.xelqoria"));
 
     const std::vector<std::filesystem::path> sceneFiles = openedProject.EnumerateSceneFiles();
     ASSERT_EQ(1u, sceneFiles.size());
-    EXPECT_EQ(L"Main.xelqoria.scene", sceneFiles[0].filename().wstring());
+    EXPECT_EQ(L"Main.scene", sceneFiles[0].filename().wstring());
 
     std::filesystem::remove_all(parentDirectory);
 }
@@ -83,6 +117,36 @@ TEST(EditorProjectTests, OpenPreservesUtf8ProjectName)
     EXPECT_TRUE(openedProject.Open(createdProject.GetInfo()->projectFilePath));
     ASSERT_TRUE(openedProject.GetInfo().has_value());
     EXPECT_EQ(L"日本語Project", openedProject.GetInfo()->name);
+
+    std::filesystem::remove_all(parentDirectory);
+}
+
+TEST(EditorProjectTests, OpenSupportsLegacyProjFile)
+{
+    const std::filesystem::path parentDirectory = MakeTempDirectory(L"XelqoriaEditorProjectTests_LegacyOpen");
+    const std::filesystem::path projectRoot = parentDirectory / L"LegacyProject";
+    const std::filesystem::path scenesDirectory = projectRoot / L"Scenes";
+    std::filesystem::create_directories(scenesDirectory);
+
+    const std::filesystem::path scenePath = scenesDirectory / L"Main.xelqoria.scene";
+    {
+        std::ofstream sceneFile(scenePath, std::ios::binary | std::ios::trunc);
+        sceneFile << Xelqoria::Game::SceneSerializer::SaveToText(MakeScene());
+    }
+
+    const std::filesystem::path projectFilePath = projectRoot / L"LegacyProject.proj";
+    {
+        std::ofstream projectFile(projectFilePath, std::ios::binary | std::ios::trunc);
+        projectFile << "XelqoriaProject=1\n";
+        projectFile << "Name=LegacyProject\n";
+        projectFile << "ActiveScene=Scenes/Main.xelqoria.scene\n";
+    }
+
+    Xelqoria::Editor::EditorProject project{};
+    ASSERT_TRUE(project.Open(projectFilePath));
+    ASSERT_TRUE(project.GetInfo().has_value());
+    EXPECT_EQ(scenePath, project.GetInfo()->activeScenePath);
+    EXPECT_EQ(scenesDirectory, project.GetInfo()->scenesDirectory);
 
     std::filesystem::remove_all(parentDirectory);
 }
@@ -120,21 +184,25 @@ TEST(EditorProjectTests, OpenRejectsActiveSceneOutsideProjectScenesDirectory)
 {
     const std::filesystem::path parentDirectory = MakeTempDirectory(L"XelqoriaEditorProjectTests_RejectOutsideScene");
     const std::filesystem::path projectRoot = parentDirectory / L"UnsafeProject";
-    const std::filesystem::path scenesDirectory = projectRoot / L"Scenes";
+    const std::filesystem::path scenesDirectory = projectRoot / L"Assets" / L"Scenes";
     std::filesystem::create_directories(scenesDirectory);
 
-    const std::filesystem::path outsideScenePath = parentDirectory / L"Outside.xelqoria.scene";
+    const std::filesystem::path outsideScenePath = parentDirectory / L"Outside.scene";
     {
         std::ofstream outsideScene(outsideScenePath, std::ios::binary | std::ios::trunc);
         outsideScene << Xelqoria::Game::SceneSerializer::SaveToText(MakeScene());
     }
 
-    const std::filesystem::path projectFilePath = projectRoot / L"UnsafeProject.proj";
+    const std::filesystem::path projectFilePath = projectRoot / L"UnsafeProject.xelqoria";
     {
         std::ofstream projectFile(projectFilePath, std::ios::binary | std::ios::trunc);
         projectFile << "XelqoriaProject=1\n";
-        projectFile << "Name=UnsafeProject\n";
-        projectFile << "ActiveScene=../Outside.xelqoria.scene\n";
+        projectFile << "projectName=UnsafeProject\n";
+        projectFile << "version=1\n";
+        projectFile << "projectStructureVersion=1\n";
+        projectFile << "assetRoot=Assets\n";
+        projectFile << "projectSettings=ProjectSettings/project_settings.json\n";
+        projectFile << "startupScene=../Outside.scene\n";
     }
 
     Xelqoria::Editor::EditorProject project{};
@@ -149,7 +217,7 @@ TEST(EditorProjectTests, SelectSceneFileRejectsOutsideSceneDirectory)
     Xelqoria::Editor::EditorProject project{};
     ASSERT_TRUE(project.Create(L"SceneProject", parentDirectory, MakeScene()));
 
-    const std::filesystem::path outsideScenePath = parentDirectory / L"Outside.xelqoria.scene";
+    const std::filesystem::path outsideScenePath = parentDirectory / L"Outside.scene";
     std::filesystem::copy_file(project.GetInfo()->activeScenePath, outsideScenePath);
 
     EXPECT_FALSE(project.SelectSceneFile(outsideScenePath));

--- a/tests/Editor/Source/RecentProjectsStoreTests.cpp
+++ b/tests/Editor/Source/RecentProjectsStoreTests.cpp
@@ -30,7 +30,7 @@ TEST(RecentProjectsStoreTests, RecordKeepsMostRecentFiveExistingProjects)
         const std::wstring projectName = L"Project" + std::to_wstring(index);
         const std::filesystem::path projectRoot = tempDirectory / projectName;
         std::filesystem::create_directories(projectRoot);
-        const std::filesystem::path projectFilePath = projectRoot / (projectName + L".proj");
+        const std::filesystem::path projectFilePath = projectRoot / (projectName + L".xelqoria");
         std::ofstream(projectFilePath).put('\n');
 
         Xelqoria::Editor::EditorProjectInfo info{};
@@ -57,7 +57,7 @@ TEST(RecentProjectsStoreTests, RecordPreservesUtf8ProjectNameAndPath)
 
     const std::filesystem::path projectRoot = tempDirectory / L"日本語Project";
     std::filesystem::create_directories(projectRoot);
-    const std::filesystem::path projectFilePath = projectRoot / L"日本語Project.proj";
+    const std::filesystem::path projectFilePath = projectRoot / L"日本語Project.xelqoria";
     std::ofstream(projectFilePath).put('\n');
 
     Xelqoria::Editor::EditorProjectInfo info{};
@@ -72,6 +72,7 @@ TEST(RecentProjectsStoreTests, RecordPreservesUtf8ProjectNameAndPath)
     ASSERT_EQ(1u, projects.size());
     EXPECT_EQ(L"日本語Project", projects[0].name);
     EXPECT_EQ(projectFilePath, projects[0].projectFilePath);
+    EXPECT_EQ(projectRoot / L"Assets" / L"Scenes", projects[0].scenesDirectory);
 
     std::filesystem::current_path(originalCurrentPath);
     std::filesystem::remove_all(tempDirectory);


### PR DESCRIPTION
## Summary
- 旧構成プロジェクトを開いた際に `Assets` / `ProjectSettings` / `.xelqoria` の標準構成へ移行する処理を追加
- ルート直下ファイルと旧 `Scenes` / `Textures` / `Materials` / `Scripts` ディレクトリを用途別に移動し、衝突時は `_1`, `_2` 形式で一意化
- 移行メッセージを `EditorProject` から `EditorSceneDocument` 経由で Application の LogOutput に表示
- child issue 用 ExecPlan と、移行あり・移行なし・legacy `.proj` の EditorProject テストを追加

## Notes
- This branch includes `issue-335` because the migration depends on the new standard project structure.

## Validation
- `MSBuild tests/Editor/Xelqoria.Tests.Editor.vcxproj /p:Configuration=Debug /p:Platform=x64 /m`
- `artifacts/x64/Debug/Xelqoria.Tests.Editor.exe` (81 tests passed)
- `git diff --check`

Closes #337