### PR TITLE
Project Settings をメニューから開く導線を追加する

### DIFF
--- a/Editor/Source/App/Application.cpp
+++ b/Editor/Source/App/Application.cpp
@@ -55,7 +55,8 @@ namespace Xelqoria::Editor
                         ownerWindow,
                         {},
                         {
-                            Platform::FileDialogFilter{ L"Xelqoria Project (*.proj)", L"*.proj" },
+                            Platform::FileDialogFilter{ L"Xelqoria Project (*.xelqoria)", L"*.xelqoria" },
+                            Platform::FileDialogFilter{ L"Legacy Xelqoria Project (*.proj)", L"*.proj" },
                             Platform::FileDialogFilter{ L"All Files (*.*)", L"*.*" }
                         },
                         {}

--- a/Editor/Source/App/Application.cpp
+++ b/Editor/Source/App/Application.cpp
@@ -5,9 +5,13 @@
 #include <cstdlib>
 #include <exception>
 #include <filesystem>
+#include <fstream>
 #include <functional>
 #include <span>
+#include <sstream>
 #include <string>
+#include <string_view>
+#include <vector>
 
 #include "PlatformAdapters/ButtonClickWin32Adapter.h"
 #include "GraphicsAPI.h"
@@ -39,6 +43,21 @@ namespace Xelqoria::Editor
         constexpr unsigned ViewMenuSceneViewCommandId = 5203;
         constexpr unsigned ViewMenuInspectorCommandId = 5204;
         constexpr unsigned ViewMenuLogOutputCommandId = 5205;
+        constexpr int ProjectSettingsEditControlId = 5301;
+        constexpr int ProjectSettingsSaveButtonId = 5302;
+        constexpr int ProjectSettingsCancelButtonId = 5303;
+        constexpr const wchar_t* ProjectSettingsEditorWindowClassName = L"XelqoriaProjectSettingsEditor";
+
+        struct ProjectSettingsEditorDialogState
+        {
+            std::filesystem::path filePath{};
+            std::wstring initialText{};
+            HWND window = nullptr;
+            HWND editControl = nullptr;
+            HWND saveButton = nullptr;
+            HWND cancelButton = nullptr;
+            bool saved = false;
+        };
 
         [[nodiscard]] std::filesystem::path GetEditorLayoutFilePath()
         {
@@ -96,6 +115,320 @@ namespace Xelqoria::Editor
                         title
                     });
             return folderPath.value_or(std::filesystem::path{});
+        }
+
+        [[nodiscard]] bool ReadUtf8TextFile(
+            const std::filesystem::path& filePath,
+            std::string& text)
+        {
+            std::ifstream input(filePath, std::ios::binary);
+            if (false == input.is_open())
+            {
+                return false;
+            }
+
+            std::ostringstream buffer;
+            buffer << input.rdbuf();
+            text = buffer.str();
+            return input.good() || input.eof();
+        }
+
+        [[nodiscard]] bool WriteUtf8TextFile(
+            const std::filesystem::path& filePath,
+            std::string_view text)
+        {
+            std::error_code errorCode;
+            std::filesystem::create_directories(filePath.parent_path(), errorCode);
+            if (errorCode)
+            {
+                return false;
+            }
+
+            std::ofstream output(filePath, std::ios::binary | std::ios::trunc);
+            if (false == output.is_open())
+            {
+                return false;
+            }
+
+            output << text;
+            return output.good();
+        }
+
+        void SetDefaultGuiFont(HWND handle)
+        {
+            SendMessageW(handle, WM_SETFONT, reinterpret_cast<WPARAM>(GetStockObject(DEFAULT_GUI_FONT)), TRUE);
+        }
+
+        void LayoutProjectSettingsEditor(ProjectSettingsEditorDialogState& state)
+        {
+            if (nullptr == state.window)
+            {
+                return;
+            }
+
+            RECT clientRect{};
+            GetClientRect(state.window, &clientRect);
+            const int width = clientRect.right - clientRect.left;
+            const int height = clientRect.bottom - clientRect.top;
+            constexpr int Padding = 12;
+            constexpr int ButtonWidth = 96;
+            constexpr int ButtonHeight = 30;
+            constexpr int ButtonGap = 8;
+
+            const int buttonTop = height - Padding - ButtonHeight;
+            const int cancelLeft = width - Padding - ButtonWidth;
+            const int saveLeft = cancelLeft - ButtonGap - ButtonWidth;
+            MoveWindow(state.editControl, Padding, Padding, width - (Padding * 2), buttonTop - (Padding * 2), TRUE);
+            MoveWindow(state.saveButton, saveLeft, buttonTop, ButtonWidth, ButtonHeight, TRUE);
+            MoveWindow(state.cancelButton, cancelLeft, buttonTop, ButtonWidth, ButtonHeight, TRUE);
+        }
+
+        [[nodiscard]] bool SaveProjectSettingsEditorText(ProjectSettingsEditorDialogState& state)
+        {
+            const int textLength = GetWindowTextLengthW(state.editControl);
+            if (textLength < 0)
+            {
+                return false;
+            }
+
+            std::vector<wchar_t> buffer(static_cast<std::size_t>(textLength) + 1u, L'\0');
+            if (0 < textLength)
+            {
+                GetWindowTextW(state.editControl, buffer.data(), static_cast<int>(buffer.size()));
+            }
+
+            const std::wstring wideText(buffer.data(), static_cast<std::size_t>(textLength));
+            const std::string utf8Text = ToNarrowString(wideText);
+            if (false == wideText.empty() && utf8Text.empty())
+            {
+                return false;
+            }
+
+            return WriteUtf8TextFile(state.filePath, utf8Text);
+        }
+
+        LRESULT CALLBACK ProjectSettingsEditorWindowProc(
+            HWND window,
+            UINT message,
+            WPARAM wParam,
+            LPARAM lParam)
+        {
+            auto* state = reinterpret_cast<ProjectSettingsEditorDialogState*>(
+                GetWindowLongPtrW(window, GWLP_USERDATA));
+
+            switch (message)
+            {
+            case WM_NCCREATE:
+            {
+                const auto* createStruct = reinterpret_cast<const CREATESTRUCTW*>(lParam);
+                state = reinterpret_cast<ProjectSettingsEditorDialogState*>(createStruct->lpCreateParams);
+                SetWindowLongPtrW(window, GWLP_USERDATA, reinterpret_cast<LONG_PTR>(state));
+                state->window = window;
+                return TRUE;
+            }
+            case WM_CREATE:
+                if (nullptr == state)
+                {
+                    return -1;
+                }
+
+                state->editControl = CreateWindowExW(
+                    WS_EX_CLIENTEDGE,
+                    L"Edit",
+                    state->initialText.c_str(),
+                    WS_CHILD | WS_VISIBLE | WS_TABSTOP | WS_VSCROLL | WS_HSCROLL
+                        | ES_MULTILINE | ES_AUTOVSCROLL | ES_AUTOHSCROLL | ES_WANTRETURN,
+                    0,
+                    0,
+                    0,
+                    0,
+                    window,
+                    reinterpret_cast<HMENU>(static_cast<INT_PTR>(ProjectSettingsEditControlId)),
+                    nullptr,
+                    nullptr);
+                state->saveButton = CreateWindowExW(
+                    0,
+                    L"Button",
+                    L"Save",
+                    WS_CHILD | WS_VISIBLE | WS_TABSTOP | BS_DEFPUSHBUTTON,
+                    0,
+                    0,
+                    0,
+                    0,
+                    window,
+                    reinterpret_cast<HMENU>(static_cast<INT_PTR>(ProjectSettingsSaveButtonId)),
+                    nullptr,
+                    nullptr);
+                state->cancelButton = CreateWindowExW(
+                    0,
+                    L"Button",
+                    L"Cancel",
+                    WS_CHILD | WS_VISIBLE | WS_TABSTOP | BS_PUSHBUTTON,
+                    0,
+                    0,
+                    0,
+                    0,
+                    window,
+                    reinterpret_cast<HMENU>(static_cast<INT_PTR>(ProjectSettingsCancelButtonId)),
+                    nullptr,
+                    nullptr);
+                SetDefaultGuiFont(state->editControl);
+                SetDefaultGuiFont(state->saveButton);
+                SetDefaultGuiFont(state->cancelButton);
+                LayoutProjectSettingsEditor(*state);
+                return 0;
+            case WM_SIZE:
+                if (nullptr != state)
+                {
+                    LayoutProjectSettingsEditor(*state);
+                }
+                return 0;
+            case WM_COMMAND:
+                if (nullptr == state)
+                {
+                    break;
+                }
+
+                switch (LOWORD(wParam))
+                {
+                case ProjectSettingsSaveButtonId:
+                    if (SaveProjectSettingsEditorText(*state))
+                    {
+                        state->saved = true;
+                        DestroyWindow(window);
+                    }
+                    else
+                    {
+                        MessageBoxW(
+                            window,
+                            L"Project Settings を保存できませんでした。",
+                            L"Project Settings",
+                            MB_OK | MB_ICONERROR);
+                    }
+                    return 0;
+                case ProjectSettingsCancelButtonId:
+                    DestroyWindow(window);
+                    return 0;
+                default:
+                    break;
+                }
+                break;
+            case WM_CLOSE:
+                DestroyWindow(window);
+                return 0;
+            case WM_NCDESTROY:
+                SetWindowLongPtrW(window, GWLP_USERDATA, 0);
+                return 0;
+            default:
+                break;
+            }
+
+            return DefWindowProcW(window, message, wParam, lParam);
+        }
+
+        [[nodiscard]] bool EnsureProjectSettingsEditorWindowClass(HINSTANCE hInstance)
+        {
+            WNDCLASSW existingClass{};
+            if (GetClassInfoW(hInstance, ProjectSettingsEditorWindowClassName, &existingClass))
+            {
+                return true;
+            }
+
+            WNDCLASSW windowClass{};
+            windowClass.lpfnWndProc = ProjectSettingsEditorWindowProc;
+            windowClass.hInstance = hInstance;
+            windowClass.hCursor = LoadCursorW(nullptr, IDC_ARROW);
+            windowClass.hbrBackground = reinterpret_cast<HBRUSH>(COLOR_WINDOW + 1);
+            windowClass.lpszClassName = ProjectSettingsEditorWindowClassName;
+            return 0 != RegisterClassW(&windowClass);
+        }
+
+        [[nodiscard]] bool ShowProjectSettingsEditorDialog(
+            HINSTANCE hInstance,
+            HWND ownerWindow,
+            const std::filesystem::path& settingsFilePath,
+            std::wstring& errorMessage)
+        {
+            std::string initialText{};
+            std::error_code errorCode;
+            if (std::filesystem::exists(settingsFilePath, errorCode))
+            {
+                if (false == ReadUtf8TextFile(settingsFilePath, initialText))
+                {
+                    errorMessage = L"Project Settings を読み込めませんでした。";
+                    return false;
+                }
+            }
+            else
+            {
+                initialText = "{\n}\n";
+            }
+
+            ProjectSettingsEditorDialogState state{};
+            state.filePath = settingsFilePath;
+            state.initialText = ToWideString(initialText);
+            if (false == initialText.empty() && state.initialText.empty())
+            {
+                errorMessage = L"Project Settings の UTF-8 テキストを読み込めませんでした。";
+                return false;
+            }
+
+            if (false == EnsureProjectSettingsEditorWindowClass(hInstance))
+            {
+                errorMessage = L"Project Settings 編集画面を初期化できませんでした。";
+                return false;
+            }
+
+            constexpr DWORD WindowStyle = WS_OVERLAPPED | WS_CAPTION | WS_SYSMENU | WS_SIZEBOX;
+            constexpr DWORD WindowExStyle = WS_EX_DLGMODALFRAME | WS_EX_WINDOWEDGE;
+            RECT windowRect{ 0, 0, 720, 520 };
+            AdjustWindowRectEx(&windowRect, WindowStyle, FALSE, WindowExStyle);
+            const int windowWidth = windowRect.right - windowRect.left;
+            const int windowHeight = windowRect.bottom - windowRect.top;
+
+            RECT ownerRect{};
+            GetWindowRect(ownerWindow, &ownerRect);
+            const int ownerWidth = ownerRect.right - ownerRect.left;
+            const int ownerHeight = ownerRect.bottom - ownerRect.top;
+            const int windowLeft = ownerRect.left + ((ownerWidth - windowWidth) / 2);
+            const int windowTop = ownerRect.top + ((ownerHeight - windowHeight) / 2);
+
+            HWND dialogWindow = CreateWindowExW(
+                WindowExStyle,
+                ProjectSettingsEditorWindowClassName,
+                L"Project Settings",
+                WindowStyle,
+                windowLeft,
+                windowTop,
+                windowWidth,
+                windowHeight,
+                ownerWindow,
+                nullptr,
+                hInstance,
+                &state);
+            if (nullptr == dialogWindow)
+            {
+                errorMessage = L"Project Settings 編集画面を開けませんでした。";
+                return false;
+            }
+
+            EnableWindow(ownerWindow, FALSE);
+            ShowWindow(dialogWindow, SW_SHOW);
+            UpdateWindow(dialogWindow);
+
+            MSG message{};
+            while (IsWindow(dialogWindow) && GetMessageW(&message, nullptr, 0, 0) > 0)
+            {
+                if (false == IsDialogMessageW(dialogWindow, &message))
+                {
+                    TranslateMessage(&message);
+                    DispatchMessageW(&message);
+                }
+            }
+
+            EnableWindow(ownerWindow, TRUE);
+            SetActiveWindow(ownerWindow);
+            return state.saved;
         }
 
         [[nodiscard]] std::wstring BuildNewProjectName(const std::filesystem::path& parentDirectory)
@@ -419,7 +752,7 @@ namespace Xelqoria::Editor
         AppendMenuW(m_projectMenu, MF_STRING, ProjectMenuSaveCommandId, L"プロジェクトを保存する");
         AppendMenuW(m_projectMenu, MF_STRING, ProjectMenuSaveAsCommandId, L"プロジェクトを別名で保存する");
         AppendMenuW(m_projectMenu, MF_STRING, ProjectMenuOpenCommandId, L"プロジェクトを開く");
-        AppendMenuW(m_projectMenu, MF_STRING, ProjectMenuSettingsCommandId, L"プロジェクトの設定を開く");
+        AppendMenuW(m_projectMenu, MF_STRING, ProjectMenuSettingsCommandId, L"Settings...");
         AppendMenuW(m_projectMenu, MF_SEPARATOR, 0, nullptr);
         AppendMenuW(m_projectMenu, MF_STRING, ProjectMenuResetLayoutCommandId, L"画面レイアウトを初期状態に戻す");
 
@@ -430,7 +763,7 @@ namespace Xelqoria::Editor
         AppendMenuW(m_viewMenu, MF_STRING, ViewMenuLogOutputCommandId, L"LogOutput");
 
         m_menuBar = CreateMenu();
-        AppendMenuW(m_menuBar, MF_POPUP, reinterpret_cast<UINT_PTR>(m_projectMenu), L"プロジェクト");
+        AppendMenuW(m_menuBar, MF_POPUP, reinterpret_cast<UINT_PTR>(m_projectMenu), L"Project");
         AppendMenuW(m_menuBar, MF_POPUP, reinterpret_cast<UINT_PTR>(m_viewMenu), L"表示");
         SetMenu(GetMainWindowHandle(), m_menuBar);
     }
@@ -452,10 +785,7 @@ namespace Xelqoria::Editor
             OpenProjectFromMenu();
             break;
         case ProjectMenuSettingsCommandId:
-            if (m_editorInitialized)
-            {
-                SetWindowTextW(m_editorShell.GetSceneViewPlanLabel(), L"プロジェクト設定画面は未実装です。");
-            }
+            OpenProjectSettingsFromMenu();
             break;
         case ProjectMenuResetLayoutCommandId:
             if (m_editorInitialized)
@@ -746,6 +1076,40 @@ namespace Xelqoria::Editor
         ClearProjectDirty();
         SetWindowTextW(m_editorShell.GetSceneViewPlanLabel(), L"プロジェクトを別名で保存しました。");
         AppendEditorLog(L"プロジェクトを別名で保存しました。");
+    }
+
+    void Application::OpenProjectSettingsFromMenu()
+    {
+        if (false == m_editorInitialized || false == m_sceneDocument.GetProjectInfo().has_value())
+        {
+            return;
+        }
+
+        const std::filesystem::path projectSettingsFilePath =
+            m_sceneDocument.GetProjectInfo()->projectSettingsFilePath;
+        std::wstring errorMessage{};
+        const bool saved = ShowProjectSettingsEditorDialog(
+            m_hInstance,
+            GetMainWindowHandle(),
+            projectSettingsFilePath,
+            errorMessage);
+        if (false == errorMessage.empty())
+        {
+            SetWindowTextW(m_editorShell.GetSceneViewPlanLabel(), errorMessage.c_str());
+            AppendEditorLog(errorMessage.c_str());
+            MessageBoxW(
+                GetMainWindowHandle(),
+                errorMessage.c_str(),
+                L"Project Settings",
+                MB_OK | MB_ICONERROR);
+            return;
+        }
+
+        if (saved)
+        {
+            SetWindowTextW(m_editorShell.GetSceneViewPlanLabel(), L"Project Settings を保存しました。");
+            AppendEditorLog(L"Project Settings を保存しました。");
+        }
     }
 
     bool Application::ConfirmSaveIfDirty()

--- a/Editor/Source/App/Application.h
+++ b/Editor/Source/App/Application.h
@@ -127,6 +127,11 @@ namespace Xelqoria::Editor
         void SaveProjectAsFromMenu();
 
         /// <summary>
+        /// Project Settings 編集画面を開く。
+        /// </summary>
+        void OpenProjectSettingsFromMenu();
+
+        /// <summary>
         /// 未保存変更があれば保存確認を表示する。
         /// </summary>
         /// <returns>後続操作を継続してよい場合は true。</returns>

--- a/Editor/Source/App/StartupScreenController.cpp
+++ b/Editor/Source/App/StartupScreenController.cpp
@@ -509,7 +509,8 @@ namespace Xelqoria::Editor
                         GetParent(m_openButton),
                         {},
                         {
-                            Platform::FileDialogFilter{ L"Xelqoria Project (*.proj)", L"*.proj" },
+                            Platform::FileDialogFilter{ L"Xelqoria Project (*.xelqoria)", L"*.xelqoria" },
+                            Platform::FileDialogFilter{ L"Legacy Xelqoria Project (*.proj)", L"*.proj" },
                             Platform::FileDialogFilter{ L"All Files (*.*)", L"*.*" }
                         },
                         {}

--- a/Editor/Source/Panels/Assets/AssetsPanelController.cpp
+++ b/Editor/Source/Panels/Assets/AssetsPanelController.cpp
@@ -1169,6 +1169,7 @@ namespace Xelqoria::Editor
         if (const std::optional<int> iconIndex = addIcon(L"file_proj.png"); iconIndex.has_value())
         {
             m_fileIconIndices.emplace(L".proj", *iconIndex);
+            m_fileIconIndices.emplace(L".xelqoria", *iconIndex);
         }
 
         if (const std::optional<int> iconIndex = addIcon(L"file_script.png"); iconIndex.has_value())

--- a/Editor/Source/Project/EditorProject.cpp
+++ b/Editor/Source/Project/EditorProject.cpp
@@ -1,8 +1,11 @@
 #include "Project/EditorProject.h"
 
 #include <algorithm>
+#include <array>
+#include <cstdint>
 #include <fstream>
 #include <optional>
+#include <sstream>
 #include <string_view>
 #include <system_error>
 
@@ -15,7 +18,19 @@ namespace Xelqoria::Editor
     namespace
     {
         constexpr const char* ProjectFileHeader = "XelqoriaProject=1";
-        constexpr const wchar_t* InitialSceneFileName = L"Main.xelqoria.scene";
+        constexpr std::uint32_t CurrentProjectStructureVersion = 1;
+        constexpr const wchar_t* ProjectFileExtension = L".xelqoria";
+        constexpr const wchar_t* AssetsDirectoryName = L"Assets";
+        constexpr const wchar_t* ScenesDirectoryName = L"Scenes";
+        constexpr const wchar_t* TexturesDirectoryName = L"Textures";
+        constexpr const wchar_t* MaterialsDirectoryName = L"Materials";
+        constexpr const wchar_t* ScriptsDirectoryName = L"Scripts";
+        constexpr const wchar_t* ProjectSettingsDirectoryName = L"ProjectSettings";
+        constexpr const wchar_t* ProjectSettingsFileName = L"project_settings.json";
+        constexpr const wchar_t* InternalDirectoryName = L".xelqoria";
+        constexpr const wchar_t* CacheDirectoryName = L"cache";
+        constexpr const wchar_t* InitialSceneFileName = L"Main.scene";
+        constexpr const char* ProjectVersion = "1";
 
         [[nodiscard]] std::optional<std::string> ReadValue(std::string_view line, std::string_view key)
         {
@@ -25,6 +40,50 @@ namespace Xelqoria::Editor
             }
 
             return std::string(line.substr(key.size() + 1));
+        }
+
+        [[nodiscard]] std::string ToProjectRelativeGenericString(
+            const std::filesystem::path& path,
+            const std::filesystem::path& rootDirectory,
+            std::error_code& errorCode)
+        {
+            const std::filesystem::path relativePath = std::filesystem::relative(path, rootDirectory, errorCode);
+            if (errorCode)
+            {
+                return {};
+            }
+
+            return relativePath.generic_string();
+        }
+
+        [[nodiscard]] std::string BuildDefaultProjectSettingsText(const std::wstring& projectName)
+        {
+            std::ostringstream text;
+            text << "{\n";
+            text << "  \"projectName\": \"" << ToNarrowString(projectName) << "\"\n";
+            text << "}\n";
+            return text.str();
+        }
+
+        [[nodiscard]] bool WriteTextFile(
+            const std::filesystem::path& filePath,
+            std::string_view text)
+        {
+            std::error_code errorCode;
+            std::filesystem::create_directories(filePath.parent_path(), errorCode);
+            if (errorCode)
+            {
+                return false;
+            }
+
+            std::ofstream output(filePath, std::ios::binary | std::ios::trunc);
+            if (false == output.is_open())
+            {
+                return false;
+            }
+
+            output << text;
+            return output.good();
         }
     }
 
@@ -41,13 +100,35 @@ namespace Xelqoria::Editor
         EditorProjectInfo info{};
         info.name = projectName;
         info.rootDirectory = parentDirectory / projectName;
-        info.projectFilePath = info.rootDirectory / (projectName + L".proj");
-        info.scenesDirectory = info.rootDirectory / L"Scenes";
+        info.projectFilePath = info.rootDirectory / (projectName + ProjectFileExtension);
+        info.assetRootDirectory = info.rootDirectory / AssetsDirectoryName;
+        info.scenesDirectory = info.assetRootDirectory / ScenesDirectoryName;
+        info.projectSettingsFilePath = info.rootDirectory / ProjectSettingsDirectoryName / ProjectSettingsFileName;
+        info.internalDirectory = info.rootDirectory / InternalDirectoryName;
+        info.cacheDirectory = info.internalDirectory / CacheDirectoryName;
         info.activeScenePath = info.scenesDirectory / InitialSceneFileName;
 
         std::error_code errorCode;
-        std::filesystem::create_directories(info.scenesDirectory, errorCode);
-        if (errorCode)
+        const std::array<std::filesystem::path, 6> requiredDirectories =
+        {
+            info.scenesDirectory,
+            info.assetRootDirectory / TexturesDirectoryName,
+            info.assetRootDirectory / MaterialsDirectoryName,
+            info.assetRootDirectory / ScriptsDirectoryName,
+            info.projectSettingsFilePath.parent_path(),
+            info.cacheDirectory
+        };
+
+        for (const std::filesystem::path& directory : requiredDirectories)
+        {
+            std::filesystem::create_directories(directory, errorCode);
+            if (errorCode)
+            {
+                return false;
+            }
+        }
+
+        if (false == WriteTextFile(info.projectSettingsFilePath, BuildDefaultProjectSettingsText(projectName)))
         {
             return false;
         }
@@ -83,20 +164,42 @@ namespace Xelqoria::Editor
 
         std::optional<std::string> projectName{};
         std::optional<std::string> activeScene{};
+        std::optional<std::string> assetRoot{};
+        std::optional<std::string> projectSettings{};
+        std::optional<std::string> startupScene{};
         std::string line{};
         while (std::getline(input, line))
         {
-            if (const auto value = ReadValue(line, "Name"))
+            if (const auto value = ReadValue(line, "projectName"))
             {
                 projectName = value;
+            }
+            else if (const auto value = ReadValue(line, "Name"))
+            {
+                projectName = value;
+            }
+            else if (const auto value = ReadValue(line, "startupScene"))
+            {
+                startupScene = value;
             }
             else if (const auto value = ReadValue(line, "ActiveScene"))
             {
                 activeScene = value;
             }
+            else if (const auto value = ReadValue(line, "assetRoot"))
+            {
+                assetRoot = value;
+            }
+            else if (const auto value = ReadValue(line, "projectSettings"))
+            {
+                projectSettings = value;
+            }
         }
 
-        if (false == projectName.has_value() || false == activeScene.has_value())
+        const std::optional<std::string>& scenePathText = startupScene.has_value()
+            ? startupScene
+            : activeScene;
+        if (false == projectName.has_value() || false == scenePathText.has_value())
         {
             return false;
         }
@@ -106,9 +209,23 @@ namespace Xelqoria::Editor
             return false;
         }
 
-        const std::filesystem::path activeSceneRelativePath(*activeScene);
+        const std::filesystem::path activeSceneRelativePath(*scenePathText);
         if (false == EditorPathSecurity::IsSafeRelativePath(activeSceneRelativePath)
             || activeSceneRelativePath.extension() != ".scene")
+        {
+            return false;
+        }
+
+        const bool isModernProjectFile = projectFilePath.extension() == ProjectFileExtension;
+        const std::filesystem::path assetRootRelativePath = assetRoot.has_value()
+            ? std::filesystem::path(*assetRoot)
+            : std::filesystem::path(AssetsDirectoryName);
+        const std::filesystem::path projectSettingsRelativePath = projectSettings.has_value()
+            ? std::filesystem::path(*projectSettings)
+            : std::filesystem::path(ProjectSettingsDirectoryName) / ProjectSettingsFileName;
+        if ((isModernProjectFile && false == assetRoot.has_value())
+            || false == EditorPathSecurity::IsSafeRelativePath(assetRootRelativePath)
+            || false == EditorPathSecurity::IsSafeRelativePath(projectSettingsRelativePath))
         {
             return false;
         }
@@ -117,7 +234,11 @@ namespace Xelqoria::Editor
         info.name = ToWideString(*projectName);
         info.projectFilePath = projectFilePath;
         info.rootDirectory = projectFilePath.parent_path();
-        info.scenesDirectory = info.rootDirectory / L"Scenes";
+        info.assetRootDirectory = info.rootDirectory / assetRootRelativePath;
+        info.scenesDirectory = info.assetRootDirectory / ScenesDirectoryName;
+        info.projectSettingsFilePath = info.rootDirectory / projectSettingsRelativePath;
+        info.internalDirectory = info.rootDirectory / InternalDirectoryName;
+        info.cacheDirectory = info.internalDirectory / CacheDirectoryName;
         info.activeScenePath = info.rootDirectory / activeSceneRelativePath;
 
         if (false == std::filesystem::exists(info.activeScenePath))
@@ -125,9 +246,18 @@ namespace Xelqoria::Editor
             return false;
         }
 
-        if (false == EditorPathSecurity::IsPathInsideOrEqual(info.activeScenePath, info.scenesDirectory))
+        const std::filesystem::path expectedSceneRoot = isModernProjectFile
+            ? info.scenesDirectory
+            : info.rootDirectory / ScenesDirectoryName;
+        if (false == EditorPathSecurity::IsPathInsideOrEqual(info.activeScenePath, expectedSceneRoot))
         {
             return false;
+        }
+
+        if (false == isModernProjectFile)
+        {
+            info.assetRootDirectory = info.rootDirectory;
+            info.scenesDirectory = expectedSceneRoot;
         }
 
         m_info = info;
@@ -214,7 +344,9 @@ namespace Xelqoria::Editor
     bool EditorProject::WriteProjectFile(const EditorProjectInfo& info) const
     {
         if (false == EditorPathSecurity::IsValidProjectName(info.name)
-            || false == EditorPathSecurity::IsPathInsideOrEqual(info.activeScenePath, info.scenesDirectory))
+            || false == EditorPathSecurity::IsPathInsideOrEqual(info.activeScenePath, info.scenesDirectory)
+            || false == EditorPathSecurity::IsPathInsideOrEqual(info.scenesDirectory, info.assetRootDirectory)
+            || false == EditorPathSecurity::IsPathInsideOrEqual(info.projectSettingsFilePath, info.rootDirectory))
         {
             return false;
         }
@@ -232,15 +364,31 @@ namespace Xelqoria::Editor
             return false;
         }
 
-        const std::filesystem::path relativeScenePath = std::filesystem::relative(info.activeScenePath, info.rootDirectory, errorCode);
+        const std::string relativeScenePath = ToProjectRelativeGenericString(info.activeScenePath, info.rootDirectory, errorCode);
+        if (errorCode)
+        {
+            return false;
+        }
+
+        const std::string relativeAssetRoot = ToProjectRelativeGenericString(info.assetRootDirectory, info.rootDirectory, errorCode);
+        if (errorCode)
+        {
+            return false;
+        }
+
+        const std::string relativeProjectSettings = ToProjectRelativeGenericString(info.projectSettingsFilePath, info.rootDirectory, errorCode);
         if (errorCode)
         {
             return false;
         }
 
         output << ProjectFileHeader << '\n';
-        output << "Name=" << ToNarrowString(info.name) << '\n';
-        output << "ActiveScene=" << relativeScenePath.generic_string() << '\n';
+        output << "projectName=" << ToNarrowString(info.name) << '\n';
+        output << "version=" << ProjectVersion << '\n';
+        output << "projectStructureVersion=" << CurrentProjectStructureVersion << '\n';
+        output << "assetRoot=" << relativeAssetRoot << '\n';
+        output << "projectSettings=" << relativeProjectSettings << '\n';
+        output << "startupScene=" << relativeScenePath << '\n';
         return output.good();
     }
 

--- a/Editor/Source/Project/EditorProject.h
+++ b/Editor/Source/Project/EditorProject.h
@@ -25,7 +25,7 @@ namespace Xelqoria::Editor
         std::filesystem::path rootDirectory{};
 
         /// <summary>
-        /// `.proj` ファイルのパスを表す。
+        /// プロジェクトファイルのパスを表す。
         /// </summary>
         std::filesystem::path projectFilePath{};
 
@@ -33,6 +33,26 @@ namespace Xelqoria::Editor
         /// Scene 保存フォルダを表す。
         /// </summary>
         std::filesystem::path scenesDirectory{};
+
+        /// <summary>
+        /// Assets ルートフォルダを表す。
+        /// </summary>
+        std::filesystem::path assetRootDirectory{};
+
+        /// <summary>
+        /// Project Settings ファイルのパスを表す。
+        /// </summary>
+        std::filesystem::path projectSettingsFilePath{};
+
+        /// <summary>
+        /// Editor 内部管理フォルダを表す。
+        /// </summary>
+        std::filesystem::path internalDirectory{};
+
+        /// <summary>
+        /// Editor 内部キャッシュフォルダを表す。
+        /// </summary>
+        std::filesystem::path cacheDirectory{};
 
         /// <summary>
         /// 現在編集中の Scene ファイルパスを表す。
@@ -59,9 +79,9 @@ namespace Xelqoria::Editor
             const Game::Scene& initialScene);
 
         /// <summary>
-        /// 既存の `.proj` ファイルを開く。
+        /// 既存のプロジェクトファイルを開く。
         /// </summary>
-        /// <param name="projectFilePath">開く `.proj` ファイル。</param>
+        /// <param name="projectFilePath">開くプロジェクトファイル。</param>
         /// <returns>読込に成功した場合は true。</returns>
         [[nodiscard]] bool Open(const std::filesystem::path& projectFilePath);
 
@@ -111,7 +131,7 @@ namespace Xelqoria::Editor
 
     private:
         /// <summary>
-        /// `.proj` ファイルを書き出す。
+        /// プロジェクトファイルを書き出す。
         /// </summary>
         /// <param name="info">書き出すプロジェクト情報。</param>
         /// <returns>書き出しに成功した場合は true。</returns>

--- a/Editor/Source/Project/EditorSceneDocument.h
+++ b/Editor/Source/Project/EditorSceneDocument.h
@@ -70,7 +70,7 @@ namespace Xelqoria::Editor
         /// <summary>
         /// 既存プロジェクトを開き、アクティブ Scene を読み込む。
         /// </summary>
-        /// <param name="projectFilePath">開く `.proj` ファイル。</param>
+        /// <param name="projectFilePath">開くプロジェクトファイル。</param>
         /// <returns>読込に成功した場合は true。</returns>
         [[nodiscard]] bool OpenProject(const std::filesystem::path& projectFilePath);
 

--- a/Editor/Source/Project/RecentProjectsStore.cpp
+++ b/Editor/Source/Project/RecentProjectsStore.cpp
@@ -12,6 +12,21 @@ namespace Xelqoria::Editor
     namespace
     {
         constexpr std::size_t MaxRecentProjectCount = 5;
+
+        /// <summary>
+        /// プロジェクトファイル種別に応じた Scene 保存フォルダを取得する。
+        /// </summary>
+        /// <param name="projectFilePath">対象プロジェクトファイル。</param>
+        /// <returns>Scene 保存フォルダ。</returns>
+        [[nodiscard]] std::filesystem::path GetScenesDirectory(const std::filesystem::path& projectFilePath)
+        {
+            if (projectFilePath.extension() == L".xelqoria")
+            {
+                return projectFilePath.parent_path() / L"Assets" / L"Scenes";
+            }
+
+            return projectFilePath.parent_path() / L"Scenes";
+        }
     }
 
     std::vector<EditorProjectInfo> RecentProjectsStore::Load() const
@@ -43,7 +58,13 @@ namespace Xelqoria::Editor
             info.name = name;
             info.projectFilePath = projectFilePath;
             info.rootDirectory = projectFilePath.parent_path();
-            info.scenesDirectory = info.rootDirectory / L"Scenes";
+            info.assetRootDirectory = projectFilePath.extension() == L".xelqoria"
+                ? info.rootDirectory / L"Assets"
+                : info.rootDirectory;
+            info.scenesDirectory = GetScenesDirectory(projectFilePath);
+            info.projectSettingsFilePath = info.rootDirectory / L"ProjectSettings" / L"project_settings.json";
+            info.internalDirectory = info.rootDirectory / L".xelqoria";
+            info.cacheDirectory = info.internalDirectory / L"cache";
             projects.emplace_back(info);
         }
 

--- a/Editor/Source/Project/RecentProjectsStore.h
+++ b/Editor/Source/Project/RecentProjectsStore.h
@@ -16,7 +16,7 @@ namespace Xelqoria::Editor
         /// <summary>
         /// 最近使ったプロジェクト一覧を読み込む。
         /// </summary>
-        /// <returns>存在する `.proj` のみを含むプロジェクト情報一覧。</returns>
+        /// <returns>存在するプロジェクトファイルのみを含むプロジェクト情報一覧。</returns>
         [[nodiscard]] std::vector<EditorProjectInfo> Load() const;
 
         /// <summary>

--- a/docs/plans/issue-335-project-standard-structure.md
+++ b/docs/plans/issue-335-project-standard-structure.md
@@ -1,0 +1,51 @@
+# ExecPlan: issue-335 新規プロジェクト標準構成とプロジェクトファイル保存内容を更新する
+
+## 目的
+
+新規プロジェクト作成時に、ユーザー管理対象の Assets とプロジェクト管理ファイルを分離した標準構成を生成する。
+
+## 対象範囲
+
+- 変更対象プロジェクト: `Editor`, `tests/Editor`
+- 変更対象ファイル: `EditorProject.h`, `EditorProject.cpp`, `EditorProjectTests.cpp`
+- 変更対象クラス: `Xelqoria::Editor::EditorProject`
+- 影響する機能: 新規プロジェクト作成、プロジェクトファイル保存、既存プロジェクト読込
+
+## 前提
+
+- parent issue: issue-334
+- ブランチ運用ルール: `docs/agents/branch-rules.md`
+- parent issue ブランチ: `issue-334`
+- この child issue のブランチ: `issue-335`
+- PR の向き: `issue-335` -> `issue-334`
+
+## 実装方針
+
+新規プロジェクト作成時の標準構成を `EditorProject` に集約する。
+
+新しいプロジェクトファイルは `<ProjectName>.xelqoria` とし、`projectStructureVersion`、`assetRoot`、`projectSettings`、`startupScene` をプロジェクトルートからの相対パスで保存する。既存 `.proj` 形式は Open 側で引き続き読み込めるようにする。
+
+## 作業手順
+
+1. `EditorProject` のプロジェクト情報に Assets、ProjectSettings、内部ディレクトリのパスを追加する
+2. 新規作成時に `Assets/Scenes`、`Assets/Textures`、`Assets/Materials`、`Assets/Scripts`、`ProjectSettings`、`.xelqoria/cache` を作成する
+3. 初期 Scene を `Assets/Scenes/Main.scene` に保存する
+4. `<ProjectName>.xelqoria` に新しいメタデータを保存する
+5. 既存 `.proj` 読み込み互換を維持する
+6. EditorProject のテストを新構成に更新する
+7. Editor テストまたはビルドを実行する
+
+## 検証方法
+
+- 実行するビルド: `dotnet build tools/LayerDependencyChecker/LayerDependencyChecker.csproj` または利用可能な Visual Studio ビルド
+- 実行するテスト: `Xelqoria.Tests.Editor`
+- 手動確認項目: 生成されたプロジェクトファイルの相対パス、標準ディレクトリ構成
+
+## 完了条件
+
+- 新規プロジェクト作成時に標準構成のディレクトリとファイルが作成される
+- `.xelqoria` に `projectStructureVersion`、`assetRoot`、`projectSettings`、`startupScene` が保存される
+- `.xelqoria` 内のパスがプロジェクトルートからの相対パスで保存される
+- 初期 Scene が `Assets/Scenes/Main.scene` に配置される
+- 関連テストが通る
+- `issue-335` から `issue-334` への PR が作成されている

--- a/docs/plans/issue-338-project-settings-menu.md
+++ b/docs/plans/issue-338-project-settings-menu.md
@@ -1,0 +1,52 @@
+# ExecPlan: issue-338 Project Settings をメニューから開く導線を追加する
+
+## 目的
+
+`ProjectSettings/project_settings.json` を Assets ビューではなく、ヘッダーの `Project > Settings...` から編集できるようにする。
+
+## 対象範囲
+
+- 変更対象プロジェクト: `Editor`
+- 変更対象ファイル: `Application.h`, `Application.cpp`
+- 変更対象クラス: `Xelqoria::Editor::Application`
+- 影響する機能: Project メニュー、Project Settings 編集導線
+
+## 前提
+
+- parent issue: issue-334
+- 先行 child issue: issue-335
+- ブランチ運用ルール: `docs/agents/branch-rules.md`
+- parent issue ブランチ: `issue-334`
+- この child issue のブランチ: `issue-338`
+- PR の向き: `issue-338` -> `issue-334`
+
+## 実装方針
+
+既存の Project メニューに用意されている Settings コマンドを実装し、現在開いているプロジェクトの `EditorProjectInfo::projectSettingsFilePath` を開く。
+
+編集画面は Editor 内のモーダルウィンドウとして実装し、`project_settings.json` の UTF-8 テキストをそのまま編集・保存できるようにする。設定項目の追加や Assets ビューの表示ルート変更はこの issue では扱わない。
+
+## 作業手順
+
+1. ヘッダーの Project メニュー表記を `Project` にする
+2. Settings メニュー項目を `Settings...` として表示する
+3. Settings コマンドから Project Settings 編集画面を開く
+4. `project_settings.json` を UTF-8 テキストとして読み込む
+5. Save 操作で `project_settings.json` に書き戻す
+6. 保存結果またはエラーを LogOutput と SceneView ステータスに表示する
+7. Editor ビルドと差分チェックを実行する
+
+## 検証方法
+
+- 実行するビルド: `MSBuild Editor/Xelqoria.Editor.vcxproj /p:Configuration=Debug /p:Platform=x64 /m`
+- 実行する静的確認: `git diff --check`
+- 手動確認項目: メニュー表記が `Project > Settings...` であること、Project Settings 編集画面が開き保存できること
+
+## 完了条件
+
+- ヘッダーに `Project > Settings...` が表示される
+- `Project > Settings...` から `ProjectSettings/project_settings.json` の編集画面を開ける
+- 編集画面から `project_settings.json` を保存できる
+- `ProjectSettings/` を Assets ビュー上の編集導線として扱わない
+- 関連ビルドが通る
+- `issue-338` から `issue-334` への PR が作成されている

--- a/tests/Editor/Source/EditorProjectTests.cpp
+++ b/tests/Editor/Source/EditorProjectTests.cpp
@@ -2,6 +2,7 @@
 
 #include <filesystem>
 #include <fstream>
+#include <iterator>
 #include <vector>
 
 #include <gtest/gtest.h>
@@ -27,7 +28,7 @@ namespace
     }
 }
 
-TEST(EditorProjectTests, CreateBuildsProjectFileScenesDirectoryAndInitialScene)
+TEST(EditorProjectTests, CreateBuildsStandardProjectStructureAndInitialScene)
 {
     const std::filesystem::path parentDirectory = MakeTempDirectory(L"XelqoriaEditorProjectTests_Create");
     Xelqoria::Editor::EditorProject project{};
@@ -35,10 +36,43 @@ TEST(EditorProjectTests, CreateBuildsProjectFileScenesDirectoryAndInitialScene)
     EXPECT_TRUE(project.Create(L"SampleProject", parentDirectory, MakeScene()));
 
     const std::filesystem::path projectRoot = parentDirectory / L"SampleProject";
-    EXPECT_TRUE(std::filesystem::exists(projectRoot / L"SampleProject.proj"));
-    EXPECT_TRUE(std::filesystem::is_directory(projectRoot / L"Scenes"));
-    EXPECT_TRUE(std::filesystem::exists(projectRoot / L"Scenes" / L"Main.xelqoria.scene"));
+    EXPECT_TRUE(std::filesystem::exists(projectRoot / L"SampleProject.xelqoria"));
+    EXPECT_TRUE(std::filesystem::is_directory(projectRoot / L"Assets" / L"Scenes"));
+    EXPECT_TRUE(std::filesystem::is_directory(projectRoot / L"Assets" / L"Textures"));
+    EXPECT_TRUE(std::filesystem::is_directory(projectRoot / L"Assets" / L"Materials"));
+    EXPECT_TRUE(std::filesystem::is_directory(projectRoot / L"Assets" / L"Scripts"));
+    EXPECT_TRUE(std::filesystem::is_directory(projectRoot / L"ProjectSettings"));
+    EXPECT_TRUE(std::filesystem::is_directory(projectRoot / L".xelqoria" / L"cache"));
+    EXPECT_TRUE(std::filesystem::exists(projectRoot / L"ProjectSettings" / L"project_settings.json"));
+    EXPECT_TRUE(std::filesystem::exists(projectRoot / L"Assets" / L"Scenes" / L"Main.scene"));
     EXPECT_TRUE(project.HasProject());
+
+    std::filesystem::remove_all(parentDirectory);
+}
+
+TEST(EditorProjectTests, CreateWritesProjectMetadataAsRootRelativePaths)
+{
+    const std::filesystem::path parentDirectory = MakeTempDirectory(L"XelqoriaEditorProjectTests_Metadata");
+    Xelqoria::Editor::EditorProject project{};
+
+    ASSERT_TRUE(project.Create(L"SampleProject", parentDirectory, MakeScene()));
+
+    const std::filesystem::path projectFilePath = parentDirectory / L"SampleProject" / L"SampleProject.xelqoria";
+    std::string text{};
+    {
+        std::ifstream input(projectFilePath, std::ios::binary);
+        ASSERT_TRUE(input.is_open());
+        text.assign(
+            std::istreambuf_iterator<char>(input),
+            std::istreambuf_iterator<char>());
+    }
+
+    EXPECT_NE(std::string::npos, text.find("projectName=SampleProject\n"));
+    EXPECT_NE(std::string::npos, text.find("version=1\n"));
+    EXPECT_NE(std::string::npos, text.find("projectStructureVersion=1\n"));
+    EXPECT_NE(std::string::npos, text.find("assetRoot=Assets\n"));
+    EXPECT_NE(std::string::npos, text.find("projectSettings=ProjectSettings/project_settings.json\n"));
+    EXPECT_NE(std::string::npos, text.find("startupScene=Assets/Scenes/Main.scene\n"));
 
     std::filesystem::remove_all(parentDirectory);
 }
@@ -52,7 +86,7 @@ TEST(EditorProjectTests, SaveAsSwitchesCurrentProject)
 
     ASSERT_TRUE(project.GetInfo().has_value());
     EXPECT_EQ(L"RenamedProject", project.GetInfo()->name);
-    EXPECT_TRUE(std::filesystem::exists(parentDirectory / L"RenamedProject" / L"RenamedProject.proj"));
+    EXPECT_TRUE(std::filesystem::exists(parentDirectory / L"RenamedProject" / L"RenamedProject.xelqoria"));
 
     std::filesystem::remove_all(parentDirectory);
 }
@@ -64,11 +98,11 @@ TEST(EditorProjectTests, OpenReadsProjectAndEnumeratesScenes)
     ASSERT_TRUE(createdProject.Create(L"OpenProject", parentDirectory, MakeScene()));
 
     Xelqoria::Editor::EditorProject openedProject{};
-    EXPECT_TRUE(openedProject.Open(parentDirectory / L"OpenProject" / L"OpenProject.proj"));
+    EXPECT_TRUE(openedProject.Open(parentDirectory / L"OpenProject" / L"OpenProject.xelqoria"));
 
     const std::vector<std::filesystem::path> sceneFiles = openedProject.EnumerateSceneFiles();
     ASSERT_EQ(1u, sceneFiles.size());
-    EXPECT_EQ(L"Main.xelqoria.scene", sceneFiles[0].filename().wstring());
+    EXPECT_EQ(L"Main.scene", sceneFiles[0].filename().wstring());
 
     std::filesystem::remove_all(parentDirectory);
 }
@@ -83,6 +117,36 @@ TEST(EditorProjectTests, OpenPreservesUtf8ProjectName)
     EXPECT_TRUE(openedProject.Open(createdProject.GetInfo()->projectFilePath));
     ASSERT_TRUE(openedProject.GetInfo().has_value());
     EXPECT_EQ(L"日本語Project", openedProject.GetInfo()->name);
+
+    std::filesystem::remove_all(parentDirectory);
+}
+
+TEST(EditorProjectTests, OpenSupportsLegacyProjFile)
+{
+    const std::filesystem::path parentDirectory = MakeTempDirectory(L"XelqoriaEditorProjectTests_LegacyOpen");
+    const std::filesystem::path projectRoot = parentDirectory / L"LegacyProject";
+    const std::filesystem::path scenesDirectory = projectRoot / L"Scenes";
+    std::filesystem::create_directories(scenesDirectory);
+
+    const std::filesystem::path scenePath = scenesDirectory / L"Main.xelqoria.scene";
+    {
+        std::ofstream sceneFile(scenePath, std::ios::binary | std::ios::trunc);
+        sceneFile << Xelqoria::Game::SceneSerializer::SaveToText(MakeScene());
+    }
+
+    const std::filesystem::path projectFilePath = projectRoot / L"LegacyProject.proj";
+    {
+        std::ofstream projectFile(projectFilePath, std::ios::binary | std::ios::trunc);
+        projectFile << "XelqoriaProject=1\n";
+        projectFile << "Name=LegacyProject\n";
+        projectFile << "ActiveScene=Scenes/Main.xelqoria.scene\n";
+    }
+
+    Xelqoria::Editor::EditorProject project{};
+    ASSERT_TRUE(project.Open(projectFilePath));
+    ASSERT_TRUE(project.GetInfo().has_value());
+    EXPECT_EQ(scenePath, project.GetInfo()->activeScenePath);
+    EXPECT_EQ(scenesDirectory, project.GetInfo()->scenesDirectory);
 
     std::filesystem::remove_all(parentDirectory);
 }
@@ -120,21 +184,25 @@ TEST(EditorProjectTests, OpenRejectsActiveSceneOutsideProjectScenesDirectory)
 {
     const std::filesystem::path parentDirectory = MakeTempDirectory(L"XelqoriaEditorProjectTests_RejectOutsideScene");
     const std::filesystem::path projectRoot = parentDirectory / L"UnsafeProject";
-    const std::filesystem::path scenesDirectory = projectRoot / L"Scenes";
+    const std::filesystem::path scenesDirectory = projectRoot / L"Assets" / L"Scenes";
     std::filesystem::create_directories(scenesDirectory);
 
-    const std::filesystem::path outsideScenePath = parentDirectory / L"Outside.xelqoria.scene";
+    const std::filesystem::path outsideScenePath = parentDirectory / L"Outside.scene";
     {
         std::ofstream outsideScene(outsideScenePath, std::ios::binary | std::ios::trunc);
         outsideScene << Xelqoria::Game::SceneSerializer::SaveToText(MakeScene());
     }
 
-    const std::filesystem::path projectFilePath = projectRoot / L"UnsafeProject.proj";
+    const std::filesystem::path projectFilePath = projectRoot / L"UnsafeProject.xelqoria";
     {
         std::ofstream projectFile(projectFilePath, std::ios::binary | std::ios::trunc);
         projectFile << "XelqoriaProject=1\n";
-        projectFile << "Name=UnsafeProject\n";
-        projectFile << "ActiveScene=../Outside.xelqoria.scene\n";
+        projectFile << "projectName=UnsafeProject\n";
+        projectFile << "version=1\n";
+        projectFile << "projectStructureVersion=1\n";
+        projectFile << "assetRoot=Assets\n";
+        projectFile << "projectSettings=ProjectSettings/project_settings.json\n";
+        projectFile << "startupScene=../Outside.scene\n";
     }
 
     Xelqoria::Editor::EditorProject project{};
@@ -149,7 +217,7 @@ TEST(EditorProjectTests, SelectSceneFileRejectsOutsideSceneDirectory)
     Xelqoria::Editor::EditorProject project{};
     ASSERT_TRUE(project.Create(L"SceneProject", parentDirectory, MakeScene()));
 
-    const std::filesystem::path outsideScenePath = parentDirectory / L"Outside.xelqoria.scene";
+    const std::filesystem::path outsideScenePath = parentDirectory / L"Outside.scene";
     std::filesystem::copy_file(project.GetInfo()->activeScenePath, outsideScenePath);
 
     EXPECT_FALSE(project.SelectSceneFile(outsideScenePath));

--- a/tests/Editor/Source/RecentProjectsStoreTests.cpp
+++ b/tests/Editor/Source/RecentProjectsStoreTests.cpp
@@ -30,7 +30,7 @@ TEST(RecentProjectsStoreTests, RecordKeepsMostRecentFiveExistingProjects)
         const std::wstring projectName = L"Project" + std::to_wstring(index);
         const std::filesystem::path projectRoot = tempDirectory / projectName;
         std::filesystem::create_directories(projectRoot);
-        const std::filesystem::path projectFilePath = projectRoot / (projectName + L".proj");
+        const std::filesystem::path projectFilePath = projectRoot / (projectName + L".xelqoria");
         std::ofstream(projectFilePath).put('\n');
 
         Xelqoria::Editor::EditorProjectInfo info{};
@@ -57,7 +57,7 @@ TEST(RecentProjectsStoreTests, RecordPreservesUtf8ProjectNameAndPath)
 
     const std::filesystem::path projectRoot = tempDirectory / L"日本語Project";
     std::filesystem::create_directories(projectRoot);
-    const std::filesystem::path projectFilePath = projectRoot / L"日本語Project.proj";
+    const std::filesystem::path projectFilePath = projectRoot / L"日本語Project.xelqoria";
     std::ofstream(projectFilePath).put('\n');
 
     Xelqoria::Editor::EditorProjectInfo info{};
@@ -72,6 +72,7 @@ TEST(RecentProjectsStoreTests, RecordPreservesUtf8ProjectNameAndPath)
     ASSERT_EQ(1u, projects.size());
     EXPECT_EQ(L"日本語Project", projects[0].name);
     EXPECT_EQ(projectFilePath, projects[0].projectFilePath);
+    EXPECT_EQ(projectRoot / L"Assets" / L"Scenes", projects[0].scenesDirectory);
 
     std::filesystem::current_path(originalCurrentPath);
     std::filesystem::remove_all(tempDirectory);


### PR DESCRIPTION
## Summary
- ヘッダーのメニュー導線を `Project > Settings...` として表示
- 現在の `EditorProjectInfo::projectSettingsFilePath` を開く Project Settings 編集画面を追加
- `project_settings.json` を UTF-8 テキストとして読み込み、モーダル画面から保存できるように変更
- child issue 用 ExecPlan を追加

## Notes
- This branch includes `issue-335` because the Project Settings path is provided by the new standard project structure.
- Assets view changes are intentionally outside this PR; `ProjectSettings/` is edited only through the Project menu path here.

## Validation
- `MSBuild Editor/Xelqoria.Editor.vcxproj /p:Configuration=Debug /p:Platform=x64 /m` (0 warnings, 0 errors)
- `MSBuild tests/Editor/Xelqoria.Tests.Editor.vcxproj /p:Configuration=Debug /p:Platform=x64 /m` (0 warnings, 0 errors)
- `artifacts/x64/Debug/Xelqoria.Tests.Editor.exe` (79 tests passed)
- `git diff --check`

Closes #338